### PR TITLE
admin plugin management

### DIFF
--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
+using PluginBuilder.Components.PluginVersion;
+using PluginBuilder.ModelBinders;
 using PluginBuilder.Services;
 using PluginBuilder.ViewModels;
 using PluginBuilder.ViewModels.Admin;
@@ -56,12 +58,97 @@ public class AdminController : Controller
             };
             plugins.Add(plugin);
         }
-
         return View(plugins);
-        
-        
-        
-        
+    }
+
+
+    [Route("admin/plugins/{pluginSlug}")]
+    public async Task<IActionResult> GetPlugin([ModelBinder(typeof(PluginSlugModelBinder))]
+            PluginSlug pluginSlug)
+    {
+        await using var conn = await _connectionFactory.Open();
+        var pluginDetail = await conn.QueryFirstOrDefaultAsync(
+            $"""
+              SELECT p.slug, v.ver, v.build_id, v.btcpay_min_ver, v.pre_release, v.updated_at, u."Email" as email
+              FROM plugins p 
+              JOIN versions v ON p.slug = v.plugin_slug
+              JOIN users_plugins up ON v.plugin_slug = up.plugin_slug 
+              JOIN "AspNetUsers" u ON up.user_id = u."Id"
+              WHERE p.slug = @pluginSlug  AND v.ver = (SELECT MAX(ver) FROM versions WHERE plugin_slug = p.slug)
+              """, new { pluginSlug = pluginSlug.ToString() });
+
+        var plugin = new AdminPluginViewModel
+        {
+            ProjectSlug = pluginDetail.slug,
+            Version = string.Join('.', pluginDetail.ver),
+            BuildId = pluginDetail.build_id,
+            BtccpayMinVer = string.Join('.', pluginDetail.btcpay_min_ver),
+            PreRelease = pluginDetail.pre_release,
+            UpdatedAt = pluginDetail.updated_at,
+            PublisherEmail = pluginDetail.email
+        };
+
+        var pluginBuilds = await conn.QueryAsync<(long id, string state, string? manifest_info, string? build_info, DateTimeOffset created_at, bool published, bool pre_release)>
+                ("SELECT id, state, manifest_info, build_info, created_at, v.ver IS NOT NULL, v.pre_release " +
+                "FROM builds b " +
+                "LEFT JOIN versions v ON b.plugin_slug=v.plugin_slug AND b.id=v.build_id " +
+                "WHERE b.plugin_slug = @pluginSlug " +
+                "ORDER BY id DESC " +
+                "LIMIT 20", new { pluginSlug = pluginSlug.ToString() });
+        var vm = new BuildListViewModel();
+        foreach (var row in pluginBuilds)
+        {
+            var b = new BuildListViewModel.BuildViewModel();
+            var buildInfo = row.build_info is null ? null : BuildInfo.Parse(row.build_info);
+            var manifest = row.manifest_info is null ? null : PluginManifest.Parse(row.manifest_info);
+            vm.Builds.Add(b);
+            b.BuildId = row.id;
+            b.State = row.state;
+            b.Commit = buildInfo?.GitCommit?.Substring(0, 8);
+            b.Repository = buildInfo?.GitRepository;
+            b.GitRef = buildInfo?.GitRef;
+            b.Version = PluginVersionViewModel.CreateOrNull(manifest?.Version?.ToString(), row.published, row.pre_release, row.state, pluginSlug.ToString());
+            b.Date = (DateTimeOffset.UtcNow - row.created_at).ToTimeAgo();
+            b.RepositoryLink = PluginController.GetUrl(buildInfo);
+            b.DownloadLink = buildInfo?.Url;
+            b.Error = buildInfo?.Error;
+        }
+        plugin.PluginSlugBuilds[pluginSlug.ToString()] = vm.Builds;
+        return View(plugin);
+    }
+
+    [HttpGet("admin/plugins/{pluginSlug}/delete")]
+    public async Task<IActionResult> DeletePlugin([ModelBinder(typeof(PluginSlugModelBinder))]
+            PluginSlug pluginSlug)
+    {
+        await using var conn = await _connectionFactory.Open();
+        var plugin = await conn.QueryFirstOrDefaultAsync<string>(
+            $"""
+              SELECT p.slug FROM plugins p 
+              WHERE p.slug = @pluginSlug
+              """, new { pluginSlug = pluginSlug.ToString() });
+
+        if (string.IsNullOrEmpty(plugin))
+            return NotFound();
+
+        return View("Confirm", new ConfirmModel("Delete user", $"The plugin and all its versions will be permanently deleted. Are you sure?", "Delete"));
+    }
+
+    [HttpPost("admin/plugins/{pluginSlug}/delete")]
+    public async Task<IActionResult> DeleteUserPost([ModelBinder(typeof(PluginSlugModelBinder))]
+            PluginSlug pluginSlug)
+    {
+        await using var conn = await _connectionFactory.Open();
+        var plugin = await conn.QueryFirstOrDefaultAsync<string>(
+            $"""
+              SELECT p.slug FROM plugins p 
+              WHERE p.slug = @pluginSlug
+              """, new { pluginSlug = pluginSlug.ToString() });
+
+        if (string.IsNullOrEmpty(plugin))
+            return NotFound();
+
+        return RedirectToAction(nameof(ListPlugins));
     }
 
     // list users

