### PR TITLE
Option to set primary owner of plugin

### DIFF
--- a/PluginBuilder/Data/Scripts/13.PluginOwner.sql
+++ b/PluginBuilder/Data/Scripts/13.PluginOwner.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users_plugins
+ADD COLUMN is_primary_owner BOOLEAN DEFAULT FALSE;
+
+CREATE UNIQUE INDEX ux_one_primary_owner_per_plugin
+ON users_plugins(plugin_slug)
+WHERE is_primary_owner = TRUE;

--- a/PluginBuilder/Util/Extensions/UserManagerExtensions.cs
+++ b/PluginBuilder/Util/Extensions/UserManagerExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace PluginBuilder.Util.Extensions;
+
+public static class UserManagerExtensions
+{
+    public static async Task<List<TUser>> FindUsersByIdsAsync<TUser>(
+        this UserManager<TUser> userManager,
+        IEnumerable<string> userIds) where TUser : class
+    {
+        if (!userIds.Any())
+            return new List<TUser>();
+
+        var users = await Task.WhenAll(userIds.Select(userManager.FindByIdAsync));
+        return users.Where(u => u != null).ToList();
+    }
+}

--- a/PluginBuilder/ViewModels/Admin/PluginEditViewModel.cs
+++ b/PluginBuilder/ViewModels/Admin/PluginEditViewModel.cs
@@ -17,7 +17,7 @@ public class PluginEditViewModel : PluginViewModel
 
 public class PluginUsersViewModel
 {
-    public string UserId { get; set; }
-    public string Email { get; set; }
+    public string UserId { get; set; } = null!;
+    public string Email { get; set; } = null!;
     public bool IsPluginOwner { get; set; }
 }

--- a/PluginBuilder/ViewModels/Admin/PluginEditViewModel.cs
+++ b/PluginBuilder/ViewModels/Admin/PluginEditViewModel.cs
@@ -9,3 +9,15 @@ public class PluginViewModel
     public string Settings { get; set; } = null!;
     public PluginVisibilityEnum Visibility { get; set; }
 }
+
+public class PluginEditViewModel : PluginViewModel
+{
+    public List<PluginUsersViewModel> PluginUsers { get; set; }
+}
+
+public class PluginUsersViewModel
+{
+    public string UserId { get; set; }
+    public string Email { get; set; }
+    public bool IsPluginOwner { get; set; }
+}

--- a/PluginBuilder/ViewModels/PluginSettingViewModel.cs
+++ b/PluginBuilder/ViewModels/PluginSettingViewModel.cs
@@ -6,22 +6,22 @@ public class PluginSettingViewModel
 {
     [MaxLength(200)]
     [Display(Name = "Documentation link")]
-    public string Documentation { get; set; }
+    public string Documentation { get; set; } = null!;
 
     [MaxLength(200)]
     [Display(Name = "Git repository")]
-    public string GitRepository { get; set; }
+    public string GitRepository { get; set; } = null!;
     [MaxLength(200)]
     [Display(Name = "Git branch or tag")]
-    public string GitRef { get; set; }
+    public string GitRef { get; set; } = null!;
 
     [MaxLength(200)]
     [Display(Name = "Directory to the plugin's project")]
-    public string PluginDirectory { get; set; }
+    public string PluginDirectory { get; set; } = null!;
 
     [MaxLength(200)]
     [Display(Name = "Dotnet build configuration ")]
-    public string BuildConfig { get; set; }
+    public string BuildConfig { get; set; } = null!;
 
     [Display(Name = "Logo")]
     public string? LogoUrl { get; set; }

--- a/PluginBuilder/ViewModels/PluginSettingViewModel.cs
+++ b/PluginBuilder/ViewModels/PluginSettingViewModel.cs
@@ -28,4 +28,5 @@ public class PluginSettingViewModel
 
     [Display(Name = "Logo")]
     public IFormFile? Logo { get; set; }
+    public bool IsPluginOwner { get; set; }
 }

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -1,5 +1,5 @@
 @using PluginBuilder.DataModels
-@model PluginViewModel
+@model PluginEditViewModel
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(AdminNavPages.Plugins, "Edit Plugin");
@@ -7,33 +7,68 @@
 
 <div class="d-sm-flex align-items-center justify-content-between mb-4">
     <h2 class="mb-0">
-        @ViewData["Title"]
+        @ViewData["Title"] - @Model.Slug
     </h2>
 </div>
 
