### PR TITLE
Providing rudimentary password reset flow, along with misc changes

### DIFF
--- a/PluginBuilder/Authentication/SimpleTwoFactorTokenProvider.cs
+++ b/PluginBuilder/Authentication/SimpleTwoFactorTokenProvider.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace PluginBuilder.Authentication
+{
+    public class SimpleTwoFactorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUser> where TUser : IdentityUser
+    {
+        public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<TUser> manager, TUser user)
+        {
+            if (manager != null && user != null)
+            {
+                return Task.FromResult(true);
+            }
+            else
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        // Genereates a simple token based on the user id, email and another string.
+        private string GenerateToken(IdentityUser user, string purpose)
+        {
+            string secretString = "coffeIsGood" + user.Email + purpose + user.Id + user.PasswordHash;
+            return WebEncoders.Base64UrlEncode(
+                SHA256.HashData(Encoding.UTF8.GetBytes(secretString))
+            );
+        }
+
+        public Task<string> GenerateAsync(string purpose, UserManager<TUser> manager, TUser user)
+        {
+            return Task.FromResult(GenerateToken(user, purpose));
+        }
+
+        public Task<bool> ValidateAsync(string purpose, string token, UserManager<TUser> manager, TUser user)
+        {
+            return Task.FromResult(token == GenerateToken(user, purpose));
+        }
+    }
+}

--- a/PluginBuilder/Components/MainNav/Default.cshtml
+++ b/PluginBuilder/Components/MainNav/Default.cshtml
@@ -75,5 +75,17 @@
 				</ul>
 			</li>
 		</ul>
+        <script type="text/javascript">
+            (function () {
+                // Preventing dropdown from collapsing on clicks inside the dropdown menu that don't trigger links
+                var dropdownLinks = document.querySelectorAll(".dropdown-menu li");
+
+                dropdownLinks.forEach(function (link) {
+                    link.addEventListener("click", function (event) {
+                        event.stopPropagation();
+                    });
+                });
+            })();
+        </script>
 	}
 </nav>

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -46,6 +46,8 @@ namespace PluginBuilder.Controllers
             return View();
         }
 
+        // auth methods
+
         [HttpGet("/logout")]
         public async Task<IActionResult> Logout()
         {
@@ -124,6 +126,8 @@ namespace PluginBuilder.Controllers
             await SignInManager.SignInAsync(user, isPersistent: false);
             return RedirectToLocal(returnUrl);
         }
+
+        // plugin methods
 
         [HttpGet("/plugins/create")]
         public IActionResult CreatePlugin()

--- a/PluginBuilder/Controllers/PasswordResetController.cs
+++ b/PluginBuilder/Controllers/PasswordResetController.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Authorization;
+using System.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Identity;
+using PluginBuilder.Services;
+using PluginBuilder.ViewModels;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace PluginBuilder.Controllers
+{
+    public class PasswordResetController : Controller
+    {
+        private DBConnectionFactory ConnectionFactory { get; }
+        private UserManager<IdentityUser> UserManager { get; }
+        public RoleManager<IdentityRole> RoleManager { get; }
+        private SignInManager<IdentityUser> SignInManager { get; }
+        private IAuthorizationService AuthorizationService { get; }
+        private ServerEnvironment Env { get; }
+
+        public PasswordResetController(
+            DBConnectionFactory connectionFactory,
+            UserManager<IdentityUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            SignInManager<IdentityUser> signInManager,
+            IAuthorizationService authorizationService,
+            ServerEnvironment env)
+        {
+            ConnectionFactory = connectionFactory;
+            UserManager = userManager;
+            RoleManager = roleManager;
+            SignInManager = signInManager;
+            AuthorizationService = authorizationService;
+            Env = env;
+        }
+
+        [HttpGet("/admin/initpasswordreset")]
+        public IActionResult InitPasswordReset()
+        {
+            return View();
+        }
+        public IActionResult Children()
+        {
+            return View();
+        }
+
+        [HttpPost("/admin/initpasswordreset")]
+        public async Task<IActionResult> InitPasswordReset(InitPasswordResetViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+            // Require the user to have a confirmed email before they can log on.
+            var user = await UserManager.FindByEmailAsync(model.Email);
+            if (user is null)
+            {
+                ModelState.AddModelError(string.Empty, "User with suggested email doesn't exist");
+                return View(model);
+            }
+
+            var result = await UserManager.GeneratePasswordResetTokenAsync(user);
+            model.PasswordResetToken = result;
+            return View(model);
+        }
+
+        [HttpGet("/passwordreset")]
+        public IActionResult PasswordReset()
+        {
+            return View(new PasswordResetViewModel());
+        }
+
+        [HttpPost("/passwordreset")]
+        public async Task<IActionResult> PasswordReset(PasswordResetViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            // Require the user to have a confirmed email before they can log on.
+            var user = await UserManager.FindByEmailAsync(model.Email);
+            if (user is null)
+            {
+                ModelState.AddModelError(string.Empty, "User with suggested email doesn't exist");
+                return View(model);
+            }
+
+            var result = await UserManager.ResetPasswordAsync(user, model.PasswordResetToken, model.Password);
+            model.PasswordSuccessfulyReset = result.Succeeded;
+
+            foreach (var err in result.Errors)
+                ModelState.AddModelError("PasswordResetToken", $"{err.Description}");
+            
+            return View(model);
+        }
+    }
+}