--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -148,6 +148,7 @@ public class AdminController : Controller
         if (string.IsNullOrEmpty(plugin))
             return NotFound();
 
+        await conn.DeletePluginDetails(pluginSlug);
         return RedirectToAction(nameof(ListPlugins));
     }
 

--- a/PluginBuilder/Data/Extensions/UrlHelperExtensions.cs
+++ b/PluginBuilder/Data/Extensions/UrlHelperExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace PluginBuilder.Data.Extensions
+{
+    public static class UrlHelperExtensions
+    {
+#nullable enable
+        public static string? EnsureLocal(this IUrlHelper helper, string? url, HttpRequest? httpRequest = null)
+        {
+            if (url is null || helper.IsLocalUrl(url))
+                return url;
+            if (httpRequest is null)
+                return null;
+            if (Uri.TryCreate(url, UriKind.Absolute, out var r) && r.Host.Equals(httpRequest.Host.Host) && (!httpRequest.IsHttps || r.Scheme == "https"))
+                return url;
+            return null;
+        }
+#nullable restore
+
+    }
+}

--- a/PluginBuilder/PluginBuilder.csproj
+++ b/PluginBuilder/PluginBuilder.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="6.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.11" />

--- a/PluginBuilder/Services/Safe.cs
+++ b/PluginBuilder/Services/Safe.cs
@@ -1,0 +1,36 @@
+using Ganss.Xss;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Web;
+
+namespace PluginBuilder.Services
+{
+    public class Safe
+    {
+        private readonly IHtmlHelper _htmlHelper;
+        private readonly IJsonHelper _jsonHelper;
+        private readonly HtmlSanitizer _htmlSanitizer;
+
+        public Safe(IHtmlHelper htmlHelper, IJsonHelper jsonHelper, HtmlSanitizer htmlSanitizer)
+        {
+            _htmlHelper = htmlHelper;
+            _jsonHelper = jsonHelper;
+            _htmlSanitizer = htmlSanitizer;
+        }
+
+        public IHtmlContent Raw(string value)
+        {
+            return _htmlHelper.Raw(_htmlSanitizer.Sanitize(value));
+        }
+
+        public IHtmlContent RawEncode(string value)
+        {
+            return _htmlHelper.Raw(HttpUtility.HtmlEncode(_htmlSanitizer.Sanitize(value)));
+        }
+
+        public IHtmlContent Json(object model)
+        {
+            return _htmlHelper.Raw(_jsonHelper.Serialize(model));
+        }
+    }
+}

--- a/PluginBuilder/ViewModels/Admin/AdminPluginViewModel.cs
+++ b/PluginBuilder/ViewModels/Admin/AdminPluginViewModel.cs
@@ -9,4 +9,5 @@ public class AdminPluginViewModel
     public bool PreRelease { get; set; }
     public DateTime UpdatedAt { get; set; }
     public string PublisherEmail { get; set; }
+    public Dictionary<string, List<BuildListViewModel.BuildViewModel>> PluginSlugBuilds { get; set; } = new();
 }

--- a/PluginBuilder/ViewModels/ConfirmModel.cs
+++ b/PluginBuilder/ViewModels/ConfirmModel.cs
@@ -1,0 +1,32 @@
+namespace PluginBuilder.ViewModels
+{
+    public class ConfirmModel
+    {
+        private const string ButtonClassDefault = "btn-danger";
+
+        public ConfirmModel() { }
+
+        public ConfirmModel(string title, string desc, string action = null, string buttonClass = ButtonClassDefault, string actionName = null, string controllerName = null)
+        {
+            Title = title;
+            Description = desc;
+            Action = action;
+            ActionName = actionName;
+            ControllerName = controllerName;
+            ButtonClass = buttonClass;
+
+            if (Description.Contains("<strong>", StringComparison.InvariantCultureIgnoreCase))
+            {
+                DescriptionHtml = true;
+            }
+        }
+
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public bool DescriptionHtml { get; set; }
+        public string Action { get; set; }
+        public string ActionName { get; set; }
+        public string ControllerName { get; set; }
+        public string ButtonClass { get; set; } = ButtonClassDefault;
+    }
+}

