### PR TITLE
Remove GPG dependency

### DIFF
--- a/PluginBuilder/PluginBuilder.Dockerfile
+++ b/PluginBuilder/PluginBuilder.Dockerfile
@@ -7,8 +7,8 @@ RUN useradd -r --create-home dotnet
 USER dotnet
 
 WORKDIR /build-tools
-ENV PLUGIN_PACKER_VERSION=https://github.com/btcpayserver/btcpayserver
-RUN git clone --depth 1 -b v2.3.6-rc5 --single-branch https://github.com/btcpayserver/btcpayserver && \
+ENV PLUGIN_PACKER_VERSION=https://github.com/teamssUTXO/btcpayserver
+RUN git clone --depth 1 -b remove-gpg --single-branch https://github.com/teamssUTXO/btcpayserver && \
     cd btcpayserver/BTCPayServer.PluginPacker && \
     dotnet build -c Release -o "/build-tools/PluginPacker" && \
     rm -rf /build-tools/btcpayserver

--- a/PluginBuilder/PluginBuilder.Dockerfile
+++ b/PluginBuilder/PluginBuilder.Dockerfile
@@ -7,8 +7,8 @@ RUN useradd -r --create-home dotnet
 USER dotnet
 
 WORKDIR /build-tools
-ENV PLUGIN_PACKER_VERSION=https://github.com/teamssUTXO/btcpayserver
-RUN git clone --depth 1 -b remove-gpg --single-branch https://github.com/teamssUTXO/btcpayserver && \
+ENV PLUGIN_PACKER_VERSION=https://github.com/btcpayserver/btcpayserver
+RUN git clone --depth 1 -b v2.3.6-rc5 --single-branch https://github.com/btcpayserver/btcpayserver && \
     cd btcpayserver/BTCPayServer.PluginPacker && \
     dotnet build -c Release -o "/build-tools/PluginPacker" && \
     rm -rf /build-tools/btcpayserver

--- a/PluginBuilder/PluginBuilder.Dockerfile
+++ b/PluginBuilder/PluginBuilder.Dockerfile
@@ -7,8 +7,8 @@ RUN useradd -r --create-home dotnet
 USER dotnet
 
 WORKDIR /build-tools
-ENV PLUGIN_PACKER_VERSION=https://github.com/btcpayserver/btcpayserver
-RUN git clone --depth 1 -b v2.3.6-rc5 --single-branch https://github.com/btcpayserver/btcpayserver && \
+ARG PLUGIN_PACKER_VERSION=v2.4.0
+RUN git clone --depth 1 -b "$PLUGIN_PACKER_VERSION" --single-branch https://github.com/btcpayserver/btcpayserver && \
     cd btcpayserver/BTCPayServer.PluginPacker && \
     dotnet build -c Release -o "/build-tools/PluginPacker" && \
     rm -rf /build-tools/btcpayserver

--- a/PluginBuilder/entrypoint.sh
+++ b/PluginBuilder/entrypoint.sh
@@ -31,8 +31,18 @@ ASSEMBLY_NAME="${ASSEMBLY_NAME/.csproj/}"
 
 # PluginPacker crash because of no gpg, but we don't use it anyway...
 /build-tools/PluginPacker/BTCPayServer.PluginPacker "/tmp/publish" "${ASSEMBLY_NAME}" "/tmp/publish-package" || true
