### PR TITLE
Allow public logo box to capture all image content

### DIFF
--- a/PluginBuilder/Views/Shared/_PluginLogo.cshtml
+++ b/PluginBuilder/Views/Shared/_PluginLogo.cshtml
@@ -11,7 +11,7 @@
 
 @if (!string.IsNullOrEmpty(Model.PluginLogo))
 {
-    <img src="@Model.PluginLogo" alt="@Model.PluginTitle" style="width: 60px; height: 60px; object-fit: cover; border-radius: 4px;" />
+	<img src="@Model.PluginLogo" alt="@Model.PluginTitle" style="width:60px; height:60px; object-fit:contain; border-radius:4px;" />
 }
 else
 {


### PR DESCRIPTION
This is the view on the current public page:

<img width="492" height="587" alt="image" src="https://github.com/user-attachments/assets/5cf29578-92a3-41e5-8122-0187c6566105" />


This is it now:

<img width="290" height="265" alt="image" src="https://github.com/user-attachments/assets/183a7fee-5c23-4986-94ed-8120ea5a94b4" />
