### PR TITLE
feat: add VerifiedEmailForLogin setting and enforce confirmed email at login

### DIFF
--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -4,7 +4,6 @@ using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Npgsql;
 using PluginBuilder.Controllers.Logic;
@@ -93,11 +92,11 @@ public class AdminController(
     }
 
     [HttpPost]
-    public async Task<IActionResult> UpdateVerifiedEmailRequirement(bool verifiedEmailForPluginPublish)
+    public async Task<IActionResult> UpdateVerifiedEmailForPublishRequirement(bool verifiedEmailForPluginPublish)
     {
         await using var conn = await connectionFactory.Open();
         await conn.UpdateVerifiedEmailForPluginPublishSetting(verifiedEmailForPluginPublish);
-        await emailVerifiedCache.RefreshIsVerifiedEmailRequired(conn);
+        await emailVerifiedCache.RefreshIsVerifiedEmailRequiredForPublish(conn);
         TempData[TempDataConstant.SuccessMessage] = "Email requirement setting for publishing plugin updated successfully";
         return RedirectToAction("ListPlugins");
     }
@@ -509,7 +508,7 @@ public class AdminController(
 
         await using var conn = await connectionFactory.Open();
         var result = await conn.SettingsSetAsync(key, value);
-        await emailVerifiedCache.RefreshIsVerifiedEmailRequired(conn);
+        await emailVerifiedCache.RefreshAllVerifiedEmailSettings(conn);
         return RedirectToAction(nameof(SettingsEditor));
     }
 
@@ -521,7 +520,7 @@ public class AdminController(
 
         await using var conn = await connectionFactory.Open();
         var result = await conn.SettingsDeleteAsync(key);
-        await emailVerifiedCache.RefreshIsVerifiedEmailRequired(conn);
+        await emailVerifiedCache.RefreshAllVerifiedEmailSettings(conn);
         return Ok();
     }
 

