### PR TITLE
[Feature] improve rating sort tie-breakers (reviews, recency)

### DIFF
--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -249,7 +249,7 @@ public class HomeController(
             const string pluginNameExpr = "COALESCE(p.settings->>'pluginTitle', b.manifest_info->>'Name')";
             var orderByClause = sort.ToLowerInvariant() switch
             {
-                "rating" => $"rs.avg_rating DESC NULLS LAST, {pluginNameExpr}",
+                "rating" => $"rs.avg_rating DESC NULLS LAST, rs.total_reviews DESC, b.created_at DESC, {pluginNameExpr}",
                 "recent" => $"b.created_at DESC, {pluginNameExpr}",
                 "alpha" => pluginNameExpr,
                 _ => $"""


### PR DESCRIPTION
## Changes 

Sort by average rating. If tied, sort by total reviews. If still tied, sort by created_at, then plugin name.