### PR TITLE
Feat: GitLab Provider

### DIFF
--- a/PluginBuilder.Tests/GitHostingProviderTests.cs
+++ b/PluginBuilder.Tests/GitHostingProviderTests.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
+using PluginBuilder.DataModels;
 using PluginBuilder.Services;
 using PluginBuilder.Util;
 using Xunit;
@@ -379,6 +381,90 @@ public class GitHostingProviderTests
         Assert.Null(Controllers.PluginController.GetUrl(buildInfo));
     }
 
+    // ── GitLab avatar resolution ─────────────────────────────────────
+
+    [Fact]
+    public async Task GitLab_GetContributors_ResolvesAvatarFromEmail()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Alice", author_email = "alice@example.com" },
+            new { author_name = "Alice", author_email = "alice@example.com" },
+            new { author_name = "Bob", author_email = "bob@example.com" }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            ["avatar?email=alice%40example.com&size=48"] =
+                (HttpStatusCode.OK, """{"avatar_url":"https://gitlab.com/uploads/-/alice.png"}"""),
+            ["avatar?email=bob%40example.com&size=48"] =
+                (HttpStatusCode.OK, """{"avatar_url":"https://gitlab.com/uploads/-/bob.png"}""")
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        Assert.Equal(2, contributors.Count);
+
+        var alice = contributors.First(c => c.Login == "Alice");
+        Assert.Equal("https://gitlab.com/uploads/-/alice.png", alice.AvatarUrl);
+        Assert.Equal(2, alice.Contributions);
+
+        var bob = contributors.First(c => c.Login == "Bob");
+        Assert.Equal("https://gitlab.com/uploads/-/bob.png", bob.AvatarUrl);
+        Assert.Equal(1, bob.Contributions);
+    }
+
+    [Fact]
+    public async Task GitLab_GetContributors_AvatarEndpointFails_StillReturnsContributors()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Alice", author_email = "alice@example.com" }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            // avatar endpoint returns 500
+            ["avatar?email=alice%40example.com&size=48"] =
+                (HttpStatusCode.InternalServerError, "")
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var alice = Assert.Single(contributors);
+        Assert.Equal("Alice", alice.Login);
+        Assert.Null(alice.AvatarUrl); // gracefully null
+    }
+
+    [Fact]
+    public async Task GitLab_GetContributors_NoEmail_SkipsAvatarResolution()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "NoEmail", author_email = (string?)null }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson)
+            // no avatar endpoint registered — would throw if called
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var c = Assert.Single(contributors);
+        Assert.Equal("NoEmail", c.Login);
+        Assert.Null(c.AvatarUrl);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────
 
     private static GitHubHostingProvider CreateGitHubProvider()
@@ -387,9 +473,13 @@ public class GitHostingProviderTests
         return new GitHubHostingProvider(factory);
     }
 
-    private static GitLabHostingProvider CreateGitLabProvider(IEnumerable<string>? additionalHosts = null)
+    private static GitLabHostingProvider CreateGitLabProvider(
+        IEnumerable<string>? additionalHosts = null,
+        FakeHttpHandler? handler = null)
     {
-        var factory = new TestHttpClientFactory();
+        var factory = handler != null
+            ? new FakeHttpClientFactory(handler)
+            : (IHttpClientFactory)new TestHttpClientFactory();
         return new GitLabHostingProvider(factory, additionalHosts);
     }
 
@@ -407,5 +497,50 @@ public class GitHostingProviderTests
     private class TestHttpClientFactory : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => new();
+    }
+
+    private class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly FakeHttpHandler _handler;
+        public FakeHttpClientFactory(FakeHttpHandler handler) => _handler = handler;
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler)
+            {
+                BaseAddress = new Uri("https://gitlab.com/api/v4/")
+            };
+        }
+    }
+
+    private class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, (HttpStatusCode Status, string Body)> _responses;
+
+        public FakeHttpHandler(Dictionary<string, (HttpStatusCode, string)> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Match on the path+query relative to the base address
+            var key = request.RequestUri!.PathAndQuery.TrimStart('/');
+            // Strip the base path prefix (e.g., "/api/v4/")
+            const string prefix = "api/v4/";
+            if (key.StartsWith(prefix))
+                key = key[prefix.Length..];
+
+            if (_responses.TryGetValue(key, out var resp))
+            {
+                return Task.FromResult(new HttpResponseMessage(resp.Status)
+                {
+                    Content = new StringContent(resp.Body)
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
     }
 }

--- a/PluginBuilder.Tests/GitHostingProviderTests.cs
+++ b/PluginBuilder.Tests/GitHostingProviderTests.cs
@@ -381,6 +381,58 @@ public class GitHostingProviderTests
         Assert.Null(Controllers.PluginController.GetUrl(buildInfo));
     }
 
+    // ── Self-hosted / port preservation ─────────────────────────────
+
+    [Fact]
+    public void PublishedPlugin_GetOwnerProfileUrl_PreservesPort()
+    {
+        var httpFactory = new TestHttpClientFactory();
+        var gitlabProvider = new GitLabHostingProvider(httpFactory, new[] { "gitlab.example.com" });
+        var factory = new GitHostingProviderFactory(new IGitHostingProvider[] { gitlabProvider });
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://gitlab.example.com:8443/group/repo"
+            })
+        };
+        Assert.Equal("https://gitlab.example.com:8443/group", plugin.GetOwnerProfileUrl(factory));
+    }
+
+    [Fact]
+    public void GitLab_GetSourceUrl_PreservesPort()
+    {
+        var provider = CreateGitLabProvider(additionalHosts: new[] { "gitlab.example.com" });
+        var url = provider.GetSourceUrl(
+            "https://gitlab.example.com:8443/group/repo",
+            "abc123",
+            "src/Plugin");
+        Assert.Equal("https://gitlab.example.com:8443/group/repo/-/tree/abc123/src/Plugin", url);
+    }
+
+    // ── GitHub ExtractOwnerRepo .git handling ─────────────────────────
+
+    [Fact]
+    public void GitHub_GetSourceUrl_RepoNameContainsDotGit()
+    {
+        var provider = CreateGitHubProvider();
+        var url = provider.GetSourceUrl(
+            "https://github.com/owner/my.gitrepo",
+            "abc123",
+            null);
+        Assert.Equal("https://github.com/owner/my.gitrepo/tree/abc123", url);
+    }
+
+    [Fact]
+    public void GitHub_ParseRepository_RepoNameContainsDotGit()
+    {
+        var provider = CreateGitHubProvider();
+        var result = provider.ParseRepository("https://github.com/owner/my.gitrepo");
+        Assert.NotNull(result);
+        Assert.Equal("owner", result.Value.Owner);
+        Assert.Equal("my.gitrepo", result.Value.RepoName);
+    }
+
     // ── GitLab avatar resolution ─────────────────────────────────────
 
     [Fact]

--- a/PluginBuilder.Tests/GitHostingProviderTests.cs
+++ b/PluginBuilder.Tests/GitHostingProviderTests.cs
@@ -50,6 +50,20 @@ public class GitHostingProviderTests
         Assert.Equal(expected, provider.CanHandle(url));
     }
 
+    [Theory]
+    // Config "host:port" matches URL with same port
+    [InlineData("gitlab.example.com:8443", "https://gitlab.example.com:8443/owner/repo", true)]
+    // Config "host:port" does NOT match URL without port
+    [InlineData("gitlab.example.com:8443", "https://gitlab.example.com/owner/repo", false)]
+    // Config "host" matches URL with any port (host fallback)
+    [InlineData("gitlab.example.com", "https://gitlab.example.com:8443/owner/repo", true)]
+    [InlineData("gitlab.example.com", "https://gitlab.example.com/owner/repo", true)]
+    public void GitLab_CanHandle_AdditionalHosts_PortAware(string configuredHost, string url, bool expected)
+    {
+        var provider = CreateGitLabProvider(additionalHosts: new[] { configuredHost });
+        Assert.Equal(expected, provider.CanHandle(url));
+    }
+
     // ── GitHub ParseRepository ────────────────────────────────────────
 
     [Theory]