-cp /tmp/publish-package/*/*/*btcpay /out
-cp /tmp/publish-package/*/*/*btcpay.json /out
+shopt -s nullglob
+btcpay_files=(/tmp/publish-package/*/*/*.btcpay)
+metadata_files=(/tmp/publish-package/*/*/*.btcpay.json)
+shopt -u nullglob
+if (( ${#btcpay_files[@]} == 0 )); then
+  echo "No .btcpay artifacts were produced" >&2
+  exit 1
+fi
+cp "${btcpay_files[@]}" /out
+if (( ${#metadata_files[@]} > 0 )); then
+  cp "${metadata_files[@]}" /out
+fi
 
 BUILD_DATE=$(date --iso-8601=seconds --utc)
 # To UTC

--- a/PluginBuilder/entrypoint.sh
+++ b/PluginBuilder/entrypoint.sh
@@ -29,8 +29,7 @@ shopt -u nullglob
 dotnet publish "${ASSEMBLY_NAME}" -c "${BUILD_CONFIG}" -o "/tmp/publish"
 ASSEMBLY_NAME="${ASSEMBLY_NAME/.csproj/}"
 
-# PluginPacker crash because of no gpg, but we don't use it anyway...
-/build-tools/PluginPacker/BTCPayServer.PluginPacker "/tmp/publish" "${ASSEMBLY_NAME}" "/tmp/publish-package" || true
+/build-tools/PluginPacker/BTCPayServer.PluginPacker "/tmp/publish" "${ASSEMBLY_NAME}" "/tmp/publish-package"
 shopt -s nullglob
 btcpay_files=(/tmp/publish-package/*/*/*.btcpay)
 metadata_files=(/tmp/publish-package/*/*/*.btcpay.json)
@@ -39,10 +38,12 @@ if (( ${#btcpay_files[@]} == 0 )); then
   echo "No .btcpay artifacts were produced" >&2
   exit 1
 fi
-cp "${btcpay_files[@]}" /out
-if (( ${#metadata_files[@]} > 0 )); then
-  cp "${metadata_files[@]}" /out
+if (( ${#metadata_files[@]} == 0 )); then
+  echo "No .btcpay.json metadata files were produced" >&2
+  exit 1
 fi
+cp "${btcpay_files[@]}" /out
+cp "${metadata_files[@]}" /out
 
 BUILD_DATE=$(date --iso-8601=seconds --utc)
 # To UTC

--- a/PluginBuilder/entrypoint.sh
+++ b/PluginBuilder/entrypoint.sh
@@ -32,7 +32,7 @@ ASSEMBLY_NAME="${ASSEMBLY_NAME/.csproj/}"
 # PluginPacker crash because of no gpg, but we don't use it anyway...
 /build-tools/PluginPacker/BTCPayServer.PluginPacker "/tmp/publish" "${ASSEMBLY_NAME}" "/tmp/publish-package" || true
 cp /tmp/publish-package/*/*/* /out
-rm /out/SHA256SUMS.asc /out/SHA256SUMS
+rm -f /out/SHA256SUMS.asc /out/SHA256SUMS
 
 BUILD_DATE=$(date --iso-8601=seconds --utc)
 # To UTC

--- a/PluginBuilder/entrypoint.sh
+++ b/PluginBuilder/entrypoint.sh
@@ -31,8 +31,8 @@ ASSEMBLY_NAME="${ASSEMBLY_NAME/.csproj/}"
 
 # PluginPacker crash because of no gpg, but we don't use it anyway...
 /build-tools/PluginPacker/BTCPayServer.PluginPacker "/tmp/publish" "${ASSEMBLY_NAME}" "/tmp/publish-package" || true
-cp /tmp/publish-package/*/*/* /out
-rm -f /out/SHA256SUMS.asc /out/SHA256SUMS
+cp /tmp/publish-package/*/*/*btcpay /out
+cp /tmp/publish-package/*/*/*btcpay.json /out
 
 BUILD_DATE=$(date --iso-8601=seconds --utc)
 # To UTC


### PR DESCRIPTION
This pull request makes a minor change, due to the removal of the GPG dependency, in the `entrypoint.sh` file in the `PluginBuilder`.

Changed the `rm` command to use the `-f` (force) flag when removing `/out/SHA256SUMS.asc` and `/out/SHA256SUMS` to prevent errors if the files do not exist because without the GPG, `SHA256SUMS.asc` shouldn't be created at all. 

Fixes #202 