--- a/PluginBuilder/PluginBuilder.Dockerfile
+++ b/PluginBuilder/PluginBuilder.Dockerfile
@@ -8,7 +8,7 @@ USER dotnet
 
 WORKDIR /build-tools
 ENV PLUGIN_PACKER_VERSION=https://github.com/btcpayserver/btcpayserver
-RUN git clone --depth 1 -b v1.11.2 --single-branch https://github.com/btcpayserver/btcpayserver && \
+RUN git clone --depth 1 -b v1.11.7 --single-branch https://github.com/btcpayserver/btcpayserver && \
     cd btcpayserver/BTCPayServer.PluginPacker && \
     dotnet build -c Release -o "/build-tools/PluginPacker" && \
     rm -rf /build-tools/btcpayserver

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -111,6 +111,7 @@ public class Program
             options.Lockout.AllowedForNewUsers = true;
             options.Password.RequireUppercase = false;
         })
+        .AddTokenProvider("Default", typeof(SimpleTwoFactorTokenProvider<IdentityUser>))
         .AddEntityFrameworkStores<IdentityDbContext<IdentityUser>>();
 
         services.PostConfigure<CookieAuthenticationOptions>(IdentityConstants.ApplicationScheme, opt =>

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -63,9 +63,7 @@ public class Program
         app.UseAuthorization();
         app.MapHub<Hubs.PluginHub>("/plugins/{pluginSlug}/hub");
         app.MapHub<Hubs.PluginHub>("/plugins/{pluginSlug}/builds/{buildId}/hub");
-        //        app.MapControllerRoute(
-        //name: "default",
-        //pattern: "{controller=Home}/{action=Index}/{id?}");
+        // no default routes
         app.MapControllers();
     }
 

--- a/PluginBuilder/Properties/launchSettings.json
+++ b/PluginBuilder/Properties/launchSettings.json
@@ -9,7 +9,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "PB_POSTGRES": "User ID=postgres;Include Error Detail=true;Host=127.0.0.1;Port=61932;Database=btcpayplugin",
         "PB_STORAGE_CONNECTION_STRING": "BlobEndpoint=http://127.0.0.1:32827/satoshi;AccountName=satoshi;AccountKey=Rxb41pUHRe+ibX5XS311tjXpjvu7mVi2xYJvtmq1j2jlUpN+fY/gkzyBMjqwzgj42geXGdYSbPEcu5i5wjSjPw==",
-        "PB_CHEAT_MODE": "true"
+        "PB_CHEAT_MODE": "true",
+        "ADMIN_AUTH_STRING": "helloworld"
       }
     }
   }

