### PR TITLE
[Fix] flaky PluginCleanupTests scoped service resolution

### DIFF
--- a/PluginBuilder.Tests/PluginTests/PluginCleanupTests.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginCleanupTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Dapper;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using PluginBuilder.Services;
 using PluginBuilder.Util.Extensions;
@@ -52,7 +53,8 @@ public class PluginCleanupTests : UnitTestBase
         await UpdateAddedAtAsync(conn, recentDate, freshSlug);
 
         // Act
-        var runner = tester.GetService<PluginCleanupRunner>();
+        using var scope = tester.WebApp.Services.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<PluginCleanupRunner>();
         var deletedCount = await runner.RunOnceAsync();
 
         // Assert


### PR DESCRIPTION
Resolve PluginCleanupRunner from a created IServiceScope in PluginCleanupTests to fix flaky scoped service resolution failures.