### PR TITLE
[Fix] Accept RC BTCPay host versions in compatibility filters

### DIFF
--- a/PluginBuilder.Tests/BTCPayCompatibilityTests.cs
+++ b/PluginBuilder.Tests/BTCPayCompatibilityTests.cs
@@ -1,6 +1,11 @@
+using System.Net;
+using System.Text;
 using Dapper;
 using Microsoft.AspNetCore.OutputCaching;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using PluginBuilder.APIModels;
 using PluginBuilder.DataModels;
 using PluginBuilder.Services;
 using PluginBuilder.Util.Extensions;
@@ -11,6 +16,8 @@ namespace PluginBuilder.Tests;
 
 public class BTCPayCompatibilityTests(ITestOutputHelper logs) : UnitTestBase(logs)
 {
+    private static readonly JsonSerializerSettings SerializerSettings = new() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+
     private sealed class MinOverrideRow
     {
         public int[] EffectiveMin { get; init; } = [];
@@ -56,6 +63,61 @@ public class BTCPayCompatibilityTests(ITestOutputHelper logs) : UnitTestBase(log
     {
         Assert.Throws<FormatException>(() =>
             PluginManifest.Parse(CreateManifest(">= 2.0.0 && <= 1.9.9"), strictBTCPayVersionCondition: true));
+    }
+
+    [Fact]
+    public async Task ApiCompatibilityFilters_NormalizePrereleaseHostVersions_AndKeepPluginVersionRoutesStrict()
+    {
+        await using var tester = Create();
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var ownerId = await tester.CreateFakeUserAsync();
+        var pluginSlug = "btcpay-rc-" + Guid.NewGuid().ToString("N")[..8];
+        var fullBuildId = await tester.CreateAndBuildPluginAsync(ownerId, pluginSlug);
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        var buildRow = await conn.QuerySingleAsync<(string manifest_info, string build_info)>(
+            "SELECT manifest_info, build_info FROM builds WHERE plugin_slug = @pluginSlug AND id = @buildId",
+            new { pluginSlug, buildId = fullBuildId.BuildId });
+        var manifest = PluginManifest.Parse(buildRow.manifest_info);
+        await conn.SetVersionBuild(fullBuildId, manifest.Version, manifest.BTCPayMinVersion, PluginVersion.Parse("2.3.7"), false);
+        await conn.SetPluginSettings(pluginSlug, new PluginSettings
+        {
+            PluginTitle = pluginSlug,
+            Description = "RC compatibility test plugin",
+            GitRepository = ServerTester.RepoUrl
+        }, PluginVisibilityEnum.Listed);
+        var identifier = manifest.Identifier;
+
+        var outputCacheStore = tester.GetService<IOutputCacheStore>();
+        await outputCacheStore.EvictByTagAsync(CacheTags.Plugins, CancellationToken.None);
+
+        var client = tester.CreateHttpClient();
+
+        await AssertJsonResponseEquals(
+            client,
+            "/api/v1/plugins?btcpayVersion=2.3.7",
+            "/api/v1/plugins?btcpayVersion=2.3.7-rc2");
+
+        await AssertJsonResponseEquals(
+            client,
+            $"/api/v1/plugins/{identifier}?btcpayVersion=2.3.7",
+            $"/api/v1/plugins/{identifier}?btcpayVersion=2.3.7-rc2");
+
+        await AssertJsonResponseEquals(
+            client,
+            "/api/v1/plugins/updates?btcpayVersion=2.3.7",
+            "/api/v1/plugins/updates?btcpayVersion=2.3.7-rc2",
+            new[] { new InstalledPluginRequest(identifier, "0.0.1") });
+
+        var invalidHostVersion = await client.GetAsync("/api/v1/plugins?btcpayVersion=2.3.x-rc1");
+        Assert.Equal(HttpStatusCode.BadRequest, invalidHostVersion.StatusCode);
+        Assert.Contains("Invalid BTCPay version", await invalidHostVersion.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        var invalidPluginVersion = await client.GetAsync($"/api/v1/plugins/{pluginSlug}/versions/1.0.0-rc1");
+        Assert.Equal(HttpStatusCode.BadRequest, invalidPluginVersion.StatusCode);
+        Assert.Contains("Invalid plugin version", await invalidPluginVersion.Content.ReadAsStringAsync(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -312,5 +374,31 @@ public class BTCPayCompatibilityTests(ITestOutputHelper logs) : UnitTestBase(log
                    ]
                  }
                  """;
+    }
+
+    private static async Task AssertJsonResponseEquals(HttpClient client, string expectedUrl, string actualUrl, object? body = null)
+    {
+        var expected = await SendAsync(client, expectedUrl, body);
+        var actual = await SendAsync(client, actualUrl, body);
+
+        Assert.Equal(HttpStatusCode.OK, expected.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
+
+        var expectedJson = JToken.Parse(await expected.Content.ReadAsStringAsync());
+        var actualJson = JToken.Parse(await actual.Content.ReadAsStringAsync());
+        Assert.True(JToken.DeepEquals(expectedJson, actualJson), $"Expected JSON from '{actualUrl}' to match '{expectedUrl}'.");
+    }
+
+    private static Task<HttpResponseMessage> SendAsync(HttpClient client, string url, object? body)
+    {
+        if (body is null)
+            return client.GetAsync(url);
+
+        return client.PostAsync(url, JsonBody(body));
+    }
+
+    private static StringContent JsonBody(object body)
+    {
+        return new StringContent(JsonConvert.SerializeObject(body, SerializerSettings), Encoding.UTF8, "application/json");
     }
 }

--- a/PluginBuilder.Tests/BTCPayHostVersionParserTests.cs
+++ b/PluginBuilder.Tests/BTCPayHostVersionParserTests.cs
@@ -1,0 +1,29 @@
+using PluginBuilder.ModelBinders;
+using Xunit;
+
+namespace PluginBuilder.Tests;
+
+public class BtcPayHostVersionParserTests
+{
+    [Theory]
+    [InlineData("2.3.7-rc2", "2.3.7")]
+    [InlineData("  v2.3.7-rc2+sha  ", "2.3.7")]
+    [InlineData("2.3.7.0-rc1", "2.3.7.0")]
+    public void TryParse_AcceptsSupportedHostVersions(string input, string expected)
+    {
+        Assert.True(BtcPayHostVersionParser.TryParse(input, out var version));
+        Assert.NotNull(version);
+        Assert.Equal(expected, version.ToString());
+    }
+
+    [Theory]
+    [InlineData("2.3.x-rc1")]
+    [InlineData("2..3")]
+    [InlineData("2.-3.0")]
+    [InlineData("1.2.3.4.5")]
+    public void TryParse_RejectsMalformedHostVersions(string input)
+    {
+        Assert.False(BtcPayHostVersionParser.TryParse(input, out var version));
+        Assert.Null(version);
+    }
+}

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -55,7 +55,7 @@ public class ApiController(
     [OutputCache(PolicyName = "PluginsList")]
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> Plugins(
-        [ModelBinder(typeof(PluginVersionModelBinder))]
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
         PluginVersion? btcpayVersion = null,
         bool? includePreRelease = null,
         bool? includeAllVersions = null,
@@ -145,7 +145,7 @@ public class ApiController(
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> GetPluginVersionsForDownload(
         string identifier,
-        [ModelBinder(typeof(PluginVersionModelBinder))]
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
         PluginVersion? btcpayVersion = null,
         bool? includePreRelease = null,
         bool? includeAllVersions = null)
@@ -440,7 +440,7 @@ public class ApiController(
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> GetInstalledPluginsUpdates(
         [FromBody] InstalledPluginRequest[] plugins,
-        [ModelBinder(typeof(PluginVersionModelBinder))]
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
         PluginVersion? btcpayVersion = null,
         bool? includePreRelease = null)
     {

--- a/PluginBuilder/ModelBinders/BTCPayHostVersionModelBinder.cs
+++ b/PluginBuilder/ModelBinders/BTCPayHostVersionModelBinder.cs
@@ -22,6 +22,7 @@ public static class BtcPayHostVersionParser
         if (buildSeparator >= 0)
             normalized = normalized[..buildSeparator];
 
+        // In future consider whitelisting only -rcN suffixes instead of stripping all prerelease labels
         var prereleaseSeparator = normalized.IndexOf('-');
         if (prereleaseSeparator >= 0)
             normalized = normalized[..prereleaseSeparator];

--- a/PluginBuilder/ModelBinders/BTCPayHostVersionModelBinder.cs
+++ b/PluginBuilder/ModelBinders/BTCPayHostVersionModelBinder.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace PluginBuilder.ModelBinders;
+
+public static class BtcPayHostVersionParser
+{
+    public static bool TryParse(string value, [MaybeNullWhen(false)] out PluginVersion version)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        version = null;
+
+        var normalized = value.Trim();
+        if (normalized.Length == 0)
+            return false;
+
+        if (normalized.StartsWith('v') || normalized.StartsWith('V'))
+            normalized = normalized[1..];
+
+        var buildSeparator = normalized.IndexOf('+');
+        if (buildSeparator >= 0)
+            normalized = normalized[..buildSeparator];
+
+        var prereleaseSeparator = normalized.IndexOf('-');
+        if (prereleaseSeparator >= 0)
+            normalized = normalized[..prereleaseSeparator];
+
+        return PluginVersion.TryParse(normalized, out version);
+    }
+}
+
+public class BtcPayHostVersionModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var val = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+        var v = val.FirstValue;
+        if (v is null)
+            return Task.CompletedTask;
+
+        if (BtcPayHostVersionParser.TryParse(v, out var version))
+        {
+            bindingContext.Result = ModelBindingResult.Success(version);
+        }
+        else
+        {
+            bindingContext.Result = ModelBindingResult.Failed();
+            bindingContext.ModelState.AddModelError(bindingContext.ModelName, "Invalid BTCPay version");
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Normalize `btcpayVersion` on public API compatibility filters so values like `2.3.7-rc2`, `2.3.7+sha`, and `v2.3.7-rc2` are treated as `2.3.7`.

Fixes [btcpay repo issue](https://github.com/btcpayserver/btcpayserver/issues/7292#issuecomment-4175938186)