-<form asp-action="Edit">
-    <div class="form-group">
-        <label asp-for="Slug" class="control-label"></label>
-        <input asp-for="Slug" class="form-control" readonly="readonly" />
-        <span asp-validation-for="Slug" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Identifier" class="control-label"></label>
-        <input asp-for="Identifier" class="form-control" readonly="readonly" />
-        <span asp-validation-for="Identifier" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Settings" class="control-label"></label>
-        <textarea asp-for="Settings" class="form-control" rows="5"></textarea>
-        <span asp-validation-for="Settings" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Visibility" class="control-label"></label>
-        <select asp-for="Visibility" class="form-control" asp-items="Html.GetEnumSelectList<PluginVisibilityEnum>()"></select>
-        <span asp-validation-for="Visibility" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <input type="submit" class="btn btn-primary" id="Save" value="Save" />
-        <a href="javascript:history.back()" class="btn btn-link">Cancel</a>
-    </div>
-</form>
+
+<div class="row">
+	@if (!String.IsNullOrEmpty(@Model.Identifier))
+	{
+		<div class="mb-4">
+			<span class="fw-semibold fs-5">Identifier:</span> <span>@Model.Identifier</span>
+		</div>
+	}
+	@if (Model.PluginUsers?.Any() == true)
+	{
+		<div class="container my-4">
+			<h6>Plugin Users</h6>
+			<div class="col-md-8 col-lg-6">
+				@foreach (var user in Model.PluginUsers)
+				{
+					<div class="d-flex justify-content-between align-items-center">
+						<div>
+							<strong>Email:</strong> @user.Email
+							@if (user.IsPluginOwner)
+							{
+								<span class="badge bg-success me-2">Owner</span>
+							}
+						</div>
+						<div class="text-end">
+							<a asp-controller="Admin"
+							   asp-action="ManagePluginOwnership"
+							   asp-route-userId="@user.UserId"
+							   asp-route-pluginSlug="@Model.Slug"
+							   asp-route-command="@(user.IsPluginOwner ? "RevokeOwnership" : "AssignOwnership")"
+							   class="btn btn-sm me-2 @(user.IsPluginOwner ? "btn-outline-danger" : "btn-outline-primary")">
+								@(user.IsPluginOwner ? "Revoke Ownership" : "Set as Owner")
+							</a>
+						</div>
+					</div>
+				}
+			</div>
+		</div>
+	}
+
+	<div class="col-md-8 col-lg-6">
+		<form asp-action="Edit">
+			<div class="mb-3">
+				<label asp-for="Settings" class="form-label"></label>
+				<textarea asp-for="Settings" class="form-control" rows="5"></textarea>
+				<span asp-validation-for="Settings" class="text-danger"></span>
+			</div>
+
+			<div class="mb-3">
+				<label asp-for="Visibility" class="form-label"></label>
+				<select asp-for="Visibility" class="form-select" asp-items="Html.GetEnumSelectList<PluginVisibilityEnum>()"></select>
+				<span asp-validation-for="Visibility" class="text-danger"></span>
+			</div>
+
+			<div class="form-group">
+				<input type="submit" class="btn btn-primary" id="Save" value="Save" />
+				<a href="javascript:history.back()" class="btn btn-outline-secondary">Cancel</a>
+			</div>
+		</form>
+	</div>
+
+</div>

--- a/PluginBuilder/Views/Plugin/Settings.cshtml
+++ b/PluginBuilder/Views/Plugin/Settings.cshtml
@@ -4,7 +4,13 @@
     ViewData.SetActivePage(PluginNavPages.Settings, "Plugin settings");
 }
 
-<h2 class="mt-1 mb-4">@ViewData["Title"]</h2>
+<h2 class="mt-1 mb-4">
+	@ViewData["Title"]
+	@if (Model.IsPluginOwner)
+	{
+		<span class="badge bg-success fs-6 px-2 py-1 align-middle" style="font-size: 0.75rem;">Owner</span>
+	}
+</h2>
 <div class="row">
     <div class="col-xl-8 col-xxl-constrain">
 		<form asp-action="Settings" enctype="multipart/form-data">


### PR DESCRIPTION
Resolve #32 

This PR handles plugin ownership..

- When a plugin is set, user with first build for a plugin slug is defined as the owner of the plugin.
- A admin section to define the primary owner of plugin.

This would serve as bedrock for other implementation regarding plugin ownership and collaboration

![plugin_primary_owner](https://github.com/user-attachments/assets/8d66e85d-60d3-4177-bf0c-d16005e2f7c4)