--- a/PluginBuilder/Controllers/DashboardController.cs
+++ b/PluginBuilder/Controllers/DashboardController.cs
@@ -22,7 +22,7 @@ public class DashboardController(
     public async Task<IActionResult> CreatePlugin()
     {
         await using var conn = await connectionFactory.Open();
-        if (!await emailVerifiedLogic.IsUserEmailVerified(User))
+        if (!await emailVerifiedLogic.IsUserEmailVerifiedForPublish(User))
         {
             TempData[TempDataConstant.WarningMessage] =
                 "You need to verify your email address in order to create and publish plugins";
@@ -43,7 +43,7 @@ public class DashboardController(
         }
 
         await using var conn = await connectionFactory.Open();
-        if (!await emailVerifiedLogic.IsUserEmailVerified(User))
+        if (!await emailVerifiedLogic.IsUserEmailVerifiedForPublish(User))
         {
             TempData[TempDataConstant.WarningMessage] =
                 "You need to verify your email address in order to create and publish plugins";

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -99,7 +99,7 @@ public class PluginController(
         PluginSlug pluginSlug, long? copyBuild = null)
     {
         await using var conn = await connectionFactory.Open();
-        if (!await emailVerifiedLogic.IsUserEmailVerified(User))
+        if (!await emailVerifiedLogic.IsUserEmailVerifiedForPublish(User))
         {
             TempData[TempDataConstant.WarningMessage] =
                 "You need to verify your email address in order to create and publish plugins";
@@ -141,7 +141,7 @@ public class PluginController(
         if (!ModelState.IsValid)
             return View(model);
         await using var conn = await connectionFactory.Open();
-        if (!await emailVerifiedLogic.IsUserEmailVerified(User))
+        if (!await emailVerifiedLogic.IsUserEmailVerifiedForPublish(User))
         {
             TempData[TempDataConstant.WarningMessage] =
                 "You need to verify your email address in order to create and publish plugins";

--- a/PluginBuilder/DataModels/SettingsKeys.cs
+++ b/PluginBuilder/DataModels/SettingsKeys.cs
@@ -5,5 +5,6 @@ public static class SettingsKeys
 {
     public const string EmailSettings = nameof(EmailSettings);
     public const string VerifiedEmailForPluginPublish = nameof(VerifiedEmailForPluginPublish);
+    public const string VerifiedEmailForLogin = nameof(VerifiedEmailForLogin);
     public const string FirstPluginBuildReviewers = nameof(FirstPluginBuildReviewers);
 }

--- a/PluginBuilder/HostedServices/DatabaseStartupHostedService.cs
+++ b/PluginBuilder/HostedServices/DatabaseStartupHostedService.cs
@@ -34,7 +34,7 @@ public class DatabaseStartupHostedService : IHostedService
             await RunScripts(conn);
             await CleanupScript(conn);
 
-            await emailVerifiedCache.RefreshIsVerifiedEmailRequired(conn);
+            await emailVerifiedCache.RefreshAllVerifiedEmailSettings(conn);
             await conn.SettingsInitialize();
         }
         catch (NpgsqlException pgex) when (pgex.SqlState == "3D000")

--- a/PluginBuilder/Views/Admin/ListPlugins.cshtml
+++ b/PluginBuilder/Views/Admin/ListPlugins.cshtml
@@ -10,7 +10,7 @@
     <div class="d-flex flex-column flex-sm-row align-items-center gap-3">
 
         <div class="d-flex align-items-center">
-            <form asp-controller="Admin" asp-action="UpdateVerifiedEmailRequirement" method="post" class="d-flex align-items-center">
+            <form asp-controller="Admin" asp-action="UpdateVerifiedEmailForPublishRequirement" method="post" class="d-flex align-items-center">
                 <input type="checkbox" class="btcpay-toggle me-2" id="featureToggle" asp-for="@Model.VerifiedEmailForPluginPublish"
                        onchange="this.form.submit()" />
                 <label class="form-check-label text-wrap" for="featureToggle">

--- a/PluginBuilder/Views/Home/Login.cshtml
+++ b/PluginBuilder/Views/Home/Login.cshtml
@@ -15,12 +15,27 @@
 <div class="account-form">
     <h4>@ViewData["Title"]</h4>
     <form asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" id="login-form" asp-action="Login">
+        @Html.AntiForgeryToken()
         <fieldset>
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger">
+
+            </div>
             <div class="form-group">
                 <label asp-for="Email" class="form-label"></label>
                 <input asp-for="Email" class="form-control" required tabindex="1" autofocus />
-                <span asp-validation-for="Email" class="text-danger"></span>
+                <div class="d-flex justify-content-between align-items-center mt-1">
+                    <span asp-validation-for="Email" class="text-danger"></span>
+
+                    @if (Model.IsVerifiedEmailRequired)
+                    {
+                        <button type="submit"
+                                class="btn btn-link p-0"
+                                formaction="@Url.Action("ResendConfirmation", "Home")"
+                                formmethod="post">
+                            Resend confirmation
+                        </button>
+                    }
+                </div>
             </div>
             <div class="form-group">
                 <div class="d-flex justify-content-between">
@@ -30,12 +45,9 @@
                     <input asp-for="Password" class="form-control" required tabindex="2" />
                 </div>
                 <span asp-validation-for="Password" class="text-danger"></span>
-                @if (Model.IsVerifiedEmailRequired)
-                {
-                    <div class="form-group mt-1">
-                        <a asp-action="ForgotPassword" asp-controller="Home">Forgot your password?</a>
-                    </div>
-                }
+                <div class="form-group mt-1">
+                    <a asp-action="ForgotPassword" asp-controller="Home">Forgot your password?</a>
+                </div>
             </div>
             <div class="form-group mt-4">
                 <div class="btn-group w-100">


### PR DESCRIPTION
## Changes
- Add VerifiedEmailForLogin setting to control whether users must confirm their email before signing in.
- Enforce the check in the login flow: unconfirmed users are blocked with a clear error and a Resend confirmation option.

## Additional adjustments
- Clarified method and property names (IsUserEmailVerifiedForLogin / IsUserEmailVerifiedForPublish).
- Replaced hardcoded setting keys with constants from `SettingsKeys`.