### PR TITLE
feat: add plugin visibility support and enforce rules in public views and API

### DIFF
--- a/PluginBuilder.Tests/HttpClientExtensions.cs
+++ b/PluginBuilder.Tests/HttpClientExtensions.cs
@@ -12,11 +12,18 @@ public static class HttpClientExtensions
 {
     private static readonly JsonSerializerSettings serializerSettings = new() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 
-    public static async Task<PublishedVersion[]> GetPublishedVersions(this HttpClient httpClient, string btcpayVersion, bool includePreRelease,
-        bool includeAllVersions = false)
+    public static async Task<PublishedVersion[]> GetPublishedVersions(this HttpClient httpClient,
+        string btcpayVersion,
+        bool includePreRelease,
+        bool? includeAllVersions = false,
+        string? searchPluginName = null
+    )
     {
-        var result = await httpClient.GetStringAsync(
-            $"api/v1/plugins?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}&includeAllVersions={includeAllVersions}");
+        var url = $"api/v1/plugins?btcpayVersion={btcpayVersion}&includePreRelease={includePreRelease}&includeAllVersions={includeAllVersions}";
+        if (!string.IsNullOrEmpty(searchPluginName))
+            url += $"&searchPluginName={Uri.EscapeDataString(searchPluginName)}";
+
+        var result = await httpClient.GetStringAsync(url);
         return JsonConvert.DeserializeObject<PublishedVersion[]>(result, serializerSettings) ?? throw new InvalidOperationException();
     }
 

--- a/PluginBuilder.Tests/PlaywrightTester.cs
+++ b/PluginBuilder.Tests/PlaywrightTester.cs
@@ -84,11 +84,12 @@ public class PlaywrightTester : IAsyncDisposable
         Assert.DoesNotContain("Error", title, StringComparison.OrdinalIgnoreCase);
     }
     
-    public async Task GoToUrl(string uri)
+    public async Task<IResponse?> GoToUrl(string uri)
     {
         var fullUrl = new Uri(ServerUri ?? throw new InvalidOperationException(), uri).ToString();
-        await Page?.GotoAsync(fullUrl, new PageGotoOptions { WaitUntil = WaitUntilState.Commit })!;
+        return await Page?.GotoAsync(fullUrl, new PageGotoOptions { WaitUntil = WaitUntilState.Commit })!;
     }
+
     public async Task GoToLogin()
     {
         await GoToUrl("/login");

--- a/PluginBuilder.Tests/PublicTests/PublicDirectoryUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PublicDirectoryUITests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.PublicTests;
+
+public class PublicDirectoryUITests(ITestOutputHelper output) : PageTest
+{
+    private readonly XUnitLogger _log = new("PublicDirectoryUITests", output);
+    
+    [Fact]
+    public async Task PublicDirectory_RespectsPluginVisibility()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        await tester.StartAsync();
+
+        var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
+        
+        const string slug = "rockstar-stylist";
+        var fullBuildId = await tester.Server.CreateAndBuildPluginAsync();
+        
+        var manifestInfoJson = await conn.QuerySingleAsync<string>(
+            "SELECT manifest_info FROM builds WHERE plugin_slug = @PluginSlug AND id = @BuildId",
+            new { PluginSlug = slug, BuildId = fullBuildId.BuildId });
+        var manifest = PluginManifest.Parse(manifestInfoJson);
+
+        // Remove pre-release
+        await conn.SetVersionBuild(fullBuildId, manifest.Version, manifest.BTCPayMinVersion, false);
+
+        // Listed should be visible
+        await conn.ExecuteAsync("UPDATE plugins SET visibility = 'listed' WHERE slug = @Slug", new { Slug = slug });
+        await tester.GoToUrl("/public/plugins");
+        await tester.Page!.WaitForSelectorAsync("a[href='/public/plugins/rockstar-stylist']");
+        Assert.True(await tester.Page.Locator("a[href='/public/plugins/rockstar-stylist']").IsVisibleAsync());
+        
+        // Plugin public page should be visible
+        await tester.GoToUrl($"/public/plugins/{slug}");
+        var contentListed = await tester.Page.ContentAsync();
+        Assert.Contains(slug, contentListed, StringComparison.OrdinalIgnoreCase);
+
+        // Unlisted shouldn't be visible
+        await conn.ExecuteAsync("UPDATE plugins SET visibility = 'unlisted' WHERE slug = @Slug", new { Slug = slug });
+        await tester.GoToUrl("/public/plugins");
+        await tester.Page.ReloadAsync();
+        Assert.False(await tester.Page.Locator("a[href='/public/plugins/rockstar-stylist']").IsVisibleAsync());
+
+        // Unlisted with search term should be visible
+        await tester.Page.Locator("input[name='searchPluginName']").FillAsync("rockstar");
+        await tester.Page.Keyboard.PressAsync("Enter");
+        await tester.Page.WaitForSelectorAsync("a[href='/public/plugins/rockstar-stylist']", new PageWaitForSelectorOptions { State = WaitForSelectorState.Visible });
+        Assert.True(await tester.Page.Locator("a[href='/public/plugins/rockstar-stylist']").IsVisibleAsync());
+
+        // Hidden shouldn't appear
+        await conn.ExecuteAsync("UPDATE plugins SET visibility = 'hidden' WHERE slug = @Slug", new { Slug = slug });
+        await tester.GoToUrl("/public/plugins");
+        await tester.Page.Locator("input[name='searchPluginName']").FillAsync("rockstar");
+        await tester.Page.Keyboard.PressAsync("Enter");
+        await tester.Page.WaitForSelectorAsync("a[href='/public/plugins/rockstar-stylist']", new PageWaitForSelectorOptions { State = WaitForSelectorState.Hidden });
+        Assert.False(await tester.Page.Locator("a[href='/public/plugins/rockstar-stylist']").IsVisibleAsync());
+        
+        // Public page should not be accessible if hidden and owner is not logged in
+        var response = await tester.GoToUrl("/public/plugins/rockstar-stylist");
+        Assert.Equal(404, response?.Status);
+
+        // Log in as plugin owner and access page again
+        await tester.GoToUrl("/register");
+        var email = await tester.RegisterNewUser();
+        await tester.LogIn(email);
+        var userId = await conn.QuerySingleAsync<string>(
+            "SELECT \"Id\" FROM \"AspNetUsers\" WHERE \"Email\" = @Email", new { Email = email });
+        await conn.AddUserPlugin(slug, userId);
+
+        await tester.GoToUrl($"/public/plugins/{slug}");
+        var hiddenAlert = tester.Page.Locator("#hidden-plugin-alert");
+        Assert.True(await hiddenAlert.IsVisibleAsync());
+    }
+}

