### PR TITLE
bugfix: prevent DbContext concurrency on user lookup

### DIFF
--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -527,16 +527,19 @@ public class AdminController(
 
     private async Task<List<PluginUsersViewModel>> GetPluginUsers(NpgsqlConnection conn, string slug)
     {
-        var pluginOwner = await conn.RetrievePluginOwner(slug);
-        var userIds = await conn.RetrievePluginUserIds(slug);
+        var ownerId = await conn.RetrievePluginOwner(slug);
+        var userIds = (await conn.RetrievePluginUserIds(slug)).ToList();
+
+        if (userIds.Count == 0)
+            return new List<PluginUsersViewModel>();
+
         var users = await userManager.FindUsersByIdsAsync(userIds);
-        return userIds.Any()
-            ? (await userManager.FindUsersByIdsAsync(userIds)).Select(u => new PluginUsersViewModel
-            {
-                Email = u.Email,
-                UserId = u.Id,
-                IsPluginOwner = u.Id == pluginOwner
-            }).ToList()
-            : new List<PluginUsersViewModel>();
+
+        return users.Select(u => new PluginUsersViewModel
+        {
+            Email = u.Email ?? string.Empty,
+            UserId = u.Id,
+            IsPluginOwner = u.Id == ownerId
+        }).ToList();
     }
 }

--- a/PluginBuilder/Util/Extensions/UserManagerExtensions.cs
+++ b/PluginBuilder/Util/Extensions/UserManagerExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace PluginBuilder.Util.Extensions;
 
@@ -8,10 +9,13 @@ public static class UserManagerExtensions
         this UserManager<TUser> userManager,
         IEnumerable<string> userIds) where TUser : class
     {
-        if (!userIds.Any())
+        var ids = userIds.Distinct().ToArray();
+        if (ids.Length == 0)
             return new List<TUser>();
 
-        var users = await Task.WhenAll(userIds.Select(userManager.FindByIdAsync));
-        return users.Where(u => u != null).ToList();
+        return await userManager.Users
+            .Where(u => ids.Contains(EF.Property<string>(u, "Id")))
+            .AsNoTracking()
+            .ToListAsync();
     }
 }


### PR DESCRIPTION
Bug:
Parallel calls against UserManager caused EF Core concurrency exceptions when a plugin had multiple users.

Changes:
- Fixed InvalidOperationException: A second operation was started on this context instance by replacing parallel FindByIdAsync calls with a single EF query.

- Refactored GetPluginUsers to materialize userIds, remove duplicate queries, and null-guard email.