### PR TITLE
[Fix] Prevent NRE in plugin details

### DIFF
--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -308,6 +308,9 @@ public class HomeController(
         PluginSlug pluginSlug,
         [FromQuery] PluginDetailsViewModel? model)
     {
+        if (pluginSlug is null)
+            return NotFound();
+
         model ??= new PluginDetailsViewModel();
 
         var sort = string.Equals(model.Sort, "helpful", StringComparison.OrdinalIgnoreCase) ? "helpful" : "newest";


### PR DESCRIPTION
Prevent intermittent NullReferenceException in GetPluginDetails

<img width="1051" height="433" alt="Screenshot 2026-01-15 at 00 30 06" src="https://github.com/user-attachments/assets/1ed4853c-1e1c-4e1e-aa06-cfbcb647f6dc" />