--- a/PluginBuilder.Tests/ServerTester.cs
+++ b/PluginBuilder.Tests/ServerTester.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
 
 namespace PluginBuilder.Tests;
 
@@ -103,4 +105,25 @@ public class ServerTester : IAsyncDisposable
 
         return directory;
     }
+    
+    public async Task<FullBuildId> CreateAndBuildPluginAsync(
+        string slug = "rockstar-stylist",
+        string gitRef = "plugins/collection2",
+        string pluginDir = "Plugins/BTCPayServer.Plugins.RockstarStylist")
+    {
+        var conn = await GetService<DBConnectionFactory>().Open();
+        var buildService = GetService<BuildService>();
+
+        await conn.NewPlugin(slug);
+        var buildId = await conn.NewBuild(slug, new PluginBuildParameters("https://github.com/NicolasDorier/btcpayserver")
+        {
+            GitRef = gitRef,
+            PluginDirectory = pluginDir
+        });
+
+        var fullBuildId = new FullBuildId(slug, buildId);
+        await buildService.Build(fullBuildId);
+        return fullBuildId;
+    }
+
 }

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -49,15 +49,45 @@ public class ApiController(
         };
         await using var conn = await connectionFactory.Open();
 
+        var filters = new List<string>
+        {
+            "b.manifest_info IS NOT NULL",
+            "b.build_info IS NOT NULL"
+        };
+
+        var isBtcpayV21OrHigher = btcpayVersion?.IsAtLeast(2, 1) == true;
+        var hasSearchTerm = !string.IsNullOrWhiteSpace(searchPluginName);
+
+        if (isBtcpayV21OrHigher)
+        {
+            if (hasSearchTerm)
+            {
+                filters.Add("(p.visibility = 'listed' OR p.visibility = 'unlisted')");
+                filters.Add("(p.slug ILIKE @searchPattern OR b.manifest_info->>'Name' ILIKE @searchPattern)");
+            }
+            else
+            {
+                filters.Add("p.visibility = 'listed'");
+            }
+        }
+        else
+        {
+            filters.Add("(p.visibility = 'listed' OR p.visibility = 'unlisted')");
+            if (hasSearchTerm)
+            {
+                filters.Add("(p.slug ILIKE @searchPattern OR b.manifest_info->>'Name' ILIKE @searchPattern)");
+            }
+        }
+
+        var whereClause = "WHERE " + string.Join(" AND ", filters);
+
         // This query definitely doesn't have right indexes
         var query = $"""
                      SELECT lv.plugin_slug, lv.ver, p.settings, b.id, b.manifest_info, b.build_info
                      FROM {getVersions}(@btcpayVersion, @includePreRelease) lv
                      JOIN builds b ON b.plugin_slug = lv.plugin_slug AND b.id = lv.build_id
                      JOIN plugins p ON b.plugin_slug = p.slug
-                     WHERE b.manifest_info IS NOT NULL AND b.build_info IS NOT NULL 
-                     AND (p.visibility = 'unlisted' OR p.visibility = 'listed')
-                     {(!string.IsNullOrWhiteSpace(searchPluginName) ? "AND (p.slug ILIKE @searchPattern OR b.manifest_info->>'Name' ILIKE @searchPattern)" : "")}
+                     {whereClause}
                      ORDER BY manifest_info->>'Name'
                      """;
         var rows =
