### PR TITLE
[Fix] Align review ownership and helpful vote logic with plugin_reviewers

### DIFF
--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -395,7 +395,7 @@ public class HomeController(
                           r.created_at AS ""CreatedAt"",
                           COALESCE(hv.up_count, 0)   AS ""UpCount"",
                           COALESCE(hv.down_count, 0) AS ""DownCount"",
-                          ( @currentUserId IS NOT NULL AND r.user_id = @currentUserId ) AS ""IsReviewOwner"",
+                          ( @currentUserId IS NOT NULL AND u.user_id = @currentUserId ) AS ""IsReviewOwner"",
                           CASE
                             WHEN @currentUserId IS NULL THEN NULL
                             WHEN r.helpful_voters ? @currentUserId


### PR DESCRIPTION
## Changes

- Replace legacy plugin_reviews.user_id with plugin_reviewers.user_id in all ownership checks
- Fix IsReviewOwner flag in plugin details query
- Update DeleteReviewAsync to validate owner via plugin_reviewers
- Update helpful vote queries (upsert / remove) to use reviewer’s user_id
- Remove unused GetPluginReviews method