### PR TITLE
[Fix] include PluginSlug in PluginVersionViewModel to fix version link routing

### DIFF
--- a/PluginBuilder/Components/MainNav/MainNav.cs
+++ b/PluginBuilder/Components/MainNav/MainNav.cs
@@ -33,6 +33,7 @@ public class MainNav : ViewComponent
             foreach (var r in rows)
                 vm.Versions.Add(new PluginVersionViewModel
                 {
+                    PluginSlug = pluginSlug?.ToString(),
                     Version = new PluginBuilder.PluginVersion(r.ver).ToString(),
                     PreRelease = r.pre_release,
                     Published = true,


### PR DESCRIPTION
Pass PluginSlug when creating PluginVersionViewModel items in MainNav so the <vc:plugin-version> tag generates correct URLs.