--- a/PluginBuilder.Tests/GitHostingProviderTests.cs
+++ b/PluginBuilder.Tests/GitHostingProviderTests.cs
@@ -1,0 +1,411 @@
+using Newtonsoft.Json.Linq;
+using PluginBuilder.APIModels;
+using PluginBuilder.Services;
+using PluginBuilder.Util;
+using Xunit;
+
+namespace PluginBuilder.Tests;
+
+public class GitHostingProviderTests
+{
+    // ── GitHub CanHandle ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo", true)]
+    [InlineData("https://www.github.com/owner/repo", true)]
+    [InlineData("https://github.com/owner/repo.git", true)]
+    [InlineData("https://GITHUB.COM/owner/repo", true)]
+    [InlineData("https://gitlab.com/owner/repo", false)]
+    [InlineData("https://bitbucket.org/owner/repo", false)]
+    [InlineData("not a url", false)]
+    public void GitHub_CanHandle(string url, bool expected)
+    {
+        var provider = CreateGitHubProvider();
+        Assert.Equal(expected, provider.CanHandle(url));
+    }
+
+    // ── GitLab CanHandle ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://gitlab.com/owner/repo", true)]
+    [InlineData("https://www.gitlab.com/owner/repo", true)]
+    [InlineData("https://gitlab.com/group/subgroup/repo", true)]
+    [InlineData("https://GITLAB.COM/owner/repo", true)]
+    [InlineData("https://github.com/owner/repo", false)]
+    [InlineData("not a url", false)]
+    public void GitLab_CanHandle(string url, bool expected)
+    {
+        var provider = CreateGitLabProvider();
+        Assert.Equal(expected, provider.CanHandle(url));
+    }
+
+    [Theory]
+    [InlineData("https://gitlab.selfhosted.com/owner/repo", true)]
+    [InlineData("https://github.com/owner/repo", false)]
+    public void GitLab_CanHandle_AdditionalHosts(string url, bool expected)
+    {
+        var provider = CreateGitLabProvider(additionalHosts: new[] { "gitlab.selfhosted.com" });
+        Assert.Equal(expected, provider.CanHandle(url));
+    }
+
+    // ── GitHub ParseRepository ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://github.com/Kukks/btcpayserver", "Kukks", "btcpayserver")]
+    [InlineData("https://github.com/Kukks/btcpayserver.git", "Kukks", "btcpayserver")]
+    [InlineData("https://www.github.com/Kukks/btcpayserver/", "Kukks", "btcpayserver")]
+    public void GitHub_ParseRepository_Valid(string url, string expectedOwner, string expectedRepo)
+    {
+        var provider = CreateGitHubProvider();
+        var result = provider.ParseRepository(url);
+        Assert.NotNull(result);
+        Assert.Equal(expectedOwner, result.Value.Owner);
+        Assert.Equal(expectedRepo, result.Value.RepoName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("https://github.com/")]
+    [InlineData("https://gitlab.com/owner/repo")]
+    public void GitHub_ParseRepository_Invalid(string url)
+    {
+        var provider = CreateGitHubProvider();
+        var result = provider.ParseRepository(url);
+        Assert.Null(result);
+    }
+
+    // ── GitLab ParseRepository ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://gitlab.com/owner/repo", "owner", "repo")]
+    [InlineData("https://gitlab.com/owner/repo.git", "owner", "repo")]
+    [InlineData("https://gitlab.com/group/subgroup/repo", "group/subgroup", "repo")]
+    [InlineData("https://gitlab.com/a/b/c/repo", "a/b/c", "repo")]
+    public void GitLab_ParseRepository_Valid(string url, string expectedOwner, string expectedRepo)
+    {
+        var provider = CreateGitLabProvider();
+        var result = provider.ParseRepository(url);
+        Assert.NotNull(result);
+        Assert.Equal(expectedOwner, result.Value.Owner);
+        Assert.Equal(expectedRepo, result.Value.RepoName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("https://gitlab.com/")]
+    [InlineData("https://gitlab.com/onlyone")]
+    public void GitLab_ParseRepository_Invalid(string url)
+    {
+        var provider = CreateGitLabProvider();
+        var result = provider.ParseRepository(url);
+        Assert.Null(result);
+    }
+
+    // ── GitHub GetSourceUrl ───────────────────────────────────────────
+
+    [Fact]
+    public void GitHub_GetSourceUrl_WithCommitAndPluginDir()
+    {
+        var provider = CreateGitHubProvider();
+        var url = provider.GetSourceUrl(
+            "https://github.com/NicolasDorier/btcpayserver",
+            "abc123",
+            "Plugins/MyPlugin");
+        Assert.Equal("https://github.com/NicolasDorier/btcpayserver/tree/abc123/Plugins/MyPlugin", url);
+    }
+
+    [Fact]
+    public void GitHub_GetSourceUrl_WithCommitNoPluginDir()
+    {
+        var provider = CreateGitHubProvider();
+        var url = provider.GetSourceUrl(
+            "https://github.com/NicolasDorier/btcpayserver",
+            "abc123",
+            null);
+        Assert.Equal("https://github.com/NicolasDorier/btcpayserver/tree/abc123", url);
+    }
+
+    [Fact]
+    public void GitHub_GetSourceUrl_NullCommit()
+    {
+        var provider = CreateGitHubProvider();
+        var url = provider.GetSourceUrl(
+            "https://github.com/NicolasDorier/btcpayserver",
+            null,
+            "Plugins/MyPlugin");
+        Assert.Null(url);
+    }
+
+    [Fact]
+    public void GitHub_GetSourceUrl_GitAtUrl()
+    {
+        var provider = CreateGitHubProvider();
+        var url = provider.GetSourceUrl(
+            "git@github.com:Kukks/btcpayserver.git",
+            "abc123",
+            "Plugins/AOPP");
+        Assert.Equal("https://github.com/Kukks/btcpayserver/tree/abc123/Plugins/AOPP", url);
+    }
+
+    // ── GitLab GetSourceUrl ───────────────────────────────────────────
+
+    [Fact]
+    public void GitLab_GetSourceUrl_WithCommitAndPluginDir()
+    {
+        var provider = CreateGitLabProvider();
+        var url = provider.GetSourceUrl(
+            "https://gitlab.com/mygroup/myrepo",
+            "def456",
+            "src/MyPlugin");
+        Assert.Equal("https://gitlab.com/mygroup/myrepo/-/tree/def456/src/MyPlugin", url);
+    }
+
+    [Fact]
+    public void GitLab_GetSourceUrl_NestedGroup()
+    {
+        var provider = CreateGitLabProvider();
+        var url = provider.GetSourceUrl(
+            "https://gitlab.com/group/subgroup/repo",
+            "def456",
+            null);
+        Assert.Equal("https://gitlab.com/group/subgroup/repo/-/tree/def456", url);
+    }
+
+    [Fact]
+    public void GitLab_GetSourceUrl_NullCommit()
+    {
+        var provider = CreateGitLabProvider();
+        var url = provider.GetSourceUrl(
+            "https://gitlab.com/owner/repo",
+            null,
+            null);
+        Assert.Null(url);
+    }
+
+    [Fact]
+    public void GitLab_GetSourceUrl_DotGitSuffix()
+    {
+        var provider = CreateGitLabProvider();
+        var url = provider.GetSourceUrl(
+            "https://gitlab.com/owner/repo.git",
+            "abc",
+            null);
+        Assert.Equal("https://gitlab.com/owner/repo/-/tree/abc", url);
+    }
+
+    // ── Factory ───────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo", typeof(GitHubHostingProvider))]
+    [InlineData("https://gitlab.com/owner/repo", typeof(GitLabHostingProvider))]
+    public void Factory_ReturnsCorrectProvider(string url, Type expectedType)
+    {
+        var factory = CreateFactory();
+        var provider = factory.GetProvider(url);
+        Assert.NotNull(provider);
+        Assert.IsType(expectedType, provider);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://bitbucket.org/owner/repo")]
+    public void Factory_ReturnsNull_ForUnsupported(string? url)
+    {
+        var factory = CreateFactory();
+        var provider = factory.GetProvider(url);
+        Assert.Null(provider);
+    }
+
+    // ── PublishedPlugin provider-agnostic methods ─────────────────────
+
+    [Fact]
+    public void PublishedPlugin_GetSourceUrl_GitHub()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://github.com/owner/repo",
+                gitCommit = "abc123",
+                pluginDir = "Plugins/MyPlugin"
+            })
+        };
+        var url = plugin.GetSourceUrl(factory);
+        Assert.Equal("https://github.com/owner/repo/tree/abc123/Plugins/MyPlugin", url);
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetSourceUrl_GitLab()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://gitlab.com/group/repo",
+                gitCommit = "def456",
+                pluginDir = "src/Plugin"
+            })
+        };
+        var url = plugin.GetSourceUrl(factory);
+        Assert.Equal("https://gitlab.com/group/repo/-/tree/def456/src/Plugin", url);
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetOwnerName_GitHub()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://github.com/NicolasDorier/btcpayserver"
+            })
+        };
+        Assert.Equal("NicolasDorier", plugin.GetOwnerName(factory));
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetOwnerName_GitLab_NestedGroup()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://gitlab.com/group/subgroup/repo"
+            })
+        };
+        Assert.Equal("group/subgroup", plugin.GetOwnerName(factory));
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetOwnerProfileUrl_GitHub()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://github.com/Kukks/btcpayserver"
+            })
+        };
+        Assert.Equal("https://github.com/Kukks", plugin.GetOwnerProfileUrl(factory));
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetOwnerProfileUrl_GitLab()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin
+        {
+            BuildInfo = JObject.FromObject(new
+            {
+                gitRepository = "https://gitlab.com/mygroup/myrepo"
+            })
+        };
+        Assert.Equal("https://gitlab.com/mygroup", plugin.GetOwnerProfileUrl(factory));
+    }
+
+    [Fact]
+    public void PublishedPlugin_GetSourceUrl_NullBuildInfo()
+    {
+        var factory = CreateFactory();
+        var plugin = new PublishedPlugin { BuildInfo = null };
+        Assert.Null(plugin.GetSourceUrl(factory));
+    }
+
+    // ── PluginController.GetUrl backward compatibility ────────────────
+
+    [Fact]
+    public void PluginController_GetUrl_GitHub_WithFactory()
+    {
+        var factory = CreateFactory();
+        var buildInfo = new BuildInfo
+        {
+            GitRepository = "https://github.com/Kukks/btcpayserver",
+            GitCommit = "abc123",
+            PluginDir = "Plugins/AOPP"
+        };
+        var url = Controllers.PluginController.GetUrl(buildInfo, factory);
+        Assert.Equal("https://github.com/Kukks/btcpayserver/tree/abc123/Plugins/AOPP", url);
+    }
+
+    [Fact]
+    public void PluginController_GetUrl_GitLab_WithFactory()
+    {
+        var factory = CreateFactory();
+        var buildInfo = new BuildInfo
+        {
+            GitRepository = "https://gitlab.com/group/repo",
+            GitCommit = "def456",
+            PluginDir = "src/Plugin"
+        };
+        var url = Controllers.PluginController.GetUrl(buildInfo, factory);
+        Assert.Equal("https://gitlab.com/group/repo/-/tree/def456/src/Plugin", url);
+    }
+
+    [Fact]
+    public void PluginController_GetUrl_GitAtUrl_WithoutFactory()
+    {
+        // Backward compat: no factory, git@ URL should still work
+        var buildInfo = new BuildInfo
+        {
+            GitRepository = "git@github.com:Kukks/btcpayserver.git",
+            GitCommit = "abc123",
+            PluginDir = "Plugins/AOPP"
+        };
+        var url = Controllers.PluginController.GetUrl(buildInfo);
+        Assert.Equal("https://github.com/Kukks/btcpayserver/tree/abc123/Plugins/AOPP", url);
+    }
+
+    [Fact]
+    public void PluginController_GetUrl_NullBuildInfo()
+    {
+        var factory = CreateFactory();
+        Assert.Null(Controllers.PluginController.GetUrl(null, factory));
+    }
+
+    [Fact]
+    public void PluginController_GetUrl_UnsupportedProvider_WithoutFactory()
+    {
+        var buildInfo = new BuildInfo
+        {
+            GitRepository = "https://bitbucket.org/owner/repo",
+            GitCommit = "abc123"
+        };
+        Assert.Null(Controllers.PluginController.GetUrl(buildInfo));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+
+    private static GitHubHostingProvider CreateGitHubProvider()
+    {
+        var factory = new TestHttpClientFactory();
+        return new GitHubHostingProvider(factory);
+    }
+
+    private static GitLabHostingProvider CreateGitLabProvider(IEnumerable<string>? additionalHosts = null)
+    {
+        var factory = new TestHttpClientFactory();
+        return new GitLabHostingProvider(factory, additionalHosts);
+    }
+
+    private static GitHostingProviderFactory CreateFactory()
+    {
+        var httpFactory = new TestHttpClientFactory();
+        var providers = new IGitHostingProvider[]
+        {
+            new GitHubHostingProvider(httpFactory),
+            new GitLabHostingProvider(httpFactory)
+        };
+        return new GitHostingProviderFactory(providers);
+    }
+
+    private class TestHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/PluginBuilder.Tests/GitHostingProviderTests.cs
+++ b/PluginBuilder.Tests/GitHostingProviderTests.cs
@@ -531,6 +531,148 @@ public class GitHostingProviderTests
         Assert.Null(c.AvatarUrl);
     }
 