--- a/PluginBuilder/Services/ServerEnvironment.cs
+++ b/PluginBuilder/Services/ServerEnvironment.cs
@@ -5,7 +5,9 @@ namespace PluginBuilder.Services
         public ServerEnvironment(IConfiguration configuration)
         {
             CheatMode = configuration.GetValue<bool?>("CHEAT_MODE") ?? false;
+            AdminAuthString = configuration.GetValue<string?>("ADMIN_AUTH_STRING") ?? null;
         }
         public bool CheatMode { get; set; }
+        public string AdminAuthString { get; set; }
     }
 }

--- a/PluginBuilder/ViewModels/InitPasswordResetViewModel.cs
+++ b/PluginBuilder/ViewModels/InitPasswordResetViewModel.cs
@@ -1,0 +1,14 @@
+#nullable disable
+using System.ComponentModel.DataAnnotations;
+
+namespace PluginBuilder.ViewModels
+{
+    public class InitPasswordResetViewModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Email")]
+        public string Email { get; set; }
+        public string PasswordResetToken { get; set; }
+    }
+}

--- a/PluginBuilder/ViewModels/PasswordResetViewModel.cs
+++ b/PluginBuilder/ViewModels/PasswordResetViewModel.cs
@@ -1,0 +1,29 @@
+#nullable disable
+using System.ComponentModel.DataAnnotations;
+
+namespace PluginBuilder.ViewModels
+{
+    public class PasswordResetViewModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Email")]
+        public string Email { get; set; }
+
+        [Required]
+        public string PasswordResetToken { get; set; }
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        public string Password { get; set; }
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+        public string ConfirmPassword { get; set; }
+
+        public bool PasswordSuccessfulyReset{ get; set; }
+    }
+}

