### PR TITLE
Record only contributors that has contributed to project

### DIFF
--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -19,8 +19,8 @@ public class PublishedVersion
 public class PublishedPlugin : PublishedVersion
 {
     static Regex GithubRepositoryRegex = new Regex("^https://(www\\.)?github\\.com/([^/]+)/([^/]+)/?");
-    public string? gitRepository => BuildInfo?["gitRepository"]?.ToString();
-    public string? pluginDir => BuildInfo?["pluginDir"]?.ToString();
+    public string gitRepository => BuildInfo?["gitRepository"]?.ToString();
+    public string pluginDir => BuildInfo?["pluginDir"]?.ToString();
     public record GithubRepository(string Owner, string RepositoryName)
     {
         public string? GetSourceUrl(string commit, string pluginDir)

--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -23,14 +23,14 @@ public class PublishedPlugin : PublishedVersion
     public string pluginDir => BuildInfo?["pluginDir"]?.ToString();
     public record GithubRepository(string Owner, string RepositoryName)
     {
-        public string? GetSourceUrl(string commit, string pluginDir)
+        public string GetSourceUrl(string commit, string pluginDir)
         {
             if (commit is null)
                 return null;
             return $"https://github.com/{Owner}/{RepositoryName}/tree/{commit}/{pluginDir}";
         }
     }
-    public GithubRepository? GetGithubRepository()
+    public GithubRepository GetGithubRepository()
     {
         if (gitRepository is null)
             return null;

--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -20,6 +20,7 @@ public class PublishedPlugin : PublishedVersion
 {
     static Regex GithubRepositoryRegex = new Regex("^https://(www\\.)?github\\.com/([^/]+)/([^/]+)/?");
     public string? gitRepository => BuildInfo?["gitRepository"]?.ToString();
+    public string? pluginDir => BuildInfo?["pluginDir"]?.ToString();
     public record GithubRepository(string Owner, string RepositoryName)
     {
         public string? GetSourceUrl(string commit, string pluginDir)
@@ -39,13 +40,15 @@ public class PublishedPlugin : PublishedVersion
         return new GithubRepository(match.Groups[2].Value, match.Groups[3].Value);
     }
 
-    public async Task<List<GitHubContributor>> GetContributorsAsync(HttpClient httpClient)
+    public async Task<List<GitHubContributor>> GetContributorsAsync(HttpClient httpClient, string pluginDir)
     {
         var repo = GetGithubRepository();
         if (repo == null)
             return new();
 
-        var url = $"https://api.github.com/repos/{repo.Owner}/{repo.RepositoryName}/contributors";
+        string url = string.IsNullOrEmpty(pluginDir)
+            ? $"https://api.github.com/repos/{repo.Owner}/{repo.RepositoryName}/commits"
+            : $"https://api.github.com/repos/{repo.Owner}/{repo.RepositoryName}/commits?path={pluginDir}";
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -55,8 +58,20 @@ public class PublishedPlugin : PublishedVersion
                 return new();
 
             var json = await response.Content.ReadAsStringAsync();
-            var contributors = JsonConvert.DeserializeObject<List<GitHubContributor>>(json) ?? new();
-            return contributors?.Where(c => c.UserViewType == "public").ToList();
+            var commits = JArray.Parse(json);
+
+            return commits
+                .Select(c => c["author"])
+                .Where(a => a != null && a["login"] != null)
+                .GroupBy(a => a["login"]!.ToString())
+                .Select(g => new GitHubContributor
+                {
+                    Login = g.Key,
+                    AvatarUrl = g.First()?["avatar_url"]?.ToString(),
+                    HtmlUrl = g.First()?["html_url"]?.ToString(),
+                    Contributions = g.Count()
+                })
+                .ToList();
         }
         catch (Exception)
         {

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -225,7 +225,7 @@ LIMIT 50", new { userId = userManager.GetUserId(User) });
                     ORDER BY v.ver DESC
                     LIMIT 1
                     """;
-        var r = await conn.QueryFirstOrDefaultAsync(query, new { pluginSlug = pluginSlug.ToString() });
+        var r = await conn.QueryFirstOrDefaultAsync<dynamic>(query, new { pluginSlug = pluginSlug.ToString() });
         if (r is null)
             return NotFound();
 
@@ -259,7 +259,7 @@ LIMIT 50", new { userId = userManager.GetUserId(User) });
             Documentation = JsonConvert.DeserializeObject<PluginSettings>(r.settings)!.Documentation
         };
 
-        ViewBag.Contributors = await plugin.GetContributorsAsync(httpClient);
+        ViewBag.Contributors = await plugin.GetContributorsAsync(httpClient, plugin.pluginDir);
         ViewBag.ShowHiddenNotice = r.visibility == PluginVisibilityEnum.Hidden && isAuthor;
 
         return View(plugin);


### PR DESCRIPTION
Resolve #62 

Retrieve plugin contributors based on commits on a project rather than repository contributors.

So that individual plugins would retrieve actual contributors based on commits


<img width="3770" height="1340" alt="image" src="https://github.com/user-attachments/assets/1fbb0b28-13b9-46d5-a7aa-8f89c7f2d0bb" />