+    // ── GitLab Users API resolution ───────────────────────────────────
+
+    [Fact]
+    public async Task GitLab_GetContributors_ResolvesUserViaPublicEmail()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Alice Commit", author_email = "alice@example.com" }
+        }).ToString();
+
+        var userJson = JArray.FromObject(new[]
+        {
+            new
+            {
+                username = "alice_gitlab",
+                web_url = "https://gitlab.com/alice_gitlab",
+                avatar_url = "https://gitlab.com/uploads/-/alice.png"
+            }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            ["users?public_email=alice%40example.com"] =
+                (HttpStatusCode.OK, userJson)
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var alice = Assert.Single(contributors);
+        Assert.Equal("alice_gitlab", alice.Login); // uses canonical username
+        Assert.Equal("https://gitlab.com/alice_gitlab", alice.HtmlUrl);
+        Assert.Equal("https://gitlab.com/uploads/-/alice.png", alice.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task GitLab_GetContributors_FallsBackToSearchWhenPublicEmailEmpty()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Bob Commit", author_email = "bob@example.com" }
+        }).ToString();
+
+        var userJson = JArray.FromObject(new[]
+        {
+            new
+            {
+                username = "bob_gitlab",
+                web_url = "https://gitlab.com/bob_gitlab",
+                avatar_url = "https://gitlab.com/uploads/-/bob.png"
+            }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            // public_email returns empty (user hasn't made email public)
+            ["users?public_email=bob%40example.com"] =
+                (HttpStatusCode.OK, "[]"),
+            // search returns a single match
+            ["users?search=bob%40example.com"] =
+                (HttpStatusCode.OK, userJson)
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var bob = Assert.Single(contributors);
+        Assert.Equal("bob_gitlab", bob.Login);
+        Assert.Equal("https://gitlab.com/bob_gitlab", bob.HtmlUrl);
+        Assert.Equal("https://gitlab.com/uploads/-/bob.png", bob.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task GitLab_GetContributors_SearchAmbiguous_FallsBackToAvatarOnly()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Carol Commit", author_email = "carol@example.com" }
+        }).ToString();
+
+        // Two matches — ambiguous, should be rejected
+        var ambiguousJson = JArray.FromObject(new[]
+        {
+            new { username = "carol1", web_url = "https://gitlab.com/carol1", avatar_url = "https://gitlab.com/carol1.png" },
+            new { username = "carol2", web_url = "https://gitlab.com/carol2", avatar_url = "https://gitlab.com/carol2.png" }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            ["users?public_email=carol%40example.com"] =
+                (HttpStatusCode.OK, "[]"),
+            ["users?search=carol%40example.com"] =
+                (HttpStatusCode.OK, ambiguousJson),
+            ["avatar?email=carol%40example.com&size=48"] =
+                (HttpStatusCode.OK, """{"avatar_url":"https://gitlab.com/uploads/-/carol_gravatar.png"}""")
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var carol = Assert.Single(contributors);
+        // Name stays as commit author since we couldn't resolve unambiguously
+        Assert.Equal("Carol Commit", carol.Login);
+        // No profile URL since we couldn't resolve
+        Assert.Null(carol.HtmlUrl);
+        // But avatar came through via the /avatar fallback
+        Assert.Equal("https://gitlab.com/uploads/-/carol_gravatar.png", carol.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task GitLab_GetContributors_NoUserMatch_AllFallbacksFail_LeavesNull()
+    {
+        var commitsJson = JArray.FromObject(new[]
+        {
+            new { author_name = "Ghost", author_email = "ghost@example.com" }
+        }).ToString();
+
+        var handler = new FakeHttpHandler(new Dictionary<string, (HttpStatusCode, string)>
+        {
+            ["projects/owner%2Frepo/repository/commits?per_page=100&page=1"] =
+                (HttpStatusCode.OK, commitsJson),
+            ["users?public_email=ghost%40example.com"] = (HttpStatusCode.OK, "[]"),
+            ["users?search=ghost%40example.com"] = (HttpStatusCode.OK, "[]"),
+            // avatar endpoint returns 500
+            ["avatar?email=ghost%40example.com&size=48"] = (HttpStatusCode.InternalServerError, "")
+        });
+
+        var provider = CreateGitLabProvider(handler: handler);
+        var contributors = await provider.GetContributorsAsync("https://gitlab.com/owner/repo", "");
+
+        var ghost = Assert.Single(contributors);
+        Assert.Equal("Ghost", ghost.Login); // original commit author name
+        Assert.Null(ghost.HtmlUrl);
+        Assert.Null(ghost.AvatarUrl);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────
 
     private static GitHubHostingProvider CreateGitHubProvider()

--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -68,9 +68,9 @@ public class PublishedPlugin : PublishedVersion
         if (parsed is null)
             return null;
 
-        // Build profile URL from the repository host
+        // Build profile URL from the repository host, preserving port for self-hosted instances
         if (Uri.TryCreate(gitRepository, UriKind.Absolute, out var uri))
-            return $"{uri.Scheme}://{uri.Host}/{parsed.Value.Owner}";
+            return $"{uri.Scheme}://{uri.Authority}/{parsed.Value.Owner}";
         return null;
     }
 

--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using PluginBuilder.Services;
 
 namespace PluginBuilder.APIModels;
 
@@ -40,6 +41,40 @@ public class PublishedPlugin : PublishedVersion
 
     public PluginRatingSummary RatingSummary { get; set; } = new();
 
+    public string GetSourceUrl(GitHostingProviderFactory providerFactory)
+    {
+        if (gitRepository is null)
+            return null;
+        var commit = BuildInfo?["gitCommit"]?.ToString();
+        var dir = BuildInfo?["pluginDir"]?.ToString();
+        var provider = providerFactory?.GetProvider(gitRepository);
+        return provider?.GetSourceUrl(gitRepository, commit, dir);
+    }
+
+    public string GetOwnerName(GitHostingProviderFactory providerFactory)
+    {
+        if (gitRepository is null)
+            return null;
+        var provider = providerFactory?.GetProvider(gitRepository);
+        return provider?.ParseRepository(gitRepository)?.Owner;
+    }
+
+    public string GetOwnerProfileUrl(GitHostingProviderFactory providerFactory)
+    {
+        if (gitRepository is null)
+            return null;
+        var provider = providerFactory?.GetProvider(gitRepository);
+        var parsed = provider?.ParseRepository(gitRepository);
+        if (parsed is null)
+            return null;
+
+        // Build profile URL from the repository host
+        if (Uri.TryCreate(gitRepository, UriKind.Absolute, out var uri))
+            return $"{uri.Scheme}://{uri.Host}/{parsed.Value.Owner}";
+        return null;
+    }
+
+    // Kept for backward compatibility with existing code that uses this pattern
     public GithubRepository GetGithubRepository()
     {
         if (gitRepository is null)

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -26,13 +26,13 @@ namespace PluginBuilder.Controllers;
 public class HomeController(
     DBConnectionFactory connectionFactory,
     UserManager<IdentityUser> userManager,
-    IHttpClientFactory httpClientFactory,
     SignInManager<IdentityUser> signInManager,
     EmailService emailService,
     UserVerifiedLogic userVerifiedLogic,
     PluginBuilderOptions options,
     ServerEnvironment env,
     NostrService nostrService,
+    GitHostingProviderFactory gitHostingProviderFactory,
     ILogger<HomeController> logger,
     HealthCheckService healthCheckService)
     : Controller
@@ -83,7 +83,7 @@ public class HomeController(
             b.GitRef = buildInfo?.GitRef;
             b.Version = PluginVersionViewModel.CreateOrNull(manifest?.Version?.ToString(), row.published, row.pre_release, row.state, row.slug);
             b.Date = (DateTimeOffset.UtcNow - row.created_at).ToTimeAgo();
-            b.RepositoryLink = PluginController.GetUrl(buildInfo);
+            b.RepositoryLink = PluginController.GetUrl(buildInfo, gitHostingProviderFactory);
             b.DownloadLink = buildInfo?.Url;
             b.Error = buildInfo?.Error;
             b.PluginSlug = row.slug;
@@ -482,13 +482,16 @@ public class HomeController(
         if (!string.IsNullOrWhiteSpace(ownerNpub))
             ownerNostrUrl = string.Format(ExternalProfileUrls.PrimalProfileFormat, Uri.EscapeDataString(ownerNpub));
 
-        var githubClient = httpClientFactory.CreateClient(HttpClientNames.GitHub);
         var pluginContributors = GithubService.LoadSnapshot(options.PluginDataDir, pluginSlug);
         if (pluginContributors.Count == 0)
         {
-            pluginContributors = await GithubService.GetContributorsAsync(githubClient, plugin.gitRepository, plugin.pluginDir);
-            if (pluginContributors.Count > 0)
-                await GithubService.SaveSnapshot(options.PluginDataDir, pluginSlug, pluginContributors);
+            var provider = gitHostingProviderFactory.GetProvider(plugin.gitRepository);
+            if (provider != null)
+            {
+                pluginContributors = await provider.GetContributorsAsync(plugin.gitRepository, plugin.pluginDir);
+                if (pluginContributors.Count > 0)
+                    await GithubService.SaveSnapshot(options.PluginDataDir, pluginSlug, pluginContributors);
+            }
         }
 
         var vm = new PluginDetailsViewModel

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -31,6 +31,7 @@ public class PluginController(
     IOutputCacheStore outputCacheStore,
     PluginOwnershipService ownershipService,
     VersionLifecycleService versionLifecycleService,
+    GitHostingProviderFactory gitHostingProviderFactory,
     ILogger<PluginController> logger)
     : Controller
 {
@@ -288,7 +289,7 @@ public class PluginController(
 
         try
         {
-            var identifier = await buildService.FetchIdentifierFromGithubCsprojAsync(model.GitRepository, model.GitRef, model.PluginDirectory);
+            var identifier = await buildService.FetchIdentifierFromCsprojAsync(model.GitRepository, model.GitRef, model.PluginDirectory);
             var owns = await conn.EnsureIdentifierOwnership(pluginSlug, identifier);
             if (!owns)
             {
@@ -582,7 +583,7 @@ public class PluginController(
         vm.Repository = buildInfo?.GitRepository;
         vm.GitRef = buildInfo?.GitRef;
         vm.Version = PluginVersionViewModel.CreateOrNull(manifest?.Version?.ToString(), row.published, row.pre_release, row.state, pluginSlug.ToString());
-        vm.RepositoryLink = GetUrl(buildInfo);
+        vm.RepositoryLink = GetUrl(buildInfo, gitHostingProviderFactory);
         vm.DownloadLink = buildInfo?.Url;
         //vm.Error = buildInfo?.Error;
         vm.RequireGPGSignatureForRelease = pluginSetting?.RequireGPGSignatureForRelease ?? false;
@@ -730,7 +731,7 @@ public class PluginController(
             b.GitRef = buildInfo?.GitRef;
             b.Version = PluginVersionViewModel.CreateOrNull(manifest?.Version?.ToString(), row.published, row.pre_release, row.state, pluginSlug.ToString());
             b.Date = (DateTimeOffset.UtcNow - row.created_at).ToTimeAgo();
-            b.RepositoryLink = GetUrl(buildInfo);
+            b.RepositoryLink = GetUrl(buildInfo, gitHostingProviderFactory);
             b.DownloadLink = buildInfo?.Url;
             b.Error = buildInfo?.Error;
         }
@@ -740,32 +741,35 @@ public class PluginController(
         return View(vm);
     }
 
-    public static string? GetUrl(BuildInfo? buildInfo)
+    public static string? GetUrl(BuildInfo? buildInfo, GitHostingProviderFactory? providerFactory = null)
     {
-        if (buildInfo?.GitRepository is string repo && buildInfo?.GitCommit is string commit)
+        if (buildInfo?.GitRepository is not string repo || buildInfo?.GitCommit is not string commit)
+            return null;
+
+        if (providerFactory != null)
         {
-            string? repoName = null;
-            // git@github.com:Kukks/btcpayserver.git
-            if (repo.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
-                repoName = repo.Substring("git@github.com:".Length);
-            // https://github.com/Kukks/btcpayserver.git
-            // https://github.com/Kukks/btcpayserver
-            else if (repo.StartsWith("https://github.com/"))
-                repoName = repo.Substring("https://github.com/".Length);
-            if (repoName is not null)
-            {
-                // Kukks/btcpayserver
-                if (repoName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                    repoName = repoName.Substring(0, repoName.Length - 4);
-                // https://github.com/Kukks/btcpayserver/tree/plugins/collection/Plugins/BTCPayServer.Plugins.AOPP
-                var link = $"https://github.com/{repoName}/tree/{commit}";
-                if (buildInfo?.PluginDir is string pluginDir)
-                    link += $"/{pluginDir}";
-                return link;
-            }
+            var provider = providerFactory.GetProvider(repo);
+            if (provider != null)
+                return provider.GetSourceUrl(repo, commit, buildInfo.PluginDir);
         }
 
-        return null;
+        // Fallback for backward compatibility (git@ URLs, etc.)
+        string? repoName = null;
+        if (repo.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+            repoName = repo.Substring("git@github.com:".Length);
+        else if (repo.StartsWith("https://github.com/"))
+            repoName = repo.Substring("https://github.com/".Length);
+
+        if (repoName is null)
+            return null;
+
+        if (repoName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            repoName = repoName.Substring(0, repoName.Length - 4);
+
+        var link = $"https://github.com/{repoName}/tree/{commit}";
+        if (buildInfo?.PluginDir is string pluginDir)
+            link += $"/{pluginDir}";
+        return link;
     }
 
     private static bool VersionEquals(PluginVersion? left, PluginVersion? right)

--- a/PluginBuilder/DataModels/HttpClientNames.cs
+++ b/PluginBuilder/DataModels/HttpClientNames.cs
@@ -3,4 +3,5 @@ namespace PluginBuilder.DataModels;
 public static class HttpClientNames
 {
     public const string GitHub = nameof(GitHub);
+    public const string GitLab = nameof(GitLab);
 }

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -207,6 +207,18 @@ public class Program
                 client.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue("Bearer", token);
         });
+        services.AddHttpClient(HttpClientNames.GitLab, client =>
+        {
+            client.BaseAddress = new Uri("https://gitlab.com/api/v4/");
+            client.DefaultRequestHeaders.Add("User-Agent", "PluginBuilder");
+
+            var token = configuration["GITLAB_TOKEN"];
+            if (!string.IsNullOrWhiteSpace(token))
+                client.DefaultRequestHeaders.Add("PRIVATE-TOKEN", token);
+        });
+        services.AddSingleton<IGitHostingProvider, GitHubHostingProvider>();
+        services.AddSingleton<IGitHostingProvider, GitLabHostingProvider>();
+        services.AddSingleton<GitHostingProviderFactory>();
         services.AddSingleton<ExternalAccountVerificationService>();
         services.AddSingleton<EmailService>();
         services.AddSingleton<FirstBuildEvent>();

--- a/PluginBuilder/Services/BuildService.cs
+++ b/PluginBuilder/Services/BuildService.cs
@@ -1,11 +1,8 @@
 using System.Threading.Channels;
-using System.Xml.Linq;
 using Dapper;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.Configuration;
-using PluginBuilder.DataModels;
 using PluginBuilder.Events;
-using PluginBuilder.JsonConverters;
 using PluginBuilder.Util;
 using PluginBuilder.Util.Extensions;
 
@@ -16,7 +13,7 @@ public class BuildServiceException(string message) : Exception(message);
 public class BuildService
 {
     private static readonly SemaphoreSlim _semaphore = new(5);
-    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly GitHostingProviderFactory _providerFactory;
     private readonly PluginBuilderOptions _options;
 
     public BuildService(
@@ -26,7 +23,7 @@ public class BuildService
         DBConnectionFactory connectionFactory,
         EventAggregator eventAggregator,
         AzureStorageClient azureStorageClient,
-        IHttpClientFactory httpClientFactory)
+        GitHostingProviderFactory providerFactory)
     {
         Logger = logger;
         _options = options;
@@ -34,7 +31,7 @@ public class BuildService
         ConnectionFactory = connectionFactory;
         EventAggregator = eventAggregator;
         AzureStorageClient = azureStorageClient;
-        _httpClientFactory = httpClientFactory;
+        _providerFactory = providerFactory;
     }
 
     public ILogger<BuildService> Logger { get; }
@@ -42,11 +39,6 @@ public class BuildService
     public DBConnectionFactory ConnectionFactory { get; }
     public EventAggregator EventAggregator { get; }
     public AzureStorageClient AzureStorageClient { get; }
-
-    private HttpClient GitHubClient()
-    {
-        return _httpClientFactory.CreateClient(HttpClientNames.GitHub);
-    }
 
     public async Task Build(FullBuildId fullBuildId)
     {
@@ -232,8 +224,10 @@ public class BuildService
     {
         try
         {
-            var githubClient = _httpClientFactory.CreateClient(HttpClientNames.GitHub);
-            var contributors = await GithubService.GetContributorsAsync(githubClient, buildInfo.GitRepository, buildInfo.PluginDir);
+            var provider = _providerFactory.GetProvider(buildInfo.GitRepository);
+            if (provider == null)
+                return;
+            var contributors = await provider.GetContributorsAsync(buildInfo.GitRepository, buildInfo.PluginDir);
             await GithubService.SaveSnapshot(_options.PluginDataDir, pluginSlug, contributors);
         }
         catch (Exception) { }
@@ -281,71 +275,12 @@ public class BuildService
         EventAggregator.Publish(new BuildChanged(fullBuildId, newState) { BuildInfo = buildInfo?.ToString(), ManifestInfo = manifestInfo?.ToString() });
     }
 
-    public async Task<string> FetchIdentifierFromGithubCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
     {
-        var githubClient = GitHubClient();
-
-        var (owner, repo) = ExtractOwnerRepo(repoUrl);
-        var dir = string.IsNullOrWhiteSpace(pluginDir) ? "" : pluginDir.Trim('/');
-
-        var encodedDir = string.Join('/', dir.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
-        var apiUrl = $"repos/{owner}/{repo}/contents" + (string.IsNullOrEmpty(encodedDir) ? "" : "/" + encodedDir);
-
-        if (!string.IsNullOrWhiteSpace(gitRef))
-            apiUrl += $"?ref={Uri.EscapeDataString(gitRef.Trim())}";
-
-        using var resp = await githubClient.GetAsync(apiUrl);
-        var body = await resp.Content.ReadAsStringAsync();
-        if (!resp.IsSuccessStatusCode)
-            throw new BuildServiceException(
-                $"GitHub error ({(int)resp.StatusCode}) listing '{(string.IsNullOrEmpty(dir) ? "/" : dir)}': {apiUrl}\nBody: {body}");
-
-        if (body.TrimStart().StartsWith('{'))
-            throw new BuildServiceException(
-                $"Expected directory listing but GitHub returned an object. Check pluginDir='{pluginDir}' (must be a directory). Path: {apiUrl}");
-
-        var items = SafeJson.Deserialize<List<GithubContentItem>>(body);
-        var csprojs = items
-            .Where(i => string.Equals(i.type, "file", StringComparison.OrdinalIgnoreCase)
-                        && i.name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)).ToList();
-
-        if (csprojs == null || csprojs.Count == 0)
-            throw new BuildServiceException(
-                $"No .csproj found in '{(string.IsNullOrEmpty(dir) ? "/" : dir)}' at {(string.IsNullOrWhiteSpace(gitRef) ? "default branch" : gitRef)}.");
-        if (csprojs.Count > 1)
-            throw new BuildServiceException("Multiple .csproj found. Keep exactly one.");
-
-        var downloadUrl = csprojs[0].download_url;
-        if (string.IsNullOrWhiteSpace(downloadUrl))
-            throw new BuildServiceException($"GitHub item '{csprojs[0].name}' has no download_url.");
-
-        using var csprojResp = await githubClient.GetAsync(downloadUrl);
-        var csprojBody = await csprojResp.Content.ReadAsStringAsync();
-
-        if (!csprojResp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(csprojBody))
-            throw new BuildServiceException(
-                $"GitHub error downloading '{csprojs[0].name}' from {downloadUrl} (HTTP {(int)csprojResp.StatusCode}).\nBody: {csprojBody}");
-
-        var doc = XDocument.Parse(csprojBody);
-        var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].name);
-
-        return assemblyName;
-    }
-
-    private (string owner, string repo) ExtractOwnerRepo(string repoUrl)
-    {
-        repoUrl = repoUrl.Trim().Replace(".git", "");
-
-        if (!repoUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            repoUrl = "https://" + repoUrl.TrimStart('/');
-
-        if (!Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri))
-            throw new BuildServiceException("Invalid repository URL");
-
-        var parts = uri.AbsolutePath.Trim('/').Split('/');
-        if (parts.Length < 2)
-            throw new BuildServiceException("Invalid repository URL");
-        return (parts[0], parts[1]);
+        var provider = _providerFactory.GetProvider(repoUrl);
+        if (provider == null)
+            throw new BuildServiceException("Unsupported git hosting provider. Supported: GitHub, GitLab.");
+        return await provider.FetchIdentifierFromCsprojAsync(repoUrl, gitRef, pluginDir);
     }
 
 
@@ -393,5 +328,4 @@ public class BuildService
         }
     }
 
-    private record GithubContentItem(string name, string type, string? download_url);
 }

--- a/PluginBuilder/Services/GitHostingProviderFactory.cs
+++ b/PluginBuilder/Services/GitHostingProviderFactory.cs
@@ -1,0 +1,18 @@
+namespace PluginBuilder.Services;
+
+public class GitHostingProviderFactory
+{
+    private readonly IEnumerable<IGitHostingProvider> _providers;
+
+    public GitHostingProviderFactory(IEnumerable<IGitHostingProvider> providers)
+    {
+        _providers = providers;
+    }
+
+    public IGitHostingProvider? GetProvider(string? repoUrl)
+    {
+        if (string.IsNullOrWhiteSpace(repoUrl))
+            return null;
+        return _providers.FirstOrDefault(p => p.CanHandle(repoUrl));
+    }
+}

--- a/PluginBuilder/Services/GitHubHostingProvider.cs
+++ b/PluginBuilder/Services/GitHubHostingProvider.cs
@@ -1,0 +1,208 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PluginBuilder.APIModels;
+using PluginBuilder.DataModels;
+using PluginBuilder.JsonConverters;
+
+namespace PluginBuilder.Services;
+
+public class GitHubHostingProvider : IGitHostingProvider
+{
+    private static readonly Regex HostRegex = new(
+        @"^https?://(www\.)?github\.com/", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex RepoRegex = new(
+        @"^https://(www\.)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public GitHubHostingProvider(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public bool CanHandle(string repoUrl) => HostRegex.IsMatch(repoUrl);
+
+    public (string Owner, string RepoName)? ParseRepository(string repoUrl)
+    {
+        if (string.IsNullOrEmpty(repoUrl))
+            return null;
+        var match = RepoRegex.Match(repoUrl.Trim());
+        if (!match.Success)
+            return null;
+        return (match.Groups[2].Value, match.Groups[3].Value);
+    }
+
+    public string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir)
+    {
+        if (commit is null)
+            return null;
+
+        var repo = ParseRepository(repoUrl);
+        if (repo is null)
+        {
+            // Handle git@ and other URL variants for backward compat
+            return GetSourceUrlFromRawUrl(repoUrl, commit, pluginDir);
+        }
+
+        var link = $"https://github.com/{repo.Value.Owner}/{repo.Value.RepoName}/tree/{commit}";
+        if (!string.IsNullOrEmpty(pluginDir))
+            link += $"/{pluginDir}";
+        return link;
+    }
+
+    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientNames.GitHub);
+        var (owner, repoName) = ExtractOwnerRepo(repoUrl);
+        var dir = string.IsNullOrWhiteSpace(pluginDir) ? "" : pluginDir.Trim('/');
+
+        var encodedDir = string.Join('/', dir.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
+        var apiUrl = $"repos/{owner}/{repoName}/contents" + (string.IsNullOrEmpty(encodedDir) ? "" : "/" + encodedDir);
+
+        if (!string.IsNullOrWhiteSpace(gitRef))
+            apiUrl += $"?ref={Uri.EscapeDataString(gitRef.Trim())}";
+
+        using var resp = await client.GetAsync(apiUrl);
+        var body = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode)
+            throw new BuildServiceException(
+                $"GitHub error ({(int)resp.StatusCode}) listing '{(string.IsNullOrEmpty(dir) ? "/" : dir)}': {apiUrl}\nBody: {body}");
+
+        if (body.TrimStart().StartsWith('{'))
+            throw new BuildServiceException(
+                $"Expected directory listing but GitHub returned an object. Check pluginDir='{pluginDir}' (must be a directory). Path: {apiUrl}");
+
+        var items = SafeJson.Deserialize<List<GithubContentItem>>(body);
+        var csprojs = items
+            .Where(i => string.Equals(i.type, "file", StringComparison.OrdinalIgnoreCase)
+                        && i.name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (csprojs == null || csprojs.Count == 0)
+            throw new BuildServiceException(
+                $"No .csproj found in '{(string.IsNullOrEmpty(dir) ? "/" : dir)}' at {(string.IsNullOrWhiteSpace(gitRef) ? "default branch" : gitRef)}.");
+        if (csprojs.Count > 1)
+            throw new BuildServiceException("Multiple .csproj found. Keep exactly one.");
+
+        var downloadUrl = csprojs[0].download_url;
+        if (string.IsNullOrWhiteSpace(downloadUrl))
+            throw new BuildServiceException($"GitHub item '{csprojs[0].name}' has no download_url.");
+
+        using var csprojResp = await client.GetAsync(downloadUrl);
+        var csprojBody = await csprojResp.Content.ReadAsStringAsync();
+
+        if (!csprojResp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(csprojBody))
+            throw new BuildServiceException(
+                $"GitHub error downloading '{csprojs[0].name}' from {downloadUrl} (HTTP {(int)csprojResp.StatusCode}).\nBody: {csprojBody}");
+
+        var doc = XDocument.Parse(csprojBody);
+        var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].name);
+
+        return assemblyName;
+    }
+
+    public async Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir)
+    {
+        var repo = ParseRepository(repoUrl);
+        if (repo == null)
+            return new List<GitHubContributor>();
+
+        var client = _httpClientFactory.CreateClient(HttpClientNames.GitHub);
+        var pathQuery = string.IsNullOrEmpty(pluginDir) ? "" : $"&path={Uri.EscapeDataString(pluginDir)}";
+        var contributors = new Dictionary<string, GitHubContributor>(StringComparer.OrdinalIgnoreCase);
+        int page = 1;
+        const int perPage = 100;
+        try
+        {
+            while (true)
+            {
+                var apiPath = $"repos/{repo.Value.Owner}/{repo.Value.RepoName}/commits?per_page={perPage}&page={page}{pathQuery}";
+                using var response = await client.GetAsync(apiPath);
+                if (!response.IsSuccessStatusCode)
+                    break;
+
+                var json = await response.Content.ReadAsStringAsync();
+                var commits = JsonConvert.DeserializeObject<List<GitHubCommit>>(json);
+                if (commits == null || commits.Count == 0)
+                    break;
+
+                foreach (var commit in commits)
+                {
+                    var login = commit.Author?.Login;
+                    if (commit.Author == null || string.IsNullOrEmpty(login))
+                        continue;
+
+                    if (contributors.TryGetValue(login, out var existing))
+                    {
+                        existing.Contributions++;
+                    }
+                    else
+                    {
+                        contributors[login] = new GitHubContributor
+                        {
+                            Login = commit.Author.Login,
+                            AvatarUrl = commit.Author.AvatarUrl,
+                            HtmlUrl = commit.Author.HtmlUrl,
+                            Contributions = 1
+                        };
+                    }
+                }
+
+                if (!response.Headers.TryGetValues("Link", out var linkHeaders) || !linkHeaders.Any(l => l.Contains("rel=\"next\"")))
+                    break;
+
+                page++;
+            }
+
+            return contributors.Values.OrderByDescending(c => c.Contributions).ToList();
+        }
+        catch (Exception)
+        {
+            return new List<GitHubContributor>();
+        }
+    }
+
+    private static (string owner, string repo) ExtractOwnerRepo(string repoUrl)
+    {
+        repoUrl = repoUrl.Trim().Replace(".git", "");
+
+        if (!repoUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            repoUrl = "https://" + repoUrl.TrimStart('/');
+
+        if (!Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri))
+            throw new BuildServiceException("Invalid repository URL");
+
+        var parts = uri.AbsolutePath.Trim('/').Split('/');
+        if (parts.Length < 2)
+            throw new BuildServiceException("Invalid repository URL");
+        return (parts[0], parts[1]);
+    }
+
+    private static string? GetSourceUrlFromRawUrl(string repo, string commit, string? pluginDir)
+    {
+        string? repoName = null;
+        // git@github.com:Kukks/btcpayserver.git
+        if (repo.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+            repoName = repo.Substring("git@github.com:".Length);
+        // https://github.com/Kukks/btcpayserver.git
+        // https://github.com/Kukks/btcpayserver
+        else if (repo.StartsWith("https://github.com/"))
+            repoName = repo.Substring("https://github.com/".Length);
+
+        if (repoName is null)
+            return null;
+
+        if (repoName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            repoName = repoName.Substring(0, repoName.Length - 4);
+
+        var link = $"https://github.com/{repoName}/tree/{commit}";
+        if (!string.IsNullOrEmpty(pluginDir))
+            link += $"/{pluginDir}";
+        return link;
+    }
+
+    private record GithubContentItem(string name, string type, string? download_url);
+}

--- a/PluginBuilder/Services/GitHubHostingProvider.cs
+++ b/PluginBuilder/Services/GitHubHostingProvider.cs
@@ -167,7 +167,9 @@ public class GitHubHostingProvider : IGitHostingProvider
 
     private static (string owner, string repo) ExtractOwnerRepo(string repoUrl)
     {
-        repoUrl = repoUrl.Trim().Replace(".git", "");
+        repoUrl = repoUrl.Trim();
+        if (repoUrl.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            repoUrl = repoUrl[..^4];
 
         if (!repoUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
             repoUrl = "https://" + repoUrl.TrimStart('/');

--- a/PluginBuilder/Services/GitHubHostingProvider.cs
+++ b/PluginBuilder/Services/GitHubHostingProvider.cs
@@ -98,7 +98,15 @@ public class GitHubHostingProvider : IGitHostingProvider
             throw new BuildServiceException(
                 $"GitHub error downloading '{csprojs[0].name}' from {downloadUrl} (HTTP {(int)csprojResp.StatusCode}).\nBody: {csprojBody}");
 
-        var doc = XDocument.Parse(csprojBody);
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(csprojBody);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            throw new BuildServiceException($"Failed to parse '{csprojs[0].name}' as XML: {ex.Message}");
+        }
         var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].name);
 
         return assemblyName;

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -1,0 +1,233 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PluginBuilder.APIModels;
+using PluginBuilder.DataModels;
+
+namespace PluginBuilder.Services;
+
+public class GitLabHostingProvider : IGitHostingProvider
+{
+    private static readonly Regex HostRegex = new(
+        @"^https?://(www\.)?gitlab\.com/", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // GitLab supports nested groups: gitlab.com/group/subgroup/repo
+    private static readonly Regex RepoRegex = new(
+        @"^https://(www\.)?gitlab\.com/(.+?)(?:\.git)?/?$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IEnumerable<string> _additionalHosts;
+
+    public GitLabHostingProvider(IHttpClientFactory httpClientFactory, IEnumerable<string>? additionalHosts = null)
+    {
+        _httpClientFactory = httpClientFactory;
+        _additionalHosts = additionalHosts ?? Enumerable.Empty<string>();
+    }
+
+    public bool CanHandle(string repoUrl)
+    {
+        if (HostRegex.IsMatch(repoUrl))
+            return true;
+
+        // Support self-hosted GitLab instances via configured additional hosts
+        if (!Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri))
+            return false;
+
+        return _additionalHosts.Any(h => uri.Host.Equals(h, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public (string Owner, string RepoName)? ParseRepository(string repoUrl)
+    {
+        if (string.IsNullOrEmpty(repoUrl))
+            return null;
+
+        if (!Uri.TryCreate(repoUrl.Trim(), UriKind.Absolute, out var uri))
+            return null;
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            path = path[..^4];
+
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2)
+            return null;
+
+        // Last segment is the repo name, everything before is the namespace/owner
+        var repoName = segments[^1];
+        var owner = string.Join("/", segments[..^1]);
+        return (owner, repoName);
+    }
+
+    public string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir)
+    {
+        if (commit is null)
+            return null;
+
+        if (!Uri.TryCreate(repoUrl.Trim(), UriKind.Absolute, out var uri))
+            return null;
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            path = path[..^4];
+
+        var baseUrl = $"{uri.Scheme}://{uri.Host}/{path}";
+        var link = $"{baseUrl}/-/tree/{commit}";
+        if (!string.IsNullOrEmpty(pluginDir))
+            link += $"/{pluginDir}";
+        return link;
+    }
+
+    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientNames.GitLab);
+        var projectId = GetProjectId(repoUrl);
+        var dir = string.IsNullOrWhiteSpace(pluginDir) ? "" : pluginDir.Trim('/');
+
+        // List files in the directory using the Repository Tree API
+        var apiUrl = $"projects/{Uri.EscapeDataString(projectId)}/repository/tree";
+        var queryParams = new List<string>();
+        if (!string.IsNullOrEmpty(dir))
+            queryParams.Add($"path={Uri.EscapeDataString(dir)}");
+        if (!string.IsNullOrWhiteSpace(gitRef))
+            queryParams.Add($"ref={Uri.EscapeDataString(gitRef.Trim())}");
+        if (queryParams.Count > 0)
+            apiUrl += "?" + string.Join("&", queryParams);
+
+        using var resp = await client.GetAsync(apiUrl);
+        var body = await resp.Content.ReadAsStringAsync();
+        if (!resp.IsSuccessStatusCode)
+            throw new BuildServiceException(
+                $"GitLab error ({(int)resp.StatusCode}) listing '{(string.IsNullOrEmpty(dir) ? "/" : dir)}': {apiUrl}\nBody: {body}");
+
+        var items = JsonConvert.DeserializeObject<List<GitLabTreeItem>>(body);
+        if (items == null)
+            throw new BuildServiceException(
+                $"Failed to parse GitLab tree response for '{(string.IsNullOrEmpty(dir) ? "/" : dir)}'.");
+
+        var csprojs = items
+            .Where(i => string.Equals(i.Type, "blob", StringComparison.OrdinalIgnoreCase)
+                        && i.Name.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (csprojs.Count == 0)
+            throw new BuildServiceException(
+                $"No .csproj found in '{(string.IsNullOrEmpty(dir) ? "/" : dir)}' at {(string.IsNullOrWhiteSpace(gitRef) ? "default branch" : gitRef)}.");
+        if (csprojs.Count > 1)
+            throw new BuildServiceException("Multiple .csproj found. Keep exactly one.");
+
+        // Download the .csproj file content using the Repository Files API
+        var filePath = csprojs[0].Path;
+        var fileApiUrl = $"projects/{Uri.EscapeDataString(projectId)}/repository/files/{Uri.EscapeDataString(filePath)}/raw";
+        if (!string.IsNullOrWhiteSpace(gitRef))
+            fileApiUrl += $"?ref={Uri.EscapeDataString(gitRef.Trim())}";
+
+        using var fileResp = await client.GetAsync(fileApiUrl);
+        var csprojBody = await fileResp.Content.ReadAsStringAsync();
+
+        if (!fileResp.IsSuccessStatusCode || string.IsNullOrWhiteSpace(csprojBody))
+            throw new BuildServiceException(
+                $"GitLab error downloading '{csprojs[0].Name}' (HTTP {(int)fileResp.StatusCode}).\nBody: {csprojBody}");
+
+        var doc = XDocument.Parse(csprojBody);
+        var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].Name);
+
+        return assemblyName;
+    }
+
+    public async Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir)
+    {
+        var repo = ParseRepository(repoUrl);
+        if (repo == null)
+            return new List<GitHubContributor>();
+
+        var client = _httpClientFactory.CreateClient(HttpClientNames.GitLab);
+        var projectId = GetProjectId(repoUrl);
+        var contributors = new Dictionary<string, GitHubContributor>(StringComparer.OrdinalIgnoreCase);
+        int page = 1;
+        const int perPage = 100;
+
+        try
+        {
+            while (true)
+            {
+                var apiPath = $"projects/{Uri.EscapeDataString(projectId)}/repository/commits?per_page={perPage}&page={page}";
+                if (!string.IsNullOrEmpty(pluginDir))
+                    apiPath += $"&path={Uri.EscapeDataString(pluginDir)}";
+
+                using var response = await client.GetAsync(apiPath);
+                if (!response.IsSuccessStatusCode)
+                    break;
+
+                var json = await response.Content.ReadAsStringAsync();
+                var commits = JsonConvert.DeserializeObject<List<GitLabCommit>>(json);
+                if (commits == null || commits.Count == 0)
+                    break;
+
+                foreach (var commit in commits)
+                {
+                    var name = commit.AuthorName;
+                    if (string.IsNullOrEmpty(name))
+                        continue;
+
+                    // Use author email as key since GitLab commits don't have user login
+                    var key = commit.AuthorEmail ?? name;
+                    if (contributors.TryGetValue(key, out var existing))
+                    {
+                        existing.Contributions++;
+                    }
+                    else
+                    {
+                        contributors[key] = new GitHubContributor
+                        {
+                            Login = name,
+                            AvatarUrl = null,
+                            HtmlUrl = null,
+                            Contributions = 1
+                        };
+                    }
+                }
+
+                // Check for next page via header
+                if (!response.Headers.TryGetValues("x-next-page", out var nextPageHeaders))
+                    break;
+                var nextPage = nextPageHeaders.FirstOrDefault();
+                if (string.IsNullOrEmpty(nextPage) || !int.TryParse(nextPage, out var np) || np <= page)
+                    break;
+
+                page = np;
+            }
+
+            return contributors.Values.OrderByDescending(c => c.Contributions).ToList();
+        }
+        catch (Exception)
+        {
+            return new List<GitHubContributor>();
+        }
+    }
+
+    private static string GetProjectId(string repoUrl)
+    {
+        if (!Uri.TryCreate(repoUrl.Trim(), UriKind.Absolute, out var uri))
+            throw new BuildServiceException("Invalid repository URL");
+
+        var path = uri.AbsolutePath.Trim('/');
+        if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            path = path[..^4];
+
+        if (string.IsNullOrEmpty(path))
+            throw new BuildServiceException("Invalid repository URL");
+
+        // GitLab project ID is the URL-encoded full path (e.g., "group/subgroup/repo")
+        return path;
+    }
+
+    private record GitLabTreeItem(
+        [property: JsonProperty("name")] string Name,
+        [property: JsonProperty("type")] string Type,
+        [property: JsonProperty("path")] string Path);
+
+    private record GitLabCommit(
+        [property: JsonProperty("author_name")] string AuthorName,
+        [property: JsonProperty("author_email")] string? AuthorEmail);
+}

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -198,11 +198,41 @@ public class GitLabHostingProvider : IGitHostingProvider
                 page = np;
             }
 
-            return contributors.Values.OrderByDescending(c => c.Contributions).ToList();
+            var result = contributors.Values.OrderByDescending(c => c.Contributions).ToList();
+            await ResolveAvatarsAsync(client, contributors);
+            return result;
         }
         catch (Exception)
         {
             return new List<GitHubContributor>();
+        }
+    }
+
+    private static async Task ResolveAvatarsAsync(
+        HttpClient client,
+        Dictionary<string, GitHubContributor> contributors)
+    {
+        foreach (var (key, contributor) in contributors)
+        {
+            // key is the email when available
+            if (!key.Contains('@'))
+                continue;
+            try
+            {
+                var apiUrl = $"avatar?email={Uri.EscapeDataString(key)}&size=48";
+                using var resp = await client.GetAsync(apiUrl);
+                if (!resp.IsSuccessStatusCode)
+                    continue;
+                var json = await resp.Content.ReadAsStringAsync();
+                var obj = JObject.Parse(json);
+                var avatarUrl = obj["avatar_url"]?.ToString();
+                if (!string.IsNullOrWhiteSpace(avatarUrl))
+                    contributor.AvatarUrl = avatarUrl;
+            }
+            catch
+            {
+                // Best effort — skip if anything goes wrong
+            }
         }
     }
 

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
+using PluginBuilder.DataModels;
 
 namespace PluginBuilder.Services;
 
@@ -243,9 +244,10 @@ public class GitLabHostingProvider : IGitHostingProvider
         if (!Uri.TryCreate(repoUrl.Trim(), UriKind.Absolute, out var uri))
             throw new BuildServiceException("Invalid repository URL");
 
-        var client = _httpClientFactory.CreateClient();
+        // Use the named GitLab client so GITLAB_TOKEN config is applied
+        var client = _httpClientFactory.CreateClient(HttpClientNames.GitLab);
+        // Override base address to target the repo's actual host (self-hosted support)
         client.BaseAddress = new Uri($"{uri.Scheme}://{uri.Authority}/api/v4/");
-        client.DefaultRequestHeaders.Add("User-Agent", "PluginBuilder");
         return client;
     }
 

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -203,7 +203,7 @@ public class GitLabHostingProvider : IGitHostingProvider
             }
 
             var result = contributors.Values.OrderByDescending(c => c.Contributions).ToList();
-            await ResolveAvatarsAsync(client, contributors);
+            await ResolveUsersAsync(client, contributors);
             return result;
         }
         catch (Exception)
@@ -212,7 +212,7 @@ public class GitLabHostingProvider : IGitHostingProvider
         }
     }
 