--- a/PluginBuilder/Views/PasswordReset/InitPasswordReset.cshtml
+++ b/PluginBuilder/Views/PasswordReset/InitPasswordReset.cshtml
@@ -39,7 +39,7 @@
             <div class="account-form">
                 @if (Model?.PasswordResetToken == null)
                 {
-                    <form method="post">
+                    <form method="post" asp-route-adminAuthString="@ViewData["adminAuthString"]">
                         <fieldset disabled="@(ViewData.ContainsKey("disabled") ? "disabled" : null)">
                             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                             <div class="form-group">

--- a/PluginBuilder/Views/PasswordReset/InitPasswordReset.cshtml
+++ b/PluginBuilder/Views/PasswordReset/InitPasswordReset.cshtml
@@ -1,0 +1,68 @@
+@inject PluginBuilder.Services.ServerEnvironment env
+
+@model InitPasswordResetViewModel
+@{
+    ViewData["Title"] = "Initiate Password Reset";
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>@ViewData["Title"]</title>
+    <partial name="_CommonHead"></partial>
+    <style>
+        .account-form {
+            max-width: 35em;
+            margin: 0 auto var(--btcpay-space-xl);
+            padding: 2rem;
+            background: var(--btcpay-bg-tile);
+            border-radius: var(--btcpay-border-radius);
+        }
+
+            .account-form h4 {
+                margin-bottom: 1.5rem;
+            }
+    </style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <section class="content-wrapper flex-grow-1">
+        <div class="navbar-brand d-none"></div>
+        <div class="container">
+            <div class="row justify-content-center mb-2">
+                <div class="col text-center">
+                    <a tabindex="-1" href="/">
+                        <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="mb-4" height="70" />
+                    </a>
+                    <h1 class="h2 mb-3">Initiate Password Reset</h1>
+                </div>
+            </div>
+            <div class="account-form">
+                @if (Model?.PasswordResetToken == null)
+                {
+                    <form method="post">
+                        <fieldset disabled="@(ViewData.ContainsKey("disabled") ? "disabled" : null)">
+                            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                            <div class="form-group">
+                                <label asp-for="Email" class="form-label"></label>
+                                <input asp-for="Email" class="form-control" required autofocus />
+                                <span asp-validation-for="Email" class="text-danger"></span>
+                            </div>
+                            <div class="form-group mt-4">
+                                <button type="submit" class="btn btn-primary btn-lg w-100">Initiate Password Reset</button>
+                            </div>
+                        </fieldset>
+                    </form>
+                }
+                else
+                {
+                    <p class="text-center mt-2 mb-0">
+                        Please provide the following token to user under email @Model.Email that wants to reset the password:
+                        <b>@Model.PasswordResetToken</b>
+                    </p>
+                }
+
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/PluginBuilder/Views/PasswordReset/PasswordReset.cshtml
+++ b/PluginBuilder/Views/PasswordReset/PasswordReset.cshtml
@@ -1,0 +1,84 @@
+@inject PluginBuilder.Services.ServerEnvironment env
+
+@model PasswordResetViewModel
+@{
+	ViewData["Title"] = "Reset Password";
+	Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>@ViewData["Title"]</title>
+	<partial name="_CommonHead"></partial>
+	<style>
+		.account-form {
+			max-width: 35em;
+			margin: 0 auto var(--btcpay-space-xl);
+			padding: 2rem;
+			background: var(--btcpay-bg-tile);
+			border-radius: var(--btcpay-border-radius);
+		}
+
+			.account-form h4 {
+				margin-bottom: 1.5rem;
+			}
+	</style>
+</head>
+<body class="d-flex flex-column min-vh-100">
+	<section class="content-wrapper flex-grow-1">
+		<div class="navbar-brand d-none"></div>
+		<div class="container">
+			<div class="row justify-content-center mb-2">
+				<div class="col text-center">
+					<a tabindex="-1" href="/">
+						<img src="~/img/btcpay-logo.svg" alt="BTCPay Server" class="mb-4" height="70" />
+					</a>
+					<h1 class="h2 mb-3">Reset Password for User</h1>
+				</div>
+			</div>
+			<div class="account-form">
+                @if (Model?.PasswordSuccessfulyReset != true)
+                {
+                    <h4>@ViewData["Title"]</h4>
+                    <form asp-route-returnUrl="@ViewData["ReturnUrl"]" asp-route-logon="true" method="post">
+                        <fieldset disabled="@(ViewData.ContainsKey("disabled") ? "disabled" : null)">
+                            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                            <div class="form-group">
+                                <label asp-for="Email" class="form-label"></label>
+                                <input asp-for="Email" class="form-control" required autofocus />
+                                <span asp-validation-for="Email" class="text-danger"></span>
+                            </div>
+                            <div class="form-group">
+                                <label asp-for="PasswordResetToken" class="form-label"></label>
+                                <input asp-for="PasswordResetToken" class="form-control" required />
+                                <span asp-validation-for="PasswordResetToken" class="text-danger"></span>
+                            </div>
+                            <div class="form-group">
+                                <label asp-for="Password" class="form-label"></label>
+                                <input asp-for="Password" class="form-control" required />
+                                <span asp-validation-for="Password" class="text-danger"></span>
+                            </div>
+                            <div class="form-group">
+                                <label asp-for="ConfirmPassword" class="form-label"></label>
+                                <input asp-for="ConfirmPassword" class="form-control" required />
+                                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+                            </div>
+                            <div class="form-group mt-4">
+                                <button type="submit" class="btn btn-primary btn-lg w-100" id="ResetPassword">Reset Password</button>
+                            </div>
+                        </fieldset>
+                    </form>
+                }
+                else
+                {
+                    <p class="text-center mt-2 mb-0">
+                        Password has been successfully reset!<br />
+                        Please proceed to
+                        <a id="Login" asp-controller="Home" asp-action="Login">Log In</a>
+                    </p>                    
+                }
+            </div>
+		</div>
+	</section>
+</body>
+</html>


### PR DESCRIPTION
Right now we do not have ability to reset passwords on https://plugin-builder.btcpayserver.org

I'm locked out of my account on that website, so to start playing with this solution I've created basic password reset flow. Since we can't depend on email verification flow, I have done it with simple environment variable that's validated when initiating password reset.

@NicolasDorier you'll need to change this to a secret on production environment; something that only us that maintain the website will know.

On top of that I have also:
 - Bumped builder version of BTCPay Server (dfa64365e751324e7dbba92573d02869c62b5c9c) 
 - Done small UI fix that will now prevent dropdown from collapsing on clicks inside the dropdown menu (324d7cf671de5586da1d94ecf9d57e19e029e5b0)