### PR TITLE
Fix null-byte/control-char handling in plugin search (public + API)

### DIFF
--- a/PluginBuilder.Tests/UnitTest1.cs
+++ b/PluginBuilder.Tests/UnitTest1.cs
@@ -24,6 +24,29 @@ public class UnitTest1 : UnitTestBase
         await using var tester = await Start();
     }
 
+    [Fact]
+    public async Task PluginsSearchWithNullByte_DoesNotReturnServerError()
+    {
+        await using var tester = await Start();
+
+        var ownerId = await tester.CreateFakeUserAsync();
+        await tester.CreateAndBuildPluginAsync(ownerId);
+
+        var client = tester.CreateHttpClient();
+        var urls = new[]
+        {
+            "/public/plugins?searchPluginName=%00",
+            "/api/v1/plugins?searchPluginName=%00"
+        };
+
+        foreach (var url in urls)
+        {
+            var response = await client.GetAsync(url);
+            Assert.True(response.IsSuccessStatusCode,
+                $"Expected successful response for {url}, but got {(int)response.StatusCode} ({response.StatusCode}).");
+        }
+    }
+
     [Theory]
     [InlineData("test-6", true)]
     [InlineData("test-6-", false)]

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -44,6 +44,8 @@ public class ApiController(
         bool? includeAllVersions = null,
         string? searchPluginName = null)
     {
+        searchPluginName = searchPluginName.StripControlCharacters();
+
         includePreRelease ??= false;
         includeAllVersions ??= false;
         var getVersions = includeAllVersions switch

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -208,6 +208,8 @@ public class HomeController(
         [ModelBinder(typeof(PluginVersionModelBinder))]
         PluginVersion? btcpayVersion = null, string? searchPluginName = null, string sort = "smart")
     {
+        searchPluginName = searchPluginName.StripControlCharacters();
+
         await using var conn = await connectionFactory.Open();
 
         var query = $"""

--- a/PluginBuilder/Util/Extensions/StringExtensions.cs
+++ b/PluginBuilder/Util/Extensions/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace PluginBuilder.Util.Extensions;
 
 public static class StringExtensions
@@ -9,5 +11,19 @@ public static class StringExtensions
         var lastSpace = value.LastIndexOf(' ', maxLength);
         var cutAt = lastSpace > 0 ? lastSpace : maxLength;
         return string.Concat(value.AsSpan(0, cutAt), "…");
+    }
+
+    public static string? StripControlCharacters(this string? value)
+    {
+        if (string.IsNullOrEmpty(value) || !value.Any(char.IsControl))
+            return value;
+
+        StringBuilder sanitized = new(value.Length);
+        foreach (var c in value.Where(c => !char.IsControl(c)))
+        {
+            sanitized.Append(c);
+        }
+
+        return sanitized.ToString();
     }
 }


### PR DESCRIPTION
## Description

- Added StripControlCharacters() in StringExtensions.cs.
- Applied sanitization to searchPluginName in HomeController.cs and ApiController.cs
- Added regression test in UnitTest1.cs

This prevents PostgreSQL UTF-8 errors from control-character input (e.g. %00).

<img width="1050" height="725" alt="Screenshot 2026-02-19 at 03 27 22" src="https://github.com/user-attachments/assets/b80e414c-4f38-4ac1-a77e-4f093f905ab8" />