-    private static async Task ResolveAvatarsAsync(
+    private static async Task ResolveUsersAsync(
         HttpClient client,
         Dictionary<string, GitHubContributor> contributors)
     {
@@ -223,13 +223,21 @@ public class GitLabHostingProvider : IGitHostingProvider
                 continue;
             try
             {
-                var apiUrl = $"avatar?email={Uri.EscapeDataString(key)}&size=48";
-                using var resp = await client.GetAsync(apiUrl);
-                if (!resp.IsSuccessStatusCode)
+                var user = await TryResolveGitLabUser(client, key);
+                if (user is not null)
+                {
+                    if (!string.IsNullOrWhiteSpace(user.WebUrl))
+                        contributor.HtmlUrl = user.WebUrl;
+                    if (!string.IsNullOrWhiteSpace(user.AvatarUrl))
+                        contributor.AvatarUrl = user.AvatarUrl;
+                    // Prefer the canonical username if we found one
+                    if (!string.IsNullOrWhiteSpace(user.Username))
+                        contributor.Login = user.Username;
                     continue;
-                var json = await resp.Content.ReadAsStringAsync();
-                var obj = JObject.Parse(json);
-                var avatarUrl = obj["avatar_url"]?.ToString();
+                }
+
+                // Fallback: avatar-only lookup via /avatar
+                var avatarUrl = await TryResolveAvatarOnly(client, key);
                 if (!string.IsNullOrWhiteSpace(avatarUrl))
                     contributor.AvatarUrl = avatarUrl;
             }
@@ -238,6 +246,39 @@ public class GitLabHostingProvider : IGitHostingProvider
                 // Best effort — skip if anything goes wrong
             }
         }
