### PR TITLE
feat: add endpoint to return newer PublishedVersions for provided plugin list.

### DIFF
--- a/PluginBuilder/APIModels/InstalledPluginRequest.cs
+++ b/PluginBuilder/APIModels/InstalledPluginRequest.cs
@@ -1,0 +1,3 @@
+namespace PluginBuilder.APIModels;
+
+public sealed record InstalledPluginRequest(string Identifier, string Version);

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ List the published versions of the server compatible with `btcpayVersion`. (opti
 
 If `includeAllVersions` is set to `true`, all versions will be returned, otherwise only the latest version for each plugin will be returned.
 
-* `searchPluginIdentifier`: Query parameter to search by plugin identifier
-* `searchPluginName`: Query parameter to search by plugin slug or name. If it is formatted as `[abc]`, it will be converted to `searchPluginIdentifier=abc`.
+* `searchPluginName`: Query parameter to search by plugin slug or name.
 
 #### Get a version
 


### PR DESCRIPTION
Changes:

- Add endpoint: POST /api/v1/plugins/updates
- Output: PublishedVersion[] only for items with newer versions
- Visibility: excludes 'hidden'