### PR TITLE
include download stats

### DIFF
--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -8,6 +8,7 @@ namespace PluginBuilder.APIModels
         public string ProjectSlug { get; set; }
         public string Version { get; set; }
         public long BuildId { get; set; }
+        public long DownloadStat { get; set; }
         public JObject BuildInfo { get; set; }
         public JObject ManifestInfo { get; set; }
         public string Documentation { get; set; }

--- a/PluginBuilder/Data/Scripts/10.VersionDownloadStat.sql
+++ b/PluginBuilder/Data/Scripts/10.VersionDownloadStat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions ADD COLUMN download_stat BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
Include a download stat column in the version table. 

So that on install or uninstall or any plugin the count increases or reduces, and this can be used for analytics and also to measure popular plugins based on most downloaded

Cc. @dennisreimann 