+    }
+
+    private static async Task<GitLabUser?> TryResolveGitLabUser(HttpClient client, string email)
+    {
+        // Try exact public_email match first (only returns users who made their email public)
+        var user = await QueryUser(client, $"users?public_email={Uri.EscapeDataString(email)}");
+        if (user is not null)
+            return user;
+
+        // Fall back to search (matches any field including email substring)
+        return await QueryUser(client, $"users?search={Uri.EscapeDataString(email)}");
+    }
+
+    private static async Task<GitLabUser?> QueryUser(HttpClient client, string apiPath)
+    {
+        using var resp = await client.GetAsync(apiPath);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+        var json = await resp.Content.ReadAsStringAsync();
+        var users = JsonConvert.DeserializeObject<List<GitLabUser>>(json);
+        // Only accept unambiguous matches
+        return users is { Count: 1 } ? users[0] : null;
+    }
+
+    private static async Task<string?> TryResolveAvatarOnly(HttpClient client, string email)
+    {
+        var apiUrl = $"avatar?email={Uri.EscapeDataString(email)}&size=48";
+        using var resp = await client.GetAsync(apiUrl);
+        if (!resp.IsSuccessStatusCode)
+            return null;
+        var json = await resp.Content.ReadAsStringAsync();
+        var obj = JObject.Parse(json);
+        return obj["avatar_url"]?.ToString();
     }
 
     private HttpClient CreateClientForRepo(string repoUrl)