@@ -72,20 +102,16 @@ public class ApiController(
 
         rows.TryGetNonEnumeratedCount(out var count);
         List<PublishedVersion> versions = new(count);
-        foreach (var r in rows)
+        versions.AddRange(rows.Select(r => new PublishedVersion
         {
-            PublishedVersion v = new()
-            {
-                ProjectSlug = r.plugin_slug,
-                Version = string.Join('.', r.ver),
-                BuildId = r.id,
-                BuildInfo = JObject.Parse(r.build_info),
-                ManifestInfo = JObject.Parse(r.manifest_info),
-                PluginLogo = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Logo,
-                Documentation = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Documentation
-            };
-            versions.Add(v);
-        }
+            ProjectSlug = r.plugin_slug,
+            Version = string.Join('.', r.ver),
+            BuildId = r.id,
+            BuildInfo = JObject.Parse(r.build_info),
+            ManifestInfo = JObject.Parse(r.manifest_info),
+            PluginLogo = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Logo,
+            Documentation = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Documentation
+        }));
 
         return Ok(versions);
     }

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using PluginBuilder.APIModels;
 using PluginBuilder.Components.PluginVersion;
 using PluginBuilder.Controllers.Logic;
+using PluginBuilder.DataModels;
 using PluginBuilder.Services;
 using PluginBuilder.Util;
 using PluginBuilder.Util.Extensions;
@@ -172,33 +173,40 @@ LIMIT 50", new { userId = userManager.GetUserId(User) });
                      FROM {getVersions}(@btcpayVersion, @includePreRelease) lv
                      JOIN builds b ON b.plugin_slug = lv.plugin_slug AND b.id = lv.build_id
                      JOIN plugins p ON b.plugin_slug = p.slug
-                     WHERE b.manifest_info IS NOT NULL AND b.build_info IS NOT NULL AND p.visibility != 'hidden'
-                     AND (p.visibility = 'unlisted' OR p.visibility = 'listed')
-                     {(!string.IsNullOrWhiteSpace(searchPluginName) ? "AND (p.slug ILIKE @searchPattern OR b.manifest_info->>'Name' ILIKE @searchPattern)" : "")}
+                     WHERE b.manifest_info IS NOT NULL
+                     AND b.build_info IS NOT NULL
+                     AND (
+                         p.visibility = 'listed'
+                         OR (p.visibility = 'unlisted' AND @hasSearchTerm = true)
+                     )
+                     AND (
+                         @hasSearchTerm = false
+                         OR (p.slug ILIKE @searchPattern OR b.manifest_info->>'Name' ILIKE @searchPattern)
+                     )
                      ORDER BY manifest_info->>'Name'
                      """;
-        var rows =
-            await conn.QueryAsync<(string plugin_slug, int[] ver, string settings, long id, string manifest_info, string build_info)>(query,
-                new
-                {
-                    btcpayVersion = btcpayVersion?.VersionParts,
-                    includePreRelease = false,
-                    searchPattern = $"%{searchPluginName}%"
-                });
+
+        var rows = await conn.QueryAsync<(string plugin_slug, int[] ver, string settings, long id, string manifest_info, string build_info)>(
+            query,
+            new
+            {
+                btcpayVersion = btcpayVersion?.VersionParts,
+                includePreRelease = false,
+                searchPattern = $"%{searchPluginName}%",
+                hasSearchTerm = !string.IsNullOrWhiteSpace(searchPluginName)
+            });
+
         rows.TryGetNonEnumeratedCount(out var count);
         List<PublishedPlugin> versions = new(count);
-        foreach (var r in rows)
+        versions.AddRange(rows.Select(r => new PublishedPlugin
         {
-            PublishedPlugin v = new()
-            {
-                ProjectSlug = r.plugin_slug,
-                Version = string.Join('.', r.ver),
-                BuildInfo = JObject.Parse(r.build_info),
-                ManifestInfo = JObject.Parse(r.manifest_info),
-                PluginLogo = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Logo,
-            };
-            versions.Add(v);
-        }
+            ProjectSlug = r.plugin_slug,
+            Version = string.Join('.', r.ver),
+            BuildInfo = JObject.Parse(r.build_info),
+            ManifestInfo = JObject.Parse(r.manifest_info),
+            PluginLogo = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Logo,
+        }));
+
         return View(versions);
     }
 
@@ -208,18 +216,38 @@ LIMIT 50", new { userId = userManager.GetUserId(User) });
     {
         await using var conn = await connectionFactory.Open();
         var query = """
