### PR TITLE
align plugin page tabs with BTCPay reporting layout

### DIFF
--- a/PluginBuilder.Tests/PluginTests/OwnersUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/OwnersUITests.cs
@@ -57,12 +57,12 @@ public class OwnersUITests(ITestOutputHelper output) : PageTest
         var addForm = t.Page.Locator("form[method='post'] >> input[name='email']");
 
         await addForm.FillAsync(userB);
-        await t.Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "Add" }).ClickAsync();
+        await t.Page.Locator("#AddUser").ClickAsync();
         await Expect(t.Page.Locator(".alert-warning")).ToBeVisibleAsync();
 
         await t.VerifyUserAccounts(userB);
         await addForm.FillAsync(userB);
-        await t.Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "Add" }).ClickAsync();
+        await t.Page.Locator("#AddUser").ClickAsync();
 
         var bRow = t.Page.Locator("table tbody tr").Filter(new LocatorFilterOptions { HasText = userB });
         await Expect(bRow).ToBeVisibleAsync();
@@ -75,7 +75,7 @@ public class OwnersUITests(ITestOutputHelper output) : PageTest
         await Expect(t.Page.Locator("table tbody tr").Filter(new LocatorFilterOptions { HasText = userB })).ToHaveCountAsync(0);
 
         await addForm.FillAsync(userB);
-        await t.Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = "Add" }).ClickAsync();
+        await t.Page.Locator("#AddUser").ClickAsync();
         bRow = t.Page.Locator("table tbody tr").Filter(new LocatorFilterOptions { HasText = userB });
         await Expect(bRow).ToBeVisibleAsync();
         var transferBtn = bRow.GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Transfer Primary" });

--- a/PluginBuilder/Views/Admin/ListingRequests.cshtml
+++ b/PluginBuilder/Views/Admin/ListingRequests.cshtml
@@ -10,26 +10,34 @@
     <h2 class="mb-0">@ViewData["Title"]</h2>
 </div>
 
-<div class="mb-3">
-    <div class="btn-group" role="group">
-        <a asp-action="ListingRequests" asp-route-status="pending"
-           class="btn btn-@(Model.StatusFilter == "pending" ? "primary" : "outline-secondary")">
+<nav id="SectionNav" class="mb-3">
+    <div class="nav gap-4">
+        <a asp-action="ListingRequests"
+           asp-route-status="pending"
+           class="nav-link @(Model.StatusFilter == "pending" ? "active" : null)"
+           role="tab">
             Pending
         </a>
-        <a asp-action="ListingRequests" asp-route-status="approved"
-           class="btn btn-@(Model.StatusFilter == "approved" ? "primary" : "outline-secondary")">
+        <a asp-action="ListingRequests"
+           asp-route-status="approved"
+           class="nav-link @(Model.StatusFilter == "approved" ? "active" : null)"
+           role="tab">
             Approved
         </a>
-        <a asp-action="ListingRequests" asp-route-status="rejected"
-           class="btn btn-@(Model.StatusFilter == "rejected" ? "primary" : "outline-secondary")">
+        <a asp-action="ListingRequests"
+           asp-route-status="rejected"
+           class="nav-link @(Model.StatusFilter == "rejected" ? "active" : null)"
+           role="tab">
             Rejected
         </a>
-        <a asp-action="ListingRequests" asp-route-status="all"
-           class="btn btn-@(Model.StatusFilter == "all" ? "primary" : "outline-secondary")">
+        <a asp-action="ListingRequests"
+           asp-route-status="all"
+           class="nav-link @(Model.StatusFilter == "all" ? "active" : null)"
+           role="tab">
             All
         </a>
     </div>
-</div>
+</nav>
 
 @if (!Model.Requests.Any())
 {

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -366,12 +366,6 @@
             padding: 0 0 .75rem;
         }
 
-        #plugin-edit-tabs .nav-link.active {
-            background: none;
-            color: var(--btcpay-nav-link);
-            border-bottom-color: var(--btcpay-primary);
-        }
-
         .admin-compatibility-input {
             max-width: 12rem;
         }

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -42,8 +42,8 @@
     </div>
 </div>
 
-<ul class="nav nav-pills gap-4 mb-4" id="plugin-edit-tabs" role="tablist">
-    <li class="nav-item" role="presentation">
+<nav id="SectionNav" class="mb-4">
+    <div class="nav gap-4" id="plugin-edit-tabs" role="tablist">
         <a class="nav-link @(isSettingsTab ? "active" : null)"
            id="plugin-edit-settings-tab"
            asp-controller="Admin"
@@ -52,8 +52,6 @@
            asp-route-tab="@PluginEditTabs.Settings">
             Settings
         </a>
-    </li>
-    <li class="nav-item" role="presentation">
         <a class="nav-link @(isOwnersTab ? "active" : null)"
            id="plugin-edit-owners-tab"
            asp-controller="Admin"
@@ -62,8 +60,6 @@
            asp-route-tab="@PluginEditTabs.Owners">
             Owners
         </a>