@@ -276,4 +317,9 @@ public class GitLabHostingProvider : IGitHostingProvider
     private record GitLabCommit(
         [property: JsonProperty("author_name")] string AuthorName,
         [property: JsonProperty("author_email")] string? AuthorEmail);
+
+    private record GitLabUser(
+        [property: JsonProperty("username")] string? Username,
+        [property: JsonProperty("web_url")] string? WebUrl,
+        [property: JsonProperty("avatar_url")] string? AvatarUrl);
 }

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -30,7 +30,8 @@ public class GitLabHostingProvider : IGitHostingProvider
         if (!Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri))
             return false;
 
-        return _additionalHosts.Any(h => uri.Host.Equals(h, StringComparison.OrdinalIgnoreCase));
+        return _additionalHosts.Any(h => uri.Authority.Equals(h, StringComparison.OrdinalIgnoreCase)
+                                         || uri.Host.Equals(h, StringComparison.OrdinalIgnoreCase));
     }
 
     public (string Owner, string RepoName)? ParseRepository(string repoUrl)

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -3,7 +3,6 @@ using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
-using PluginBuilder.DataModels;
 
 namespace PluginBuilder.Services;
 
@@ -11,11 +10,6 @@ public class GitLabHostingProvider : IGitHostingProvider
 {
     private static readonly Regex HostRegex = new(
         @"^https?://(www\.)?gitlab\.com/", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    // GitLab supports nested groups: gitlab.com/group/subgroup/repo
-    private static readonly Regex RepoRegex = new(
-        @"^https://(www\.)?gitlab\.com/(.+?)(?:\.git)?/?$",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IEnumerable<string> _additionalHosts;
@@ -72,7 +66,7 @@ public class GitLabHostingProvider : IGitHostingProvider
         if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
             path = path[..^4];
 
-        var baseUrl = $"{uri.Scheme}://{uri.Host}/{path}";
+        var baseUrl = $"{uri.Scheme}://{uri.Authority}/{path}";
         var link = $"{baseUrl}/-/tree/{commit}";
         if (!string.IsNullOrEmpty(pluginDir))
             link += $"/{pluginDir}";
@@ -81,7 +75,7 @@ public class GitLabHostingProvider : IGitHostingProvider
 
     public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
     {
-        var client = _httpClientFactory.CreateClient(HttpClientNames.GitLab);
+        var client = CreateClientForRepo(repoUrl);
         var projectId = GetProjectId(repoUrl);
         var dir = string.IsNullOrWhiteSpace(pluginDir) ? "" : pluginDir.Trim('/');
 
@@ -141,7 +135,7 @@ public class GitLabHostingProvider : IGitHostingProvider
         if (repo == null)
             return new List<GitHubContributor>();
 
-        var client = _httpClientFactory.CreateClient(HttpClientNames.GitLab);
+        var client = CreateClientForRepo(repoUrl);
         var projectId = GetProjectId(repoUrl);
         var contributors = new Dictionary<string, GitHubContributor>(StringComparer.OrdinalIgnoreCase);
         int page = 1;
@@ -234,6 +228,17 @@ public class GitLabHostingProvider : IGitHostingProvider
                 // Best effort — skip if anything goes wrong
             }
         }
+    }
+
+    private HttpClient CreateClientForRepo(string repoUrl)
+    {
+        if (!Uri.TryCreate(repoUrl.Trim(), UriKind.Absolute, out var uri))
+            throw new BuildServiceException("Invalid repository URL");
+
+        var client = _httpClientFactory.CreateClient();
+        client.BaseAddress = new Uri($"{uri.Scheme}://{uri.Authority}/api/v4/");
+        client.DefaultRequestHeaders.Add("User-Agent", "PluginBuilder");
+        return client;
     }
 
     private static string GetProjectId(string repoUrl)

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -123,7 +123,15 @@ public class GitLabHostingProvider : IGitHostingProvider
             throw new BuildServiceException(
                 $"GitLab error downloading '{csprojs[0].Name}' (HTTP {(int)fileResp.StatusCode}).\nBody: {csprojBody}");
 
-        var doc = XDocument.Parse(csprojBody);
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(csprojBody);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            throw new BuildServiceException($"Failed to parse '{csprojs[0].Name}' as XML: {ex.Message}");
+        }
         var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].Name);
 
         return assemblyName;

