### PR TITLE
fix: store armour as base64 to avoid Postgres Json null error

### DIFF
--- a/PluginBuilder/Services/GPGKeyService.cs
+++ b/PluginBuilder/Services/GPGKeyService.cs
@@ -144,7 +144,7 @@ public class GPGKeyService(DBConnectionFactory connectionFactory)
 
             var signatureProof = new SignatureProof
             {
-                Armour = Encoding.ASCII.GetString(sigBytes),
+                Armour = Convert.ToBase64String(sigBytes),
                 KeyId = signature.KeyId.ToString("X"),
                 Fingerprint = BitConverter.ToString(signingKey.GetFingerprint()).Replace("-", ""),
                 SignedAt = signature.CreationTime,


### PR DESCRIPTION
This resolves the error Boltz are having with signature based on logs