-                    SELECT v.plugin_slug, v.ver, p.settings, v.build_id, b.manifest_info, b.build_info
+                    SELECT v.plugin_slug, v.ver, p.settings, v.build_id, b.manifest_info, b.build_info, p.visibility
                     FROM versions v
                     JOIN builds b ON b.plugin_slug = v.plugin_slug AND b.id = v.build_id
                     JOIN plugins p ON b.plugin_slug = p.slug
                     WHERE v.plugin_slug = @pluginSlug
-                    AND b.manifest_info IS NOT NULL AND b.build_info IS NOT NULL AND p.visibility != 'hidden'
+                    AND b.manifest_info IS NOT NULL AND b.build_info IS NOT NULL
                     ORDER BY v.ver DESC
                     LIMIT 1
                     """;
         var r = await conn.QueryFirstOrDefaultAsync(query, new { pluginSlug = pluginSlug.ToString() });
         if (r is null)
             return NotFound();
+
+        var isAuthor = false;
+
+        if (r.visibility == PluginVisibilityEnum.Hidden)
+        {
+            if (!User.Identity?.IsAuthenticated ?? true)
+                return NotFound();
+
+            var userId = userManager.GetUserId(User);
+            var isAuthorQuery = """
+                                SELECT 1 FROM users_plugins
+                                WHERE plugin_slug = @pluginSlug AND user_id = @userId
+                                LIMIT 1
+                                """;
+            isAuthor = await conn.ExecuteScalarAsync<bool>(isAuthorQuery,
+                new { pluginSlug = pluginSlug.ToString(), userId });
+
+            if (!isAuthor)
+                return NotFound();
+        }
 
         var plugin = new PublishedPlugin
         {
@@ -230,8 +258,10 @@ LIMIT 50", new { userId = userManager.GetUserId(User) });
             PluginLogo = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Logo,
             Documentation = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Documentation
         };
-        var contributors = await plugin.GetContributorsAsync(httpClient);
-        ViewBag.Contributors = contributors;
+
+        ViewBag.Contributors = await plugin.GetContributorsAsync(httpClient);
+        ViewBag.ShowHiddenNotice = r.visibility == PluginVisibilityEnum.Hidden && isAuthor;
+
         return View(plugin);
     }
 

--- a/PluginBuilder/PluginVersion.cs
+++ b/PluginBuilder/PluginVersion.cs
@@ -45,4 +45,12 @@ public class PluginVersion
     {
         return Version;
     }
+    
+    public bool IsAtLeast(int major, int minor)
+    {
+        var actualMajor = VersionParts.ElementAtOrDefault(0);
+        var actualMinor = VersionParts.ElementAtOrDefault(1);
+
+        return actualMajor > major || (actualMajor == major && actualMinor >= minor);
+    }
 }

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -13,6 +13,13 @@
 
 <partial name="_PublicHeader" />
 
+@if (ViewBag.ShowHiddenNotice == true)
+{
+    <div id="hidden-plugin-alert" class="alert alert-warning text-center mb-4" role="alert">
+        <strong>Note:</strong> This plugin is currently <strong>hidden</strong> and only visible to you.
+    </div>
+}
+
 <div class="container">
 	<div class="row mb-4">
 		<div class="col-12">


### PR DESCRIPTION
### Changes

- Added support for plugin visibility levels: listed, unlisted, and hidden
- Hidden plugins' public page now shows a banner alert when accessed by their owner
- /api/v1/plugins respects visibility rules:
    - listed: always returned
    - unlisted: returned only when searchPluginName is provided or for legacy requests (lower then 2.1)
    - hidden: never returned
- public/plugins page respects visibility:
    - listed: always shown
    - unlisted: only shown when searching by name
    - hidden: never shown, even in search
- Public plugin page (/public/plugins/{slug}):
    - Accessible if plugin is listed or unlisted
    - Returns 404 if plugin is hidden (unless accessed by owner)

### Tests

- Added Playwright UI test (PublicDirectory_RespectsPluginVisibility) to verify plugin listing and access behavior across visibility levels
- Extended unit tests to assert correct filtering in API responses for listed, unlisted, and hidden plugins, with and without search terms


https://github.com/user-attachments/assets/8bda7dbe-a873-42d7-a9a9-0ef1dff4c089

https://github.com/user-attachments/assets/cb55b743-9adc-4c86-99c1-b6688f8fee42