-    </li>
-    <li class="nav-item" role="presentation">
         <a class="nav-link @(isVersionsTab ? "active" : null)"
            id="plugin-edit-versions-tab"
            asp-controller="Admin"
@@ -72,8 +68,6 @@
            asp-route-tab="@PluginEditTabs.Versions">
             Versions
         </a>
-    </li>
-    <li class="nav-item" role="presentation">
         <a class="nav-link @(isReviewsTab ? "active" : null)"
            id="plugin-edit-reviews-tab"
            asp-controller="Admin"
@@ -82,8 +76,8 @@
            asp-route-tab="@PluginEditTabs.Reviews">
             Import Reviews
         </a>
-    </li>
-</ul>
+    </div>
+</nav>
 
 <div class="tab-content" id="plugin-edit-tab-content">
     <div class="tab-pane fade @(isSettingsTab ? "show active" : null)"
@@ -364,13 +358,18 @@
     <style>
         #plugin-edit-tabs .nav-link {
             background: none;
-            padding: 0;
-            font-weight: var(--btcpay-font-weight-semibold);
+            border: 0;
+            border-bottom: 2px solid transparent;
+            border-radius: 0;
+            color: var(--btcpay-nav-link);
             font-size: 1.125rem;
+            padding: 0 0 .75rem;
         }
 
         #plugin-edit-tabs .nav-link.active {
-            color: var(--btcpay-primary);
+            background: none;
+            color: var(--btcpay-nav-link);
+            border-bottom-color: var(--btcpay-primary);
         }
 
         .admin-compatibility-input {

--- a/PluginBuilder/Views/Plugin/Build.cshtml
+++ b/PluginBuilder/Views/Plugin/Build.cshtml
@@ -257,11 +257,6 @@
             padding: 0 0 .75rem;
         }
 
-        #artifacts-tabs .nav-link.active {
-            background: none;
-            color: var(--btcpay-nav-link);
-            border-bottom-color: var(--btcpay-primary);
-        }
     </style>
 }
 

--- a/PluginBuilder/Views/Plugin/Build.cshtml
+++ b/PluginBuilder/Views/Plugin/Build.cshtml
@@ -191,23 +191,16 @@
 </table>
 
 <div>
-    <ul class="nav nav-pills gap-4 mb-3" id="artifacts-tabs" role="tablist">
-        <li class="nav-item">
+    <nav id="SectionNav">
+        <div class="nav gap-4" id="artifacts-tabs" role="tablist">
             <button class="nav-link active" id="build-logs-tab" data-bs-toggle="pill" data-bs-target="#build-logs-pane" type="button" role="tab"
-                    aria-controls="build-logs-pane">Logs
-            </button>
-        </li>
-        <li class="nav-item">
+                    aria-controls="build-logs-pane">Logs</button>
             <button class="nav-link" id="build-info-tab" data-bs-toggle="pill" data-bs-target="#build-info-pane" type="button" role="tab"
-                    aria-controls="build-info-pane">Build info
-            </button>
-        </li>
-        <li class="nav-item">
+                    aria-controls="build-info-pane">Build info</button>
             <button class="nav-link" id="manifest-info-tab" data-bs-toggle="pill" data-bs-target="#manifest-info-pane" type="button" role="tab"
-                    aria-controls="manifest-info-pane">Plugin manifest
-            </button>
-        </li>
-    </ul>
+                    aria-controls="manifest-info-pane">Plugin manifest</button>
+        </div>
+    </nav>
     <div class="tab-content" id="pills-tabContent">
         <div class="tab-pane show active" id="build-logs-pane" role="tabpanel" aria-labelledby="build-logs-tab">
             <pre><code class="text hljs" id="Logs">@Model.Logs</code>
@@ -256,13 +249,18 @@
 
         #artifacts-tabs .nav-link {
             background: none;
-            padding: 0;
-            font-weight: var(--btcpay-font-weight-semibold);
+            border: 0;
+            border-bottom: 2px solid transparent;
+            border-radius: 0;
+            color: var(--btcpay-nav-link);
             font-size: 1.125rem;
+            padding: 0 0 .75rem;
         }
 
         #artifacts-tabs .nav-link.active {
-            color: var(--btcpay-primary);
+            background: none;
+            color: var(--btcpay-nav-link);
+            border-bottom-color: var(--btcpay-primary);
         }
     </style>
 }


### PR DESCRIPTION
This PR fixes #178 and aligns the Plugin Builder plugin-page navigation and layout with the BTCPay Server reporting-tab

### Demo

<img width="1858" height="1053" alt="Screenshot from 2026-04-06 10-03-59" src="https://github.com/user-attachments/assets/71953573-1636-45b4-bd56-d36a9174f52e" />
<img width="1858" height="1053" alt="Screenshot from 2026-04-06 10-04-12" src="https://github.com/user-attachments/assets/70e18eb5-c059-458c-8fcc-cd6c9ff8375c" />



