### PR TITLE
Include action for admin the change user email

### DIFF
--- a/PluginBuilder/Controllers/AccountController.cs
+++ b/PluginBuilder/Controllers/AccountController.cs
@@ -83,7 +83,7 @@ public class AccountController(
         return RedirectToAction(nameof(AccountDetails));
     }
 
-    [HttpGet("VerifyGithubAccount")]
+    [HttpGet("verifygithubaccount")]
     public async Task<IActionResult> VerifyGithubAccount()
     {
         await using var conn = await connectionFactory.Open();
@@ -102,7 +102,7 @@ public class AccountController(
         return View(new VerifyGitHubViewModel { Token = user!.Id });
     }
 
-    [HttpPost("VerifyGithubAccount")]
+    [HttpPost("verifygithubaccount")]
     public async Task<IActionResult> VerifyGithubAccount(VerifyGitHubViewModel model)
     {
         try

--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -5,10 +5,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using PluginBuilder.DataModels;
 using PluginBuilder.Extensions;
 using PluginBuilder.Services;
 using PluginBuilder.ViewModels;
 using PluginBuilder.ViewModels.Admin;
+using static Dapper.SqlMapper;
 
 namespace PluginBuilder.Controllers;
 
@@ -256,6 +258,40 @@ public class AdminController(
         var result = await userManager.GeneratePasswordResetTokenAsync(user);
         model.PasswordResetToken = result;
         return View(model);
+    }
+
+    [HttpGet("/admin/changeemailaddress")]
+    public async Task<IActionResult> ChangeUserEmail(string userId)
+    {
+        ChangeEmailAddressViewModel model = new();
+        var user = await userManager.FindByIdAsync(userId);
+        if (user != null)
+            model.OldEmail = user.Email;
+
+        return View(model);
+    }
+
+    [HttpPost("/admin/changeemailaddress")]
+    public async Task<IActionResult> ChangeUserEmail(ChangeEmailAddressViewModel model)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        await using var conn = await connectionFactory.Open();
+        var user = await userManager.FindByEmailAsync(model.OldEmail);
+        if (user is null)
+        {
+            ModelState.AddModelError(string.Empty, "User with suggested email doesn't exist");
+            return View(model);
+        }
+        var accountSettings = await conn.GetAccountDetailSettings(user!.Id) ?? new AccountSettings();
+        accountSettings.PendingNewEmail = model.NewEmail;
+        await conn.SetAccountDetailSettings(accountSettings, user.Id);
+        var token = await userManager.GenerateChangeEmailTokenAsync(user, model.NewEmail);
+        var link = Url.Action("VerifyEmailUpdate", "Home", new { uid = user.Id, token }, Request.Scheme, Request.Host.ToString())!;
+        await emailService.SendVerifyEmail(user.Email!, link);
+        TempData[TempDataConstant.SuccessMessage] = "A verification email has been sent to user's new email address";
+        return RedirectToAction(nameof(Users));
     }
 
     [HttpGet("emailsettings")]

--- a/PluginBuilder/DataModels/AccountSettings.cs
+++ b/PluginBuilder/DataModels/AccountSettings.cs
@@ -15,4 +15,5 @@ public class AccountSettings
 
     [Display(Name = "Public Email address")]
     public string? Email { get; set; }
+    public string? PendingNewEmail { get; set; }
 }

--- a/PluginBuilder/ViewModels/InitPasswordResetViewModel.cs
+++ b/PluginBuilder/ViewModels/InitPasswordResetViewModel.cs
@@ -12,3 +12,17 @@ public class InitPasswordResetViewModel
 
     public string PasswordResetToken { get; set; }
 }
+
+
+public class ChangeEmailAddressViewModel
+{
+    [Required]
+    [EmailAddress]
+    [Display(Name = "Old Email")]
+    public string OldEmail { get; set; }
+
+    [Required]
+    [EmailAddress]
+    [Display(Name = "New Email")]
+    public string NewEmail { get; set; }
+}

--- a/PluginBuilder/Views/Account/AccountDetails.cshtml
+++ b/PluginBuilder/Views/Account/AccountDetails.cshtml
@@ -36,7 +36,7 @@
                     @if (!Model.GithubAccountVerified)
                     {
                         <div class="input-group-append">
-                            <a asp-controller="Account" asp-action="VerifyGithubAccount" class="btn btn-secondary">Verify GitHub</a>
+							<a asp-controller="Account" asp-action="VerifyGithubAccount" class="btn btn-secondary">Verify GitHub</a>
                         </div>
                     }
                 </div>

--- a/PluginBuilder/Views/Admin/ChangeUserEmail.cshtml
+++ b/PluginBuilder/Views/Admin/ChangeUserEmail.cshtml
@@ -1,0 +1,27 @@
+@model ChangeEmailAddressViewModel
+@{
+    Layout = "_Layout";
+    ViewData.SetActivePage(AdminNavPages.Users, "Change Email Address");
+}
+
+<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<div class="row">
+    <div class="col-xl-8 col-xxl-constrain">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="OldEmail" class="form-label"></label>
+                <input asp-for="OldEmail" class="form-control" placeholder="Email of User to Reset" readonly />
+                <span asp-validation-for="OldEmail" class="text-danger"></span>
+            </div>
+			<div class="form-group">
+				<label asp-for="NewEmail" class="form-label" data-required></label>
+				<input asp-for="NewEmail" class="form-control" placeholder="Email of User to Reset" required />
+				<span asp-validation-for="NewEmail" class="text-danger"></span>
+			</div>
+            <div class="form-group mt-4">
+                <input type="submit" class="btn btn-primary" id="Submit" value="Submit" />
+            </div>
+        </form>
+    </div>
+</div>

--- a/PluginBuilder/Views/Admin/Users.cshtml
+++ b/PluginBuilder/Views/Admin/Users.cshtml
@@ -44,6 +44,10 @@
                         <a asp-action="InitPasswordReset" asp-route-userId="@user.Id">
                             Reset Password
                         </a>
+						<span class="mx-2">|</span>
+						<a asp-action="ChangeUserEmail" asp-route-userId="@user.Id">
+							Change Email
+						</a>
                     </td>
                 </tr>
             }


### PR DESCRIPTION
Admin can now initiate email change for users. 

An email with token is sent to the user's email address, once email is confirmed, the email is changed and the email status is marked as confirmed in the account settings

![image](https://github.com/user-attachments/assets/aa3f500d-af81-4f2a-8775-5dad34d1b38e)

![image](https://github.com/user-attachments/assets/7d66cd37-3f77-4f18-bd75-96e20b0c6b66)

![image](https://github.com/user-attachments/assets/228e001d-f2fb-42b2-b385-4e6ba006bee3)

![image](https://github.com/user-attachments/assets/dfb89479-824a-4633-8dfa-f6d1b0ff5272)

![image](https://github.com/user-attachments/assets/ce1d88cc-cdd1-452c-a85c-d23a34c06082)

![image](https://github.com/user-attachments/assets/dd0bd802-0311-4464-acca-00ad4b3cc619)

