### PR TITLE
add Unlisted badge to plugin cards in public directory search results

### DIFF
--- a/PluginBuilder/APIModels/PublishedVersion.cs
+++ b/PluginBuilder/APIModels/PublishedVersion.cs
@@ -39,6 +39,7 @@ public class PublishedPlugin : PublishedVersion
         get => BuildInfo?["pluginDir"]?.ToString();
     }
 
+    public bool IsUnlisted { get; set; }
     public PluginRatingSummary RatingSummary { get; set; } = new();
 
     public string GetSourceUrl(GitHostingProviderFactory providerFactory)

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -230,6 +230,7 @@ public class HomeController(
                        lv.plugin_slug,
                        lv.ver,
                        p.settings,
+                       p.visibility,
                        b.id,
                        b.manifest_info,
                        b.build_info,
@@ -278,7 +279,7 @@ public class HomeController(
         }
 
         var rows = await conn
-            .QueryAsync<(string plugin_slug, int[] ver, string settings, long id, string manifest_info, string build_info, decimal avg_rating, int total_reviews
+            .QueryAsync<(string plugin_slug, int[] ver, string settings, string visibility, long id, string manifest_info, string build_info, decimal avg_rating, int total_reviews
                 )>(
                 query,
                 new
@@ -304,6 +305,7 @@ public class HomeController(
                 BuildInfo = JObject.Parse(r.build_info),
                 ManifestInfo = manifestInfo,
                 PluginLogo = settings?.Logo,
+                IsUnlisted = r.visibility == "unlisted",
                 RatingSummary = new PluginRatingSummary
                 {
                     Average = r.avg_rating,

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -279,7 +279,7 @@ public class HomeController(
         }
 
         var rows = await conn
-            .QueryAsync<(string plugin_slug, int[] ver, string settings, string visibility, long id, string manifest_info, string build_info, decimal avg_rating, int total_reviews
+            .QueryAsync<(string plugin_slug, int[] ver, string settings, PluginVisibilityEnum visibility, long id, string manifest_info, string build_info, decimal avg_rating, int total_reviews
                 )>(
                 query,
                 new
@@ -305,7 +305,7 @@ public class HomeController(
                 BuildInfo = JObject.Parse(r.build_info),
                 ManifestInfo = manifestInfo,
                 PluginLogo = settings?.Logo,
-                IsUnlisted = r.visibility == "unlisted",
+                IsUnlisted = r.visibility == PluginVisibilityEnum.Unlisted,
                 RatingSummary = new PluginRatingSummary
                 {
                     Average = r.avg_rating,

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -102,6 +102,12 @@
                 <div class="col-md-6 mb-4">
                     <div class="card h-100 plugin-card" data-type="community">
                         <div class="card-body">
+                            @if (plugin.IsUnlisted)
+                            {
+                                <div class="position-absolute top-0 end-0 mt-3 me-3 d-flex flex-wrap justify-content-end gap-2">
+                                    <span class="badge fw-normal text-muted bg-medium rounded-pill px-2 py-1" title="This plugin is only shown in search results">Unlisted</span>
+                                </div>
+                            }
                             <div class="row">
                                 <div style="display: flex; align-items: flex-start; margin-bottom: 20px;">
                                     <div style="margin-right: 15px;">
@@ -111,10 +117,6 @@
                                         <h3 style="margin-top: 0; margin-bottom: 5px;">
                                             <a asp-action="GetPluginDetails"
                                                asp-route-pluginSlug="@plugin.ProjectSlug">@plugin.PluginTitle</a>
-                                            @if (plugin.IsUnlisted)
-                                            {
-                                                <span class="badge bg-secondary ms-2" title="This plugin is not publicly listed">Unlisted</span>
-                                            }
                                         </h3>
 
                                         <p style="margin-bottom: 5px;">

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -111,6 +111,10 @@
                                         <h3 style="margin-top: 0; margin-bottom: 5px;">
                                             <a asp-action="GetPluginDetails"
                                                asp-route-pluginSlug="@plugin.ProjectSlug">@plugin.PluginTitle</a>
+                                            @if (plugin.IsUnlisted)
+                                            {
+                                                <span class="badge bg-secondary ms-2" title="This plugin is not publicly listed">Unlisted</span>
+                                            }
                                         </h3>
 
                                         <p style="margin-bottom: 5px;">


### PR DESCRIPTION
● Title:
  feat: add Unlisted badge to plugin cards in public directory search results

  Body:
  Fixes #213

  ## Summary
  - Added `p.visibility` to the SQL query in `AllPlugins` so the visibility state is available in the mapped model
  - Added `IsUnlisted` property to `PublishedPlugin`
  - Renders a grey "Unlisted" badge next to the plugin title on cards where `IsUnlisted` is true

  ## Behaviour
  - Listed plugins: no change
  - Unlisted plugins: show a small "Unlisted" badge when they appear in search results