--- a/PluginBuilder/Services/IGitHostingProvider.cs
+++ b/PluginBuilder/Services/IGitHostingProvider.cs
@@ -1,0 +1,12 @@
+using PluginBuilder.APIModels;
+
+namespace PluginBuilder.Services;
+
+public interface IGitHostingProvider
+{
+    bool CanHandle(string repoUrl);
+    Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null);
+    Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir);
+    string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir);
+    (string Owner, string RepoName)? ParseRepository(string repoUrl);
+}

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -1,3 +1,5 @@
+@using PluginBuilder.Services
+@inject GitHostingProviderFactory GitHostingProviderFactory
 @model List<PluginBuilder.APIModels.PublishedPlugin>?
 @{
     Layout = "_LayoutPublicModal";
@@ -95,7 +97,8 @@
         {
             @foreach (var plugin in Model)
             {
-                var owner = plugin.GetGithubRepository()?.Owner;
+                var owner = plugin.GetOwnerName(GitHostingProviderFactory);
+                var ownerProfileUrl = plugin.GetOwnerProfileUrl(GitHostingProviderFactory);
                 <div class="col-md-6 mb-4">
                     <div class="card h-100 plugin-card" data-type="community">
                         <div class="card-body">
@@ -116,7 +119,7 @@
 
                                         <div style="font-size: 0.875em; color: #6c757d;">
                                             <div style="margin-bottom: 3px;">
-                                                <span>by <a href="https://github.com/@owner" rel="noreferrer noopener" target="_blank">@owner</a></span>
+                                                <span>by @if (ownerProfileUrl != null) {<a href="@ownerProfileUrl" rel="noreferrer noopener" target="_blank">@owner</a>} else {@owner}</span>
                                             </div>
                                             <div>
                                                 Version: @plugin.Version - Published:

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -2,16 +2,18 @@
 @using PluginBuilder.APIModels
 @using PluginBuilder.Controllers
 @using PluginBuilder.DataModels
+@using PluginBuilder.Services
 @using System.Text.RegularExpressions
+@inject GitHostingProviderFactory GitHostingProviderFactory
 @model PluginDetailsViewModel
 @{
     Layout = "_LayoutPublicModal";
     var desc = string.IsNullOrWhiteSpace(Model.Plugin.Description) ? "Plugin for BTCPay Server" : Model.Plugin.Description;
     ViewData["Title"] = Model.Plugin.PluginTitle + " - " + desc;
-    var owner = Model.Plugin.GetGithubRepository()?.Owner;
+    var owner = Model.Plugin.GetOwnerName(GitHostingProviderFactory);
     var dependencies = Model.Plugin.ManifestInfo?["Dependencies"] as JArray;
 
-    var sourceUrl = Model.Plugin.GetGithubRepository()?.GetSourceUrl(Model.Plugin.BuildInfo?["gitCommit"]?.ToString(), Model.Plugin.BuildInfo?["pluginDir"]?.ToString());
+    var sourceUrl = Model.Plugin.GetSourceUrl(GitHostingProviderFactory);
     var pluginUrl = Url.Action(nameof(HomeController.GetPluginDetails), "Home", new { pluginSlug = Model.Plugin.ProjectSlug },
         Context.Request.Scheme, Context.Request.Host.ToString());
 

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -11,6 +11,7 @@
     var desc = string.IsNullOrWhiteSpace(Model.Plugin.Description) ? "Plugin for BTCPay Server" : Model.Plugin.Description;
     ViewData["Title"] = Model.Plugin.PluginTitle + " - " + desc;
     var owner = Model.Plugin.GetOwnerName(GitHostingProviderFactory);
+    var ownerProfileUrl = Model.Plugin.GetOwnerProfileUrl(GitHostingProviderFactory);
     var dependencies = Model.Plugin.ManifestInfo?["Dependencies"] as JArray;
 
     var sourceUrl = Model.Plugin.GetSourceUrl(GitHostingProviderFactory);
@@ -60,7 +61,7 @@
                         @if (!string.IsNullOrWhiteSpace(owner))
                         {
                             <span class="d-inline-flex align-items-center flex-wrap">
-                                by<a href="@Model.OwnerGithubUrl" rel="noreferrer noopener" target="_blank" class="ms-1">@owner</a>
+                                by @if (!string.IsNullOrWhiteSpace(ownerProfileUrl)) {<a href="@ownerProfileUrl" rel="noreferrer noopener" target="_blank" class="ms-1">@owner</a>} else {<span class="ms-1">@owner</span>}
 
                                 <span class="d-inline-flex align-items-center gap-2 ms-2 mb-1">
                                     @if (!string.IsNullOrWhiteSpace(Model.OwnerGithubUrl))

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -647,12 +647,29 @@
 									{
 											<div class="col-12 col-lg-6 d-flex align-items-center mb-3">
 												<div class="me-3 flex-shrink-0">
-													<img src="@user.AvatarUrl" class="rounded-circle"
-													 style="width: 48px; height: 48px;"
-													 alt="@user.Login avatar" loading="lazy" />
+													@if (!string.IsNullOrEmpty(user.AvatarUrl))
+													{
+														<img src="@user.AvatarUrl" class="rounded-circle"
+														 style="width: 48px; height: 48px;"
+														 alt="@user.Login avatar" loading="lazy" />
+													}
+													else
+													{
+														<div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center text-white fw-bold"
+														     style="width: 48px; height: 48px; font-size: 1.2rem;">
+															@user.Login?.FirstOrDefault()
+														</div>
+													}
 												</div>
 												<div class="text-break">
-													<a href="@user.HtmlUrl" class="text-decoration-none text-break" target="_blank" rel="noopener noreferrer">@user.Login</a>
+													@if (!string.IsNullOrEmpty(user.HtmlUrl))
+													{
+														<a href="@user.HtmlUrl" class="text-decoration-none text-break" target="_blank" rel="noopener noreferrer">@user.Login</a>
+													}
+													else
+													{
+														<span>@user.Login</span>
+													}
 											</div>
 										</div>
 									}


### PR DESCRIPTION
### Summary

Introduces an `IGitHostingProvider` abstraction so the plugin builder can work with multiple git hosts instead of being hardcoded to `GitHub`.

### What it looks like

- Extracted GitHub-specific logic (identifier extraction, contributor fetching, source links) into `GitHubHostingProvider`
- Added `GitLabHostingProvider` using GitLab's Repository Tree/Files/Commits APIs
- `GitHostingProviderFactory` picks the right provider based on the repo URL
- Views now generate correct source links and owner profiles for both hosts
- `GitHub` account verification stays GitHub-only

### What it looks like

A GitLab repo URL works the same as GitHub in the create-build flow, plugin details page, source links, and contributor snapshots. Source links use GitLab's /-/tree/ format. Nested GitLab groups (gitlab.com/a/b/c/repo) are handled correctly.

### Local tests

<img width="2186" height="189" alt="image" src="https://github.com/user-attachments/assets/45505ac2-0578-4e40-a570-3ad94a15f163" />

### Issue

Closes https://github.com/btcpayserver/btcpayserver-plugin-builder/issues/203