--- a/PluginBuilder/Views/Admin/GetPlugin.cshtml
+++ b/PluginBuilder/Views/Admin/GetPlugin.cshtml
@@ -1,0 +1,100 @@
+@model AdminPluginViewModel
+@{
+Layout = "_Layout";
+ViewData.SetActivePage(AdminNavPages.Plugins, $"Plugins: {@Model.ProjectSlug}");
+}
+
+@functions
+{
+    void ToBadge(string state, string error)
+    {
+        @if (state == "failed")
+        {
+            <span class="badge bg-danger" tooltip="@error">
+                @state
+                <small>
+                    <a href="#" class="ms-1" target="_blank" rel="noreferrer noopener">
+                        <span class="fa fa-question-circle-o" style="color: var(--btcpay-danger-text)" title="@error"></span>
+                    </a>
+                </small>
+            </span>
+        }
+        else if (state == "uploaded")
+        {
+            <span class="badge bg-success">@state</span>
+        }
+        else
+        {
+            <span class="badge bg-warning">@state</span>
+        }
+    }
+}
+
+<div class="sticky-header" style="margin-top: 0; padding-top: 0;">
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb" style="margin-bottom: 0;">
+                <li class="breadcrumb-item">
+                    <a asp-controller="Admin" asp-action="ListPlugins">Plugins</a>
+                </li>
+                <li class="breadcrumb-item active" aria-current="page" style="color: black;">@Model.ProjectSlug</li>
+            </ol>
+        </nav>
+        <a asp-controller="Admin"
+           asp-action="DeletePlugin"
+           asp-route-pluginSlug="@Model.ProjectSlug"
+           class="btn btn-primary mt-2 mt-md-0">
+            Delete Plugin
+        </a>
+    </div>
+</div>
+
+
+<partial name="_ViewPlugin" model="Model" />
+
+<div class="table-responsive">
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th class="w-150px">Date</th>
+                <th class="text-nowrap">Build Id</th>
+                <th class="text-nowrap">Version</th>
+                <th class="text-nowrap">Repository</th>
+                <th class="text-nowrap">Git ref</th>
+                <th>Commit</th>
+                <th class="text-end">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var build in Model.PluginSlugBuilds)
+            {
+                @foreach (var item in build.Value)
+                {
+                    <tr id="plugin_@item.BuildId" class="invoice-row">
+                        <td>@item.Date</td>
+                        <td>@item.BuildId</td>
+                        <td>
+                            <vc:plugin-version model="@item.Version"></vc:plugin-version>
+                        </td>
+                        <td><a href="@item.Repository" target="_blank" rel="noreferrer noopener">@item.Repository</a></td>
+                        <td>@item.GitRef</td>
+                        @if (item.RepositoryLink is null)
+                        {
+                            <td>@item.Commit</td>
+                        }
+                        else
+                        {
+                            <td><a href="@item.RepositoryLink" target="_blank" rel="noreferrer noopener">@item.Commit</a></td>
+                        }
+                        <td class="text-end text-nowrap">
+                            @if (!string.IsNullOrEmpty(item.DownloadLink) && item.State != "removed")
+                            {
+                                <a href="@item.DownloadLink" rel="noreferrer noopener">Download</a>
+                            }
+                        </td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</div>

--- a/PluginBuilder/Views/Admin/ListPlugins.cshtml
+++ b/PluginBuilder/Views/Admin/ListPlugins.cshtml
@@ -10,30 +10,48 @@ ViewData.SetActivePage(AdminNavPages.Plugins, "Plugins");
     </h2>
 </div>
 
-<table class="table">
-    <thead>
-        <tr>
-            <th>Project Slug</th>
-            <th>Version</th>
-            <th>Build ID</th>
-            <th>BTCPay Min Version</th>
-            <th>Pre-Release</th>
-            <th>Updated At</th>
-            <th>Publisher Email</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var plugin in Model)
-        {
-            <tr>
-                <td>@plugin.ProjectSlug</td>
-                <td>@plugin.Version</td>
-                <td>@plugin.BuildId</td>
-                <td>@plugin.BtccpayMinVer</td>
-                <td>@plugin.PreRelease</td>
-                <td>@plugin.UpdatedAt</td>
-                <td>@plugin.PublisherEmail</td>
-            </tr>
-        }
-    </tbody>
-</table>
+@if (Model != null && Model.Any())
+{
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th>Project Slug</th>
+                    <th>Version</th>
+                    <th>Build ID</th>
+                    <th>BTCPay Min Version</th>
+                    <th>Pre-Release</th>
+                    <th>Updated At</th>
+                    <th>Publisher Email</th>
+                    <th class="actions-col"></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var plugin in Model)
+                {
+                    <tr>
+                        <td>@plugin.ProjectSlug</td>
+                        <td>@plugin.Version</td>
+                        <td>@plugin.BuildId</td>
+                        <td>@plugin.BtccpayMinVer</td>
+                        <td>@plugin.PreRelease</td>
+                        <td>@plugin.UpdatedAt</td>
+                        <td>@plugin.PublisherEmail</td>
+                        <td class="actions-col">
+                            <div class="d-inline-flex align-items-center gap-3">
+                                <a asp-controller="Admin" asp-action="GetPlugin" asp-route-pluginSlug="@plugin.ProjectSlug">View</a>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <div class="alert alert-warning alert-dismissible mb-4 mt-4" role="alert">
+        <p class="mb-0" style="font-size: 0.9rem;">No plugin builds available</p>
+    </div>
+}

--- a/PluginBuilder/Views/Shared/Confirm.cshtml
+++ b/PluginBuilder/Views/Shared/Confirm.cshtml
@@ -1,0 +1,25 @@
+@model ConfirmModel
+
+@{
+    ViewData["Title"] = Model.Title;
+    Layout = "_Layout";
+}
+
+@section HeaderScripts {
+    <style>
+        body > .content-wrapper { flex-grow: 1; display:  flex; }
+        body > .content-wrapper, body > .content-wrapper > .container { flex-grow:1; }
+        .modal-dialog .btn-close { display: none; }
+    </style>
+}
+
+@section FooterScripts {
+    <script>
+        delegate('click', '#ConfirmCancel', function () {
+            history.back();
+        })
+    </script>
+}
+<div class="modal position-static d-block" tabindex="-1">
+    <partial name="ConfirmModal" model="Model" />
+</div>

--- a/PluginBuilder/Views/Shared/ConfirmModal.cshtml
+++ b/PluginBuilder/Views/Shared/ConfirmModal.cshtml
@@ -1,0 +1,42 @@
+@using PluginBuilder.Data.Extensions
+@using PluginBuilder.Services
+@model ConfirmModel
+@inject LinkGenerator linkGenerator
+@{
+	string actionUrl = null;
+	if (Model.ActionName is not null)
+	{
+		var controllerName = Model.ControllerName ?? ((Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor)this.Url.ActionContext.ActionDescriptor).ControllerName;
+		actionUrl = linkGenerator.GetPathByAction(Model.ActionName, controllerName, pathBase: this.Context.Request.PathBase);
+	}
+}
+<div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h4 class="modal-title" id="ConfirmTitle">@Model.Title</h4>
+            <button type="button" class="btn-close me-3" data-bs-dismiss="modal" aria-label="Close">
+                <vc:icon symbol="close" />
+            </button>
+        </div>
+
+        <div class="modal-body">
+            <div id="ConfirmDescription">
+                @Model.Description
+            </div>
+        </div>
+
+        @if (!string.IsNullOrEmpty(Model.Action))
+        {
+			<form id="ConfirmForm" method="post" action="@Url.EnsureLocal(actionUrl, Context.Request)" rel="noreferrer noopener">
+                <div class="modal-body pt-0" id="ConfirmText" hidden>
+                    <label for="ConfirmInput" class="form-label">Confirm the action by typing <strong id="ConfirmInputText"></strong>:</label>
+                    <input id="ConfirmInput" class="form-control"/>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary only-for-js" data-bs-dismiss="modal" id="ConfirmCancel">Cancel</button>
+                    <button type="submit" class="btn @Model.ButtonClass" id="ConfirmContinue">@Model.Action</button>
+                </div>
+            </form>
+        }
+    </div>
+</div>

--- a/PluginBuilder/Views/Shared/_Confirm.cshtml
+++ b/PluginBuilder/Views/Shared/_Confirm.cshtml
@@ -1,0 +1,56 @@
+@model ConfirmModel
+<div class="modal fade" id="ConfirmModal" tabindex="-1" aria-labelledby="ConfirmTitle" aria-hidden="true">
+    <partial name="ConfirmModal" model="Model" />
+</div>
+
+<script>
+    (function () {
+        const modal = document.getElementById('ConfirmModal')
+        modal.addEventListener('show.bs.modal', event => {
+            const $target = event.relatedTarget
+            const $form = document.getElementById('ConfirmForm')
+            const $text = document.getElementById('ConfirmText')
+            const $title = document.getElementById('ConfirmTitle')
+            const $description = document.getElementById('ConfirmDescription')
+            const $input = document.getElementById('ConfirmInput')
+            const $inputText = document.getElementById('ConfirmInputText')
+            const $continue = document.getElementById('ConfirmContinue')
+            const { title, description, confirm, confirmInput } = $target.dataset
+            const action = $target.dataset.action || ($target.nodeName === 'A'
+                ? $target.getAttribute('href')
+                : $target.form.getAttribute('action'))
+    
+            if ($form && !$form.hasAttribute('action')) $form.setAttribute('action', action)
+            if (title) $title.textContent = title
+            if (description) $description.innerHTML = description
+            if (confirm) $continue.textContent = confirm
+            if (confirmInput) {
+                $text.removeAttribute('hidden')
+                $continue.setAttribute('disabled', 'disabled')
+                $inputText.textContent = confirmInput
+                $input.setAttribute("autocomplete", "off")
+                $input.addEventListener('input', event => {
+                    event.target.value.trim() === confirmInput
+                        ? $continue.removeAttribute('disabled')
+                        : $continue.setAttribute('disabled', 'disabled')
+                })
+                $form.addEventListener('submit', event => {
+                    if ($input.value.trim() !== confirmInput) {
+                        event.preventDefault()
+                    }
+                })
+            } else {
+                $text.setAttribute('hidden', 'hidden')
+                $continue.removeAttribute('disabled')
+            }
+        })
+        modal.addEventListener('shown.bs.modal', event => {
+            const $target = event.relatedTarget
+            const $input = document.getElementById('ConfirmInput')
+            const { confirmInput } = $target.dataset
+            if (confirmInput) {
+                $input.focus()
+            }
+        })
+    })()
+</script>

--- a/PluginBuilder/Views/Shared/_ViewPlugin.cshtml
+++ b/PluginBuilder/Views/Shared/_ViewPlugin.cshtml
@@ -1,0 +1,38 @@
+@model AdminPluginViewModel
+@{
+}
+
+<div class="d-flex justify-content-between mt-3 flex-wrap">
+    <div class="d-flex flex-column gap-3 col-12 col-lg-7 mb-3 mb-md-0">
+        <div class="d-flex flex-column gap-2 h-100">
+            <div class="flex-grow-1" style="background-color: rgba(128, 128, 128, 0.3); min-height: 100px; flex-basis: 100px;"></div>
+            <div class="d-flex gap-2 flex-grow-1">
+                <div class="flex-grow-1" style="background-color: rgba(128, 128, 128, 0.3); min-height: 100px; flex-basis: 100px;"></div>
+                <div class="flex-grow-1" style="background-color: rgba(128, 128, 128, 0.3); min-height: 100px; flex-basis: 100px;"></div>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 col-lg-4 mt-3">
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item d-flex justify-content-between bg-transparent px-0">
+                <strong>Version:</strong>
+                <span>@Model.Version</span>
+            </li>
+            @if (!string.IsNullOrEmpty(Model.PublisherEmail))
+            {
+                <li class="list-group-item d-flex justify-content-between bg-transparent px-0">
+                    <strong>Published By:</strong>
+                    <span><a href="@Model.PublisherEmail" rel="noreferrer noopener" target="_blank" class="text-success">@Model.PublisherEmail</a></span>
+                </li>
+            }
+            <li class="list-group-item d-flex justify-content-between bg-transparent px-0">
+                <strong>Last Updated:</strong>
+                <span>@Model.UpdatedAt</span>
+            </li>
+            <li class="list-group-item d-flex justify-content-between bg-transparent px-0">
+                <strong>BTCPay Min Version:</strong>
+                <span>@Model.BtccpayMinVer</span>
+            </li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
Part implementation for #24 

Regarding this:

Provide 3 kinds of display types for each plugin - hidden, unlisted, listed - and allow administration with switching between these states

@rockstardev  I wasn't so sure of these, please when is a plugin hidden and/or unlisted?


![image](https://github.com/user-attachments/assets/7e1f1267-f67c-4613-940e-89e2f37855dd)


![image](https://github.com/user-attachments/assets/3684ead8-025b-4e80-b53d-01fe7c2142b6)


I believe this also caters for #19 . I made the view a partial class so it can be reused at different point

