### PR TITLE
Add embedded plugin directory mode

### DIFF
--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Dapper;
 using Microsoft.Playwright;
 using Microsoft.Playwright.Xunit;
 using PluginBuilder.DataModels;
@@ -123,6 +124,104 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         Assert.Contains("embed=1", finalUrl);
         Assert.Contains("btcpayVersion=2.3.6", finalUrl);
         Assert.Contains("includePreRelease=true", finalUrl);
+    }
+
+    [Fact]
+    public async Task PluginDetails_PreReleaseInstall_ConfirmsBeforePostingEmbedInstallRequest()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        var ownerId = await tester.Server.CreateFakeUserAsync("pre-release-details-owner@x.com", confirmEmail: true, githubVerified: true);
+        const string slug = "plugin-details-pre-release";
+        var fullBuildId = await tester.Server.CreateAndBuildPluginAsync(ownerId, slug);
+
+        await using (var conn = await tester.Server.GetService<DBConnectionFactory>().Open())
+        {
+            var manifestInfo = await conn.QuerySingleAsync<string>(
+                "SELECT manifest_info FROM builds WHERE plugin_slug = @pluginSlug AND id = @buildId",
+                new { pluginSlug = slug, buildId = fullBuildId.BuildId });
+            var manifest = PluginManifest.Parse(manifestInfo);
+            await conn.SetVersionBuild(fullBuildId, manifest.Version, manifest.BTCPayMinVersion, manifest.BTCPayMaxVersion, false);
+
+            await conn.ExecuteAsync(
+                """
+                INSERT INTO versions (plugin_slug, ver, build_id, btcpay_min_ver, btcpay_max_ver, pre_release)
+                VALUES (@pluginSlug, @version, @buildId, @btcpayMinVer, @btcpayMaxVer, TRUE)
+                """,
+                new
+                {
+                    pluginSlug = slug,
+                    version = PluginVersion.Parse("1.0.3.0").VersionParts,
+                    buildId = fullBuildId.BuildId,
+                    btcpayMinVer = manifest.BTCPayMinVersion?.VersionParts ?? PluginVersion.Zero.VersionParts,
+                    btcpayMaxVer = manifest.BTCPayMaxVersion?.VersionParts
+                });
+        }
+
+        var embedOrigin = tester.ServerUri!.GetLeftPart(UriPartial.Authority);
+        var detailsUrl = new Uri(tester.ServerUri!, $"/public/plugins/{slug}?btcpayVersion=1.4.6.0&includePreRelease=true&embed=1&sort=helpful&count=10");
+
+        await tester.GoToUrl("/");
+        await tester.Page!.SetContentAsync($"""
+                                            <iframe id="details" src="{detailsUrl}"></iframe>
+                                            """);
+        await tester.Page.WaitForFunctionAsync("""
+                                               () => document.querySelector('#details')?.contentWindow?.document?.querySelector('[data-embed-page="details"]')
+                                               """);
+        await tester.Page.EvaluateAsync("""
+                                        () => {
+                                            window.__installMessages = [];
+                                            window.addEventListener('message', event => {
+                                                if (event.data?.type === 'pb:install-requested') {
+                                                    window.__installMessages.push(event.data);
+                                                }
+                                            });
+                                        }
+                                        """);
+        await tester.Page.EvaluateAsync($$"""
+                                        () => document.querySelector('#details').contentWindow.postMessage({
+                                            type: 'btcpay:host-context',
+                                            colorMode: 'light'
+                                        }, '{{embedOrigin}}')
+                                        """);
+
+        var frame = tester.Page.FrameLocator("#details");
+        var versionButton = frame.Locator("#version-dropdown-btn");
+        await Expect(versionButton).ToContainTextAsync("1.0.3");
+        await Expect(frame.Locator("#btcpay-install-plugin-btn")).ToHaveTextAsync("Install in BTCPay Server");
+
+        await frame.Locator("#btcpay-install-plugin-btn").ClickAsync();
+        await Expect(frame.Locator("#pre-release-confirm-modal")).ToBeVisibleAsync();
+        Assert.Equal(0, await tester.Page.EvaluateAsync<int>("() => window.__installMessages.length"));
+
+        await frame.Locator("#pre-release-confirm-continue").ClickAsync();
+        await tester.Page.WaitForFunctionAsync("() => window.__installMessages.length === 1");
+        var installMessageJson = await tester.Page.EvaluateAsync<string>("() => JSON.stringify(window.__installMessages[0])");
+        Assert.Contains("\"version\":\"1.0.3.0\"", installMessageJson);
+        Assert.Contains("\"preRelease\":true", installMessageJson);
+
+        await versionButton.ClickAsync();
+        var versionMenu = frame.Locator("#version-dropdown-btn").Locator("xpath=following-sibling::ul[contains(@class, 'dropdown-menu')][1]");
+        var releaseItem = versionMenu.Locator("a.dropdown-item").Filter(new LocatorFilterOptions { HasText = "1.0.2" });
+
+        Assert.DoesNotContain("pre-release", await versionMenu.InnerTextAsync(), StringComparison.OrdinalIgnoreCase);
+
+        await releaseItem.ClickAsync();
+        var finalUrlHandle = await tester.Page.WaitForFunctionAsync("""
+                                                                    () => {
+                                                                        const href = document.querySelector('#details')?.contentWindow?.location?.href || '';
+                                                                        return href.includes('version=1.0.2.0') ? href : false;
+                                                                    }
+                                                                    """);
+        var finalUrl = await finalUrlHandle.JsonValueAsync<string>();
+
+        Assert.Contains("btcpayVersion=1.4.6.0", finalUrl);
+        Assert.Contains("includePreRelease=true", finalUrl);
+        Assert.Contains("embed=1", finalUrl);
+        Assert.Contains("sort=helpful", finalUrl);
+        Assert.Contains("count=10", finalUrl);
     }
 
     [Fact]

--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -93,6 +93,8 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         await tester.Server.CreateAndBuildPluginAsync(ownerId, firstSlug);
         await tester.Server.CreateAndBuildPluginAsync(ownerId, secondSlug);
 
+        var embedOrigin = tester.ServerUri!.GetLeftPart(UriPartial.Authority);
+        await tester.GoToUrl("/");
         var detailsUrl = new Uri(tester.ServerUri!, $"/public/plugins/{firstSlug}?embed=1&btcpayVersion=2.3.6&includePreRelease=true");
         await tester.Page!.SetContentAsync($"""
                                             <iframe id="details" src="{detailsUrl}"></iframe>
@@ -106,7 +108,7 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
                                         () => document.querySelector('#details').contentWindow.postMessage({
                                             type: 'btcpay:host-context',
                                             selectedSlug: '{{secondSlug}}'
-                                        }, window.location.origin)
+                                        }, '{{embedOrigin}}')
                                         """);
 
         var finalUrlHandle = await tester.Page.WaitForFunctionAsync($$"""

--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -97,15 +97,9 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         var embedOrigin = tester.ServerUri!.GetLeftPart(UriPartial.Authority);
         await tester.GoToUrl("/");
         var detailsUrl = new Uri(tester.ServerUri!, $"/public/plugins/{firstSlug}?embed=1&btcpayVersion=2.3.6&includePreRelease=true");
-        await tester.Page!.SetContentAsync($"""
-                                            <iframe id="details" src="{detailsUrl}"></iframe>
-                                            """);
+        await LoadEmbedHostAsync(tester.Page!, detailsUrl, embedOrigin);
 
-        await tester.Page.WaitForFunctionAsync("""
-                                               () => document.querySelector('#details')?.contentWindow?.document?.querySelector('[data-embed-page="details"]')
-                                               """);
-
-        await tester.Page.EvaluateAsync($$"""
+        await tester.Page!.EvaluateAsync($$"""
                                         () => document.querySelector('#details').contentWindow.postMessage({
                                             type: 'btcpay:host-context',
                                             selectedSlug: '{{secondSlug}}'
@@ -164,13 +158,8 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         var detailsUrl = new Uri(tester.ServerUri!, $"/public/plugins/{slug}?btcpayVersion=1.4.6.0&includePreRelease=true&embed=1&sort=helpful&count=10");
 
         await tester.GoToUrl("/");
-        await tester.Page!.SetContentAsync($"""
-                                            <iframe id="details" src="{detailsUrl}"></iframe>
-                                            """);
-        await tester.Page.WaitForFunctionAsync("""
-                                               () => document.querySelector('#details')?.contentWindow?.document?.querySelector('[data-embed-page="details"]')
-                                               """);
-        await tester.Page.EvaluateAsync("""
+        await LoadEmbedHostAsync(tester.Page!, detailsUrl, embedOrigin);
+        await tester.Page!.EvaluateAsync("""
                                         () => {
                                             window.__installMessages = [];
                                             window.addEventListener('message', event => {
@@ -434,5 +423,24 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         // Test 6: Ensure trailing period is NOT part of the link
         Assert.DoesNotContain("r0ckstardev.</a>", innerHTML);
         Assert.Contains("r0ckstardev</a>.", innerHTML);
+    }
+
+    private static async Task LoadEmbedHostAsync(IPage page, Uri detailsUrl, string embedOrigin)
+    {
+        await page.SetContentAsync($$"""
+                                   <script>
+                                       window.__embedReady = false;
+                                       window.addEventListener('message', event => {
+                                           if (event.source === document.querySelector('#details')?.contentWindow &&
+                                               event.origin === '{{embedOrigin}}' &&
+                                               event.data?.type === 'pb:ready') {
+                                               window.__embedReady = true;
+                                           }
+                                       });
+                                   </script>
+                                   <iframe id="details" src="{{detailsUrl}}"></iframe>
+                                   """);
+
+        await page.WaitForFunctionAsync("() => window.__embedReady === true");
     }
 }

--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -81,6 +81,49 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
     }
 
     [Fact]
+    public async Task PluginDetails_EmbedSelection_PreservesCompatibilityQuery()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        var ownerId = await tester.Server.CreateFakeUserAsync("embed-selection-owner@x.com", confirmEmail: true, githubVerified: true);
+        const string firstSlug = "embed-select-a";
+        const string secondSlug = "embed-select-b";
+        await tester.Server.CreateAndBuildPluginAsync(ownerId, firstSlug);
+        await tester.Server.CreateAndBuildPluginAsync(ownerId, secondSlug);
+
+        var detailsUrl = new Uri(tester.ServerUri!, $"/public/plugins/{firstSlug}?embed=1&btcpayVersion=2.3.6&includePreRelease=true");
+        await tester.Page!.SetContentAsync($"""
+                                            <iframe id="details" src="{detailsUrl}"></iframe>
+                                            """);
+
+        await tester.Page.WaitForFunctionAsync("""
+                                               () => document.querySelector('#details')?.contentWindow?.document?.querySelector('[data-embed-page="details"]')
+                                               """);
+
+        await tester.Page.EvaluateAsync($$"""
+                                        () => document.querySelector('#details').contentWindow.postMessage({
+                                            type: 'btcpay:host-context',
+                                            selectedSlug: '{{secondSlug}}'
+                                        }, window.location.origin)
+                                        """);
+
+        var finalUrlHandle = await tester.Page.WaitForFunctionAsync($$"""
+                                                                       () => {
+                                                                           const href = document.querySelector('#details')?.contentWindow?.location?.href || '';
+                                                                           return href.includes('/public/plugins/{{secondSlug}}') ? href : false;
+                                                                       }
+                                                                       """);
+        var finalUrl = await finalUrlHandle.JsonValueAsync<string>();
+
+        Assert.Contains($"/public/plugins/{secondSlug}", finalUrl);
+        Assert.Contains("embed=1", finalUrl);
+        Assert.Contains("btcpayVersion=2.3.6", finalUrl);
+        Assert.Contains("includePreRelease=true", finalUrl);
+    }
+
+    [Fact]
     public async Task PluginDetails_Reviews_Flow_Works()
     {
         await using var tester = new PlaywrightTester(_log);

--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -15,6 +15,72 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
     private readonly XUnitLogger _log = new("PluginDetailsUITests", output);
 
     [Fact]
+    public async Task PluginDetails_NonEmbed_KeepsReviewsStackedUnderDescription()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        var ownerId = await tester.Server.CreateFakeUserAsync("layout-owner@x.com", confirmEmail: true, githubVerified: true);
+        const string slug = "plugin-details-layout";
+        await tester.Server.CreateAndBuildPluginAsync(ownerId, slug);
+
+        await tester.Page!.SetViewportSizeAsync(1600, 1000);
+        await tester.GoToUrl($"/public/plugins/{slug}");
+        await tester.AssertNoError();
+
+        var descriptionCard = tester.Page.Locator(".card").Filter(new LocatorFilterOptions { HasText = "Description" });
+        var detailsCard = tester.Page.Locator("#download-btn").Locator("xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' card ')][1]");
+        var reviewsCard = tester.Page.Locator("#reviews");
+
+        await Expect(descriptionCard).ToHaveCountAsync(1);
+        await Expect(detailsCard).ToHaveCountAsync(1);
+        await Expect(reviewsCard).ToHaveCountAsync(1);
+
+        var descriptionBox = await descriptionCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Description card was not visible.");
+        var detailsBox = await detailsCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Details card was not visible.");
+        var reviewsBox = await reviewsCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Reviews card was not visible.");
+
+        var reviewsGap = reviewsBox.Y - (descriptionBox.Y + descriptionBox.Height);
+        Assert.InRange(reviewsGap, 0, 80);
+        Assert.True(
+            reviewsBox.Y < detailsBox.Y + detailsBox.Height,
+            "Reviews should stack under the description column instead of waiting for the metadata card height.");
+    }
+
+    [Fact]
+    public async Task PluginDetails_EmbedNarrow_KeepsVersionBeforeReviews()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        var ownerId = await tester.Server.CreateFakeUserAsync("embed-layout-owner@x.com", confirmEmail: true, githubVerified: true);
+        const string slug = "plugin-details-embed-layout";
+        await tester.Server.CreateAndBuildPluginAsync(ownerId, slug);
+
+        await tester.Page!.SetViewportSizeAsync(700, 1000);
+        await tester.GoToUrl($"/public/plugins/{slug}?embed=1");
+        await tester.AssertNoError();
+
+        var descriptionCard = tester.Page.Locator(".plugin-details-description-card");
+        var detailsCard = tester.Page.Locator(".plugin-details-metadata-card");
+        var reviewsCard = tester.Page.Locator(".plugin-details-reviews-card");
+
+        await Expect(descriptionCard).ToHaveCountAsync(1);
+        await Expect(detailsCard).ToHaveCountAsync(1);
+        await Expect(reviewsCard).ToHaveCountAsync(1);
+        await Expect(tester.Page.Locator("#btcpay-install-plugin-btn")).ToHaveCountAsync(1);
+
+        var descriptionBox = await descriptionCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Description card was not visible.");
+        var detailsBox = await detailsCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Details card was not visible.");
+        var reviewsBox = await reviewsCard.BoundingBoxAsync() ?? throw new InvalidOperationException("Reviews card was not visible.");
+
+        Assert.True(descriptionBox.Y < detailsBox.Y, "Description should stay above metadata in embedded details.");
+        Assert.True(detailsBox.Y < reviewsBox.Y, "Metadata should stay above reviews in embedded details.");
+    }
+
+    [Fact]
     public async Task PluginDetails_Reviews_Flow_Works()
     {
         await using var tester = new PlaywrightTester(_log);

--- a/PluginBuilder.Tests/PublicTests/PublicDirectoryUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PublicDirectoryUITests.cs
@@ -18,6 +18,45 @@ public class PublicDirectoryUITests(ITestOutputHelper output) : PageTest
     private readonly XUnitLogger _log = new("PublicDirectoryUITests", output);
 
     [Fact]
+    public async Task PublicDirectory_EmbedLinks_PreserveCompatibilityQuery()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+        await using var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
+
+        var ownerId = await tester.Server.CreateFakeUserAsync(confirmEmail: true, githubVerified: true);
+        const string pluginSlug = "public-directory-embed-query";
+        var fullBuildId = await tester.Server.CreateAndBuildPluginAsync(ownerId, pluginSlug);
+
+        var manifestInfoJson = await conn.QuerySingleAsync<string>(
+            "SELECT manifest_info FROM builds WHERE plugin_slug = @PluginSlug AND id = @BuildId",
+            new { PluginSlug = pluginSlug, fullBuildId.BuildId });
+        var manifest = PluginManifest.Parse(manifestInfoJson);
+        await conn.SetVersionBuild(fullBuildId, manifest.Version, manifest.BTCPayMinVersion, manifest.BTCPayMaxVersion, false);
+        await conn.SetPluginSettings(pluginSlug, null, PluginVisibilityEnum.Listed);
+
+        await tester.GoToUrl("/public/plugins?embed=1&btcpayVersion=2.3.6-rc2&includePreRelease=true&sort=rating");
+        await tester.AssertNoError();
+
+        await Expect(tester.Page!.Locator("form input[name='btcpayVersion']")).ToHaveValueAsync("2.3.6-rc2");
+        await Expect(tester.Page.Locator("form input[name='includePreRelease']")).ToHaveValueAsync("true");
+
+        var detailsHref = await tester.Page.Locator($"a[data-plugin-slug='{pluginSlug}']").GetAttributeAsync("href");
+        Assert.NotNull(detailsHref);
+        Assert.Contains($"/public/plugins/{pluginSlug}", detailsHref);
+        Assert.Contains("embed=1", detailsHref);
+        Assert.Contains("btcpayVersion=2.3.6-rc2", detailsHref);
+        Assert.Contains("includePreRelease=true", detailsHref);
+
+        var alphaSortHref = await tester.Page.Locator("a.dropdown-item[href*='sort=alpha']").GetAttributeAsync("href");
+        Assert.NotNull(alphaSortHref);
+        Assert.Contains("embed=1", alphaSortHref);
+        Assert.Contains("btcpayVersion=2.3.6-rc2", alphaSortHref);
+        Assert.Contains("includePreRelease=true", alphaSortHref);
+    }
+
+    [Fact]
     public async Task PublicDirectory_RespectsPluginVisibility()
     {
         await using var tester = new PlaywrightTester(_log);

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -322,7 +322,12 @@ public class HomeController(
     public async Task<IActionResult> GetPluginDetails(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug,
-        [FromQuery] PluginDetailsViewModel? model)
+        [ModelBinder(typeof(PluginVersionModelBinder))]
+        PluginVersion? version = null,
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
+        PluginVersion? btcpayVersion = null,
+        bool includePreRelease = false,
+        [FromQuery] PluginDetailsViewModel? model = null)
     {
         if (pluginSlug is null)
             return NotFound();
@@ -341,9 +346,27 @@ public class HomeController(
             ? " (hv.up_count - hv.down_count) DESC, r.created_at DESC "
             : " r.created_at DESC ";
 
+        var versionFilter = version is null ? string.Empty : "AND v.ver = @version";
+        var versionSource = btcpayVersion is null
+            ? "versions v"
+            : "get_all_versions(@btcpayVersion, @includePreRelease) gv JOIN versions v ON v.plugin_slug = gv.plugin_slug AND v.ver = gv.ver";
+        var versionsQuery = btcpayVersion is null
+            ? """
+              SELECT array_agg(array_to_string(ver, '.') ORDER BY ver DESC)
+              FROM versions
+              WHERE plugin_slug = v.plugin_slug
+              """
+            : """
+              SELECT array_agg(array_to_string(gv.ver, '.') ORDER BY gv.ver DESC)
+              FROM get_all_versions(@btcpayVersion, @includePreRelease) gv
+              WHERE gv.plugin_slug = v.plugin_slug
+              """;
         var prms = new
         {
             pluginSlug = pluginSlug.ToString(),
+            version = version?.VersionParts,
+            btcpayVersion = btcpayVersion?.VersionParts,
+            includePreRelease,
             currentUserId = userId,
             isAdmin,
             skip = model.Skip,
@@ -370,15 +393,12 @@ public class HomeController(
                              WHERE b2.plugin_slug = v.plugin_slug
                              ORDER BY b2.id ASC
                              LIMIT 1) AS created_at,
-                           (
-                             SELECT array_agg(array_to_string(ver, '.') ORDER BY ver DESC)
-                             FROM versions
-                             WHERE plugin_slug = v.plugin_slug
-                           ) AS versions
-                         FROM versions v
+                           (" + versionsQuery + @") AS versions
+                         FROM " + versionSource + @"
                          JOIN builds  b ON b.plugin_slug = v.plugin_slug AND b.id = v.build_id
                          JOIN plugins p ON b.plugin_slug = p.slug
                          WHERE v.plugin_slug = @pluginSlug
+                           " + versionFilter + @"
                            AND b.manifest_info IS NOT NULL
                            AND b.build_info  IS NOT NULL
                            AND (

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -361,6 +361,18 @@ public class HomeController(
               FROM get_all_versions(@btcpayVersion, @includePreRelease) gv
               WHERE gv.plugin_slug = v.plugin_slug
               """;
+        var versionPreReleasesQuery = btcpayVersion is null
+            ? """
+              SELECT array_agg(pre_release ORDER BY ver DESC)
+              FROM versions
+              WHERE plugin_slug = v.plugin_slug
+              """
+            : """
+              SELECT array_agg(vv.pre_release ORDER BY gv.ver DESC)
+              FROM get_all_versions(@btcpayVersion, @includePreRelease) gv
+              JOIN versions vv ON vv.plugin_slug = gv.plugin_slug AND vv.ver = gv.ver
+              WHERE gv.plugin_slug = v.plugin_slug
+              """;
         var prms = new
         {
             pluginSlug = pluginSlug.ToString(),
@@ -393,7 +405,8 @@ public class HomeController(
                              WHERE b2.plugin_slug = v.plugin_slug
                              ORDER BY b2.id ASC
                              LIMIT 1) AS created_at,
-                           (" + versionsQuery + @") AS versions
+                           (" + versionsQuery + @") AS versions,
+                           (" + versionPreReleasesQuery + @") AS version_pre_releases
                          FROM " + versionSource + @"
                          JOIN builds  b ON b.plugin_slug = v.plugin_slug AND b.id = v.build_id
                          JOIN plugins p ON b.plugin_slug = p.slug
@@ -465,7 +478,15 @@ public class HomeController(
         var pluginDetails = await multi.ReadFirstOrDefaultAsync<dynamic>();
         if (pluginDetails is null)
             return NotFound();
-        var versions = pluginDetails.versions as IEnumerable<string> ?? Enumerable.Empty<string>();
+        var versionLabels = (pluginDetails.versions as IEnumerable<string> ?? Enumerable.Empty<string>()).ToList();
+        var versionPreReleases = (pluginDetails.version_pre_releases as IEnumerable<bool> ?? Enumerable.Empty<bool>()).ToList();
+        var versions = versionLabels
+            .Select((v, i) => new PluginDetailsVersionViewModel
+            {
+                Version = v,
+                PreRelease = i < versionPreReleases.Count && versionPreReleases[i]
+            })
+            .ToList();
 
         //second
         var summary = await multi.ReadFirstOrDefaultAsync<PluginRatingSummary>() ?? new PluginRatingSummary();
@@ -526,7 +547,7 @@ public class HomeController(
             Reviews = items,
             IsAdmin = isAdmin,
             IsOwner = userId != null && userId == primaryOwnerId,
-            PluginVersions = versions.ToList(),
+            PluginVersions = versions,
             ShowHiddenNotice = Enum.Parse<PluginVisibilityEnum>((string)pluginDetails.visibility, true) == PluginVisibilityEnum.Hidden,
             Contributors = pluginContributors,
             RatingFilter = model.RatingFilter,

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -511,7 +511,8 @@ public class HomeController(
             Contributors = pluginContributors,
             RatingFilter = model.RatingFilter,
             OwnerGithubUrl = ownerGithubUrl,
-            OwnerNostrUrl = ownerNostrUrl
+            OwnerNostrUrl = ownerNostrUrl,
+            EmbedMode = string.Equals(Request.Query["embed"], "1", StringComparison.Ordinal)
         };
         return View(vm);
     }
@@ -520,7 +521,7 @@ public class HomeController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpsertReview(
         [ModelBinder(typeof(PluginSlugModelBinder))]
-        PluginSlug pluginSlug, int rating, string? body, string? pluginVersion)
+        PluginSlug pluginSlug, int rating, string? body, string? pluginVersion, string? embed = null)
     {
         if (rating is < 1 or > 5)
             return BadRequest("Invalid rating");
@@ -535,7 +536,7 @@ public class HomeController(
         if (isOwner)
         {
             TempData[TempDataConstant.WarningMessage] = "You cannot review your own plugin.";
-            return RedirectToAction(nameof(GetPluginDetails), "Home", new { pluginSlug = pluginSlug.ToString() });
+            return RedirectToAction(nameof(GetPluginDetails), "Home", new { pluginSlug = pluginSlug.ToString(), embed = string.IsNullOrEmpty(embed) ? null : embed });
         }
 
         var reviewerAccountDetails = await conn.GetAccountDetailSettings(userId) ?? new AccountSettings();
@@ -560,7 +561,12 @@ public class HomeController(
         await conn.UpsertPluginReview(reviewViewModel);
 
         var sort = Request.Query["sort"].ToString();
-        var url = Url.Action(nameof(GetPluginDetails), "Home", new { pluginSlug = pluginSlug.ToString(), sort = string.IsNullOrEmpty(sort) ? null : sort });
+        var url = Url.Action(nameof(GetPluginDetails), "Home", new
+        {
+            pluginSlug = pluginSlug.ToString(),
+            sort = string.IsNullOrEmpty(sort) ? null : sort,
+            embed = string.IsNullOrEmpty(embed) ? null : embed
+        });
         return Redirect((url ?? "/") + "#reviews");
     }
 
@@ -620,7 +626,8 @@ public class HomeController(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug,
         long id,
-        bool isHelpful)
+        bool isHelpful,
+        string? embed = null)
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -637,7 +644,11 @@ public class HomeController(
         if (!ok)
             TempData[TempDataConstant.WarningMessage] = "Error while updating review helpful vote";
 
-        var url = Url.Action(nameof(GetPluginDetails), new { pluginSlug = pluginSlug.ToString() });
+        var url = Url.Action(nameof(GetPluginDetails), new
+        {
+            pluginSlug = pluginSlug.ToString(),
+            embed = string.IsNullOrEmpty(embed) ? null : embed
+        });
         return Redirect((url ?? "/") + "#reviews");
     }
 
@@ -646,7 +657,8 @@ public class HomeController(
     public async Task<IActionResult> DeleteReview(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug,
-        long id)
+        long id,
+        string? embed = null)
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -661,7 +673,11 @@ public class HomeController(
         if (!ok)
             TempData[TempDataConstant.WarningMessage] = "Error while deleting review";
 
-        var url = Url.Action(nameof(GetPluginDetails), new { pluginSlug = pluginSlug.ToString() });
+        var url = Url.Action(nameof(GetPluginDetails), new
+        {
+            pluginSlug = pluginSlug.ToString(),
+            embed = string.IsNullOrEmpty(embed) ? null : embed
+        });
         return Redirect((url ?? "/") + "#reviews");
     }
 

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -210,8 +210,8 @@ public class HomeController(
     [HttpGet("public/plugins")]
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> AllPlugins(
-        [ModelBinder(typeof(PluginVersionModelBinder))]
-        PluginVersion? btcpayVersion = null, string? searchPluginName = null, string sort = "smart")
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
+        PluginVersion? btcpayVersion = null, bool includePreRelease = false, string? searchPluginName = null, string sort = "smart")
     {
         searchPluginName = searchPluginName.StripControlCharacters();
 
@@ -285,7 +285,7 @@ public class HomeController(
                 new
                 {
                     btcpayVersion = btcpayVersion?.VersionParts,
-                    includePreRelease = false,
+                    includePreRelease,
                     searchPattern = $"%{searchPluginName}%",
                     hasSearchTerm = !string.IsNullOrWhiteSpace(searchPluginName)
                 });

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -562,7 +562,7 @@ public class HomeController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpsertReview(
         [ModelBinder(typeof(PluginSlugModelBinder))]
-        PluginSlug pluginSlug, int rating, string? body, string? pluginVersion, string? embed = null)
+        PluginSlug pluginSlug, int rating, string? body, string? pluginVersion)
     {
         if (rating is < 1 or > 5)
             return BadRequest("Invalid rating");
@@ -577,7 +577,7 @@ public class HomeController(
         if (isOwner)
         {
             TempData[TempDataConstant.WarningMessage] = "You cannot review your own plugin.";
-            return RedirectToAction(nameof(GetPluginDetails), "Home", new { pluginSlug = pluginSlug.ToString(), embed = string.IsNullOrEmpty(embed) ? null : embed });
+            return RedirectToAction(nameof(GetPluginDetails), "Home", new { pluginSlug = pluginSlug.ToString() });
         }
 
         var reviewerAccountDetails = await conn.GetAccountDetailSettings(userId) ?? new AccountSettings();
@@ -605,8 +605,7 @@ public class HomeController(
         var url = Url.Action(nameof(GetPluginDetails), "Home", new
         {
             pluginSlug = pluginSlug.ToString(),
-            sort = string.IsNullOrEmpty(sort) ? null : sort,
-            embed = string.IsNullOrEmpty(embed) ? null : embed
+            sort = string.IsNullOrEmpty(sort) ? null : sort
         });
         return Redirect((url ?? "/") + "#reviews");
     }
@@ -667,8 +666,7 @@ public class HomeController(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug,
         long id,
-        bool isHelpful,
-        string? embed = null)
+        bool isHelpful)
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -687,8 +685,7 @@ public class HomeController(
 
         var url = Url.Action(nameof(GetPluginDetails), new
         {
-            pluginSlug = pluginSlug.ToString(),
-            embed = string.IsNullOrEmpty(embed) ? null : embed
+            pluginSlug = pluginSlug.ToString()
         });
         return Redirect((url ?? "/") + "#reviews");
     }
@@ -698,8 +695,7 @@ public class HomeController(
     public async Task<IActionResult> DeleteReview(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug,
-        long id,
-        string? embed = null)
+        long id)
     {
         var userId = userManager.GetUserId(User);
         if (string.IsNullOrEmpty(userId))
@@ -716,8 +712,7 @@ public class HomeController(
 
         var url = Url.Action(nameof(GetPluginDetails), new
         {
-            pluginSlug = pluginSlug.ToString(),
-            embed = string.IsNullOrEmpty(embed) ? null : embed
+            pluginSlug = pluginSlug.ToString()
         });
         return Redirect((url ?? "/") + "#reviews");
     }

--- a/PluginBuilder/ViewModels/Home/PluginDetailsViewModel.cs
+++ b/PluginBuilder/ViewModels/Home/PluginDetailsViewModel.cs
@@ -24,6 +24,7 @@ public sealed class PluginDetailsViewModel : BasePagingViewModel
 
     public string? OwnerGithubUrl { get; set; }
     public string? OwnerNostrUrl { get; set; }
+    public bool EmbedMode { get; set; }
 }
 
 public class Review

--- a/PluginBuilder/ViewModels/Home/PluginDetailsViewModel.cs
+++ b/PluginBuilder/ViewModels/Home/PluginDetailsViewModel.cs
@@ -17,7 +17,7 @@ public sealed class PluginDetailsViewModel : BasePagingViewModel
 
     public bool IsAdmin { get; set; }
     public bool? IsOwner { get; set; }
-    public List<string>? PluginVersions { get; set; }
+    public List<PluginDetailsVersionViewModel> PluginVersions { get; set; } = new();
     public bool ShowHiddenNotice { get; set; }
     public List<GitHubContributor> Contributors { get; init; } = new();
     public int? RatingFilter { get; set; }
@@ -25,6 +25,12 @@ public sealed class PluginDetailsViewModel : BasePagingViewModel
     public string? OwnerGithubUrl { get; set; }
     public string? OwnerNostrUrl { get; set; }
     public bool EmbedMode { get; set; }
+}
+
+public sealed class PluginDetailsVersionViewModel
+{
+    public string Version { get; init; } = "";
+    public bool PreRelease { get; init; }
 }
 
 public class Review

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -6,6 +6,8 @@
     const string title = "BTCPay Server Plugin Directory";
     const string desc = "Extend and customize your BTCPay Server with community and official plugins.";
     ViewData["Title"] = title;
+    var embedMode = Context.Request.Query["embed"] == "1";
+    var embedRoute = embedMode ? "1" : null;
 
     var currentSearch = Context.Request.Query["searchPluginName"].ToString();
     var currentSort = (string?)Context.Request.Query["sort"] ?? "smart";
@@ -18,6 +20,7 @@
         "alpha" => "Alphabetical",
         _ => "Relevance"
     };
+    var containerClass = embedMode ? "container-fluid px-0 plugin-directory-embed" : "container";
 }
 
 @section Meta {
@@ -35,17 +38,72 @@
 
 <partial name="_PublicHeader" />
 
-<div class="container">
-    <div class="row mb-4">
-        <div class="col-12 text-center">
-            <h3 class="display-5 fw-bold">BTCPay Server Plugin Directory</h3>
-            <p class="text-muted">Extend and customize your BTCPay Server with community and official plugins.</p>
+@if (embedMode)
+{
+    <style>
+        .plugin-directory-embed {
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        .plugin-directory-embed .plugin-directory-toolbar {
+            margin-bottom: 1.25rem;
+            margin-left: 0;
+            margin-right: 0;
+        }
+
+        .plugin-directory-embed .plugin-directory-toolbar > * {
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        .plugin-directory-embed .plugin-directory-list {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 1.5rem;
+            margin-left: 0;
+            margin-right: 0;
+            margin-bottom: 0;
+        }
+
+        .plugin-directory-embed .plugin-directory-list > * {
+            width: auto;
+            max-width: none;
+            margin-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+        }
+
+        .plugin-directory-embed [data-plugin-directory-empty-state] {
+            grid-column: 1 / -1;
+        }
+
+        @@media (max-width: 767.98px) {
+            .plugin-directory-embed .plugin-directory-list {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+}
+
+<div class="@containerClass" data-embed-page="list">
+    @if (!embedMode)
+    {
+        <div class="row mb-4">
+            <div class="col-12 text-center">
+                <h3 class="display-5 fw-bold">BTCPay Server Plugin Directory</h3>
+                <p class="text-muted">Extend and customize your BTCPay Server with community and official plugins.</p>
+            </div>
         </div>
-    </div>
-    <div class="row mb-4">
+    }
+    <div class="row plugin-directory-toolbar mb-4">
         <div>
             <form asp-action="AllPlugins" method="get" class="d-flex flex-wrap flex-sm-nowrap align-items-center gap-3">
                 <input type="hidden" name="sort" value="@currentSort" />
+                @if (embedMode)
+                {
+                    <input type="hidden" name="embed" value="1" />
+                }
 
                 <input type="text"
                        name="searchPluginName"
@@ -66,24 +124,28 @@
                         <a class="dropdown-item @(currentSort == "smart" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-embed="@embedRoute"
                            asp-route-sort="smart">
                             Relevance
                         </a>
                         <a class="dropdown-item @(currentSort == "rating" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-embed="@embedRoute"
                            asp-route-sort="rating">
                             Highest rated
                         </a>
                         <a class="dropdown-item @(currentSort == "recent" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-embed="@embedRoute"
                            asp-route-sort="recent">
                             Most recent
                         </a>
                         <a class="dropdown-item @(currentSort == "alpha" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-embed="@embedRoute"
                            asp-route-sort="alpha">
                             Alphabetical
                         </a>
@@ -92,14 +154,15 @@
             </form>
         </div>
     </div>
-    <div class="row">
+    <div class="row plugin-directory-list">
         @if (Model != null && Model.Any())
         {
             @foreach (var plugin in Model)
             {
                 var owner = plugin.GetOwnerName(GitHostingProviderFactory);
                 var ownerProfileUrl = plugin.GetOwnerProfileUrl(GitHostingProviderFactory);
-                <div class="col-md-6 mb-4">
+                var pluginIdentifier = plugin.ManifestInfo?["Identifier"]?.ToString();
+                <div class="col-md-6 mb-4" data-plugin-card data-plugin-identifier="@pluginIdentifier">
                     <div class="card h-100 plugin-card" data-type="community">
                         <div class="card-body">
                             @if (plugin.IsUnlisted)
@@ -116,6 +179,9 @@
                                     <div>
                                         <h3 style="margin-top: 0; margin-bottom: 5px;">
                                             <a asp-action="GetPluginDetails"
+                                               asp-route-embed="@embedRoute"
+                                               data-plugin-slug="@plugin.ProjectSlug"
+                                               data-plugin-identifier="@plugin.ManifestInfo?["Identifier"]?.ToString()"
                                                asp-route-pluginSlug="@plugin.ProjectSlug">@plugin.PluginTitle</a>
                                         </h3>
 
@@ -159,9 +225,19 @@
         {
             <div class="col-12 text-center py-5">
                 <h4>No plugins available yet</h4>
-                <p class="text-muted">Check back later, or
-                    <a asp-action="Login" asp-controller="Home" class="text-success text-decoration-none">login to upload one</a>
-                </p>
+                @if (!embedMode)
+                {
+                    <p class="text-muted">Check back later, or
+                        <a asp-action="Login" asp-controller="Home" class="text-success text-decoration-none">login to upload one</a>
+                    </p>
+                }
+            </div>
+        }
+
+        @if (embedMode && Model != null && Model.Any())
+        {
+            <div class="col-12 text-center py-5" data-plugin-directory-empty-state hidden>
+                <h4>All compatible plugins from the public directory are already installed or disabled on this server.</h4>
             </div>
         }
     </div>

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -11,6 +11,10 @@
 
     var currentSearch = Context.Request.Query["searchPluginName"].ToString();
     var currentSort = (string?)Context.Request.Query["sort"] ?? "smart";
+    var currentBtcpayVersion = Context.Request.Query["btcpayVersion"].ToString();
+    var currentIncludePreRelease = Context.Request.Query["includePreRelease"].ToString();
+    var btcpayVersionRoute = string.IsNullOrEmpty(currentBtcpayVersion) ? null : currentBtcpayVersion;
+    var includePreReleaseRoute = string.IsNullOrEmpty(currentIncludePreRelease) ? null : currentIncludePreRelease;
     if (string.IsNullOrEmpty(currentSort)) currentSort = "smart";
 
     var sortLabel = currentSort switch
@@ -55,6 +59,14 @@
                 {
                     <input type="hidden" name="embed" value="1" />
                 }
+                @if (!string.IsNullOrEmpty(currentBtcpayVersion))
+                {
+                    <input type="hidden" name="btcpayVersion" value="@currentBtcpayVersion" />
+                }
+                @if (!string.IsNullOrEmpty(currentIncludePreRelease))
+                {
+                    <input type="hidden" name="includePreRelease" value="@currentIncludePreRelease" />
+                }
 
                 <input type="text"
                        name="searchPluginName"
@@ -75,6 +87,8 @@
                         <a class="dropdown-item @(currentSort == "smart" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-btcpayVersion="@btcpayVersionRoute"
+                           asp-route-includePreRelease="@includePreReleaseRoute"
                            asp-route-embed="@embedRoute"
                            asp-route-sort="smart">
                             Relevance
@@ -82,6 +96,8 @@
                         <a class="dropdown-item @(currentSort == "rating" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-btcpayVersion="@btcpayVersionRoute"
+                           asp-route-includePreRelease="@includePreReleaseRoute"
                            asp-route-embed="@embedRoute"
                            asp-route-sort="rating">
                             Highest rated
@@ -89,6 +105,8 @@
                         <a class="dropdown-item @(currentSort == "recent" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-btcpayVersion="@btcpayVersionRoute"
+                           asp-route-includePreRelease="@includePreReleaseRoute"
                            asp-route-embed="@embedRoute"
                            asp-route-sort="recent">
                             Most recent
@@ -96,6 +114,8 @@
                         <a class="dropdown-item @(currentSort == "alpha" ? "active" : "")"
                            asp-action="AllPlugins"
                            asp-route-searchPluginName="@currentSearch"
+                           asp-route-btcpayVersion="@btcpayVersionRoute"
+                           asp-route-includePreRelease="@includePreReleaseRoute"
                            asp-route-embed="@embedRoute"
                            asp-route-sort="alpha">
                             Alphabetical
@@ -132,6 +152,8 @@
                                         <h3 style="margin-top: 0; margin-bottom: 5px;">
                                             <a asp-action="GetPluginDetails"
                                                asp-route-embed="@embedRoute"
+                                               asp-route-btcpayVersion="@btcpayVersionRoute"
+                                               asp-route-includePreRelease="@includePreReleaseRoute"
                                                data-plugin-slug="@plugin.ProjectSlug"
                                                data-plugin-identifier="@plugin.ManifestInfo?["Identifier"]?.ToString()"
                                                asp-route-pluginSlug="@plugin.ProjectSlug">@plugin.PluginTitle</a>

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -20,7 +20,6 @@
         "alpha" => "Alphabetical",
         _ => "Relevance"
     };
-    var containerClass = embedMode ? "container-fluid px-0 plugin-directory-embed" : "container";
 }
 
 @section Meta {
@@ -38,55 +37,7 @@
 
 <partial name="_PublicHeader" />
 
-@if (embedMode)
-{
-    <style>
-        .plugin-directory-embed {
-            padding-left: 0;
-            padding-right: 0;
-        }
-
-        .plugin-directory-embed .plugin-directory-toolbar {
-            margin-bottom: 1.25rem;
-            margin-left: 0;
-            margin-right: 0;
-        }
-
-        .plugin-directory-embed .plugin-directory-toolbar > * {
-            padding-left: 0;
-            padding-right: 0;
-        }
-
-        .plugin-directory-embed .plugin-directory-list {
-            display: grid;
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: 1.5rem;
-            margin-left: 0;
-            margin-right: 0;
-            margin-bottom: 0;
-        }
-
-        .plugin-directory-embed .plugin-directory-list > * {
-            width: auto;
-            max-width: none;
-            margin-bottom: 0;
-            padding-left: 0;
-            padding-right: 0;
-        }
-
-        .plugin-directory-embed [data-plugin-directory-empty-state] {
-            grid-column: 1 / -1;
-        }
-
-        @@media (max-width: 767.98px) {
-            .plugin-directory-embed .plugin-directory-list {
-                grid-template-columns: 1fr;
-            }
-        }
-    </style>
-}
-
-<div class="@containerClass" data-embed-page="list">
+<div class="@(embedMode ? "container-fluid px-0" : "container")" data-embed-page="list">
     @if (!embedMode)
     {
         <div class="row mb-4">
@@ -96,8 +47,8 @@
             </div>
         </div>
     }
-    <div class="row plugin-directory-toolbar mb-4">
-        <div>
+    <div class="@(embedMode ? "mb-4" : "row mb-4")">
+        <div class="@(embedMode ? "" : "col-12")">
             <form asp-action="AllPlugins" method="get" class="d-flex flex-wrap flex-sm-nowrap align-items-center gap-3">
                 <input type="hidden" name="sort" value="@currentSort" />
                 @if (embedMode)
@@ -154,7 +105,8 @@
             </form>
         </div>
     </div>
-    <div class="row plugin-directory-list">
+    <div class="@(embedMode ? "overflow-hidden" : "")">
+        <div class="@(embedMode ? "row row-cols-1 row-cols-md-2 g-4 mb-0" : "row")">
         @if (Model != null && Model.Any())
         {
             @foreach (var plugin in Model)
@@ -162,7 +114,7 @@
                 var owner = plugin.GetOwnerName(GitHostingProviderFactory);
                 var ownerProfileUrl = plugin.GetOwnerProfileUrl(GitHostingProviderFactory);
                 var pluginIdentifier = plugin.ManifestInfo?["Identifier"]?.ToString();
-                <div class="col-md-6 mb-4" data-plugin-card data-plugin-identifier="@pluginIdentifier">
+                <div class="@(embedMode ? "col" : "col-md-6 mb-4")" data-plugin-card data-plugin-identifier="@pluginIdentifier">
                     <div class="card h-100 plugin-card" data-type="community">
                         <div class="card-body">
                             @if (plugin.IsUnlisted)
@@ -240,5 +192,6 @@
                 <h4>All compatible plugins from the public directory are already installed or disabled on this server.</h4>
             </div>
         }
+        </div>
     </div>
 </div>

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -7,11 +7,17 @@
     Layout = "_LayoutPublicModal";
     var desc = string.IsNullOrWhiteSpace(Model.Plugin.Description) ? "Plugin for BTCPay Server" : Model.Plugin.Description;
     ViewData["Title"] = Model.Plugin.PluginTitle + " - " + desc;
+    var embedRoute = Model.EmbedMode ? "1" : null;
+    var pluginIdentifier = Model.Plugin.ManifestInfo?["Identifier"]?.ToString();
     var owner = Model.Plugin.GetGithubRepository()?.Owner;
     var dependencies = Model.Plugin.ManifestInfo?["Dependencies"] as JArray;
     var sourceUrl = Model.Plugin.GetGithubRepository()?.GetSourceUrl(Model.Plugin.BuildInfo?["gitCommit"]?.ToString(), Model.Plugin.BuildInfo?["pluginDir"]?.ToString());
     var pluginUrl = Url.Action(nameof(HomeController.GetPluginDetails), "Home", new { pluginSlug = Model.Plugin.ProjectSlug }, Context.Request.Scheme, Context.Request.Host.ToString());
+    var writeReviewUrl = Model.EmbedMode ? $"{pluginUrl}#write-review" : "#write-review";
+    var writeReviewTarget = Model.EmbedMode ? "_blank" : null;
+    var writeReviewRel = Model.EmbedMode ? "noopener noreferrer" : null;
     var currentRating = Model.RatingFilter;
+    var containerClass = Model.EmbedMode ? "container-fluid px-0 plugin-directory-embed" : "container";
     DateTimeOffset.TryParse(Model.Plugin.BuildInfo?["buildDate"]?.ToString(), out var buildDate);
 
     var videoEmbedUrl = Model.Plugin.VideoUrl.GetVideoEmbedUrl();
@@ -45,6 +51,16 @@
 
 <partial name="_PublicHeader" />
 
+@if (Model.EmbedMode)
+{
+    <style>
+        .plugin-directory-embed {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    </style>
+}
+
 @if (Model.ShowHiddenNotice)
 {
     <div id="hidden-plugin-alert" class="alert alert-warning text-center mb-4" role="alert">
@@ -52,7 +68,10 @@
     </div>
 }
 
-<div class="container">
+<div class="@containerClass"
+     data-embed-page="details"
+     data-plugin-slug="@Model.Plugin.ProjectSlug"
+     data-plugin-identifier="@pluginIdentifier">
     <div class="row mb-4">
         <div class="col-12">
             <div class="rounded p-4" style="background: linear-gradient(135deg, var(--btcpay-body-bg) 0%, var(--btcpay-body-bg-medium) 100%);">
@@ -168,7 +187,7 @@
                 <div class="card-body">
                     <div class="d-flex align-items-center mb-3">
                         <h4 class="mb-0">Reviews</h4>
-                        <a class="btn btn-primary btn-sm ms-auto" href="#write-review">Write a review</a>
+                        <a class="btn btn-primary btn-sm ms-auto" href="@writeReviewUrl" target="@writeReviewTarget" rel="@writeReviewRel">Write a review</a>
                     </div>
 
                     <div class="mb-3">
@@ -180,6 +199,7 @@
                             <a class="text-decoration-none text-reset d-block"
                                asp-action="GetPluginDetails" asp-controller="Home"
                                asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                               asp-route-embed="@embedRoute"
                                asp-route-sort="@Model.Sort" asp-route-skip="0" asp-route-count="@Model.Count"
                                asp-route-RatingFilter="@(isActive ? null : star)" asp-fragment="reviews">
                                 <div class="d-flex align-items-center gap-2 mb-1 py-1 hover-bg @(isActive ? "bg-light border rounded px-2" : "")">
@@ -209,11 +229,13 @@
                                 <a class="dropdown-item @(Model.Sort == "newest" ? "active" : null)"
                                    asp-action="GetPluginDetails" asp-controller="Home"
                                    asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-sort="newest"
+                                   asp-route-embed="@embedRoute"
                                    asp-route-skip="0" asp-route-count="@Model.Count"
                                    asp-route-RatingFilter="@Model.RatingFilter" asp-fragment="reviews">Newest</a>
                                 <a class="dropdown-item @(Model.Sort == "helpful" ? "active" : null)"
                                    asp-action="GetPluginDetails" asp-controller="Home"
                                    asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-sort="helpful"
+                                   asp-route-embed="@embedRoute"
                                    asp-route-skip="0" asp-route-count="@Model.Count"
                                    asp-route-RatingFilter="@Model.RatingFilter" asp-fragment="reviews">Most helpful</a>
                             </div>
@@ -223,7 +245,7 @@
                     @if (!Model.Reviews.Any())
                     {
                         <div class="text-muted">
-                            No reviews yet. <a class="text-success fw-semibold text-decoration-none hover-underline" href="#write-review">Be the first to write one</a>.
+                            No reviews yet. <a class="text-success fw-semibold text-decoration-none hover-underline" href="@writeReviewUrl" target="@writeReviewTarget" rel="@writeReviewRel">Be the first to write one</a>.
                         </div>
                     }
                     else
@@ -278,13 +300,13 @@
                                         }
                                         else
                                         {
-                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-isHelpful="true" class="test-upvote-form d-inline">
+                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-embed="@embedRoute" asp-route-isHelpful="true" class="test-upvote-form d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <button type="submit" class="@voteBtn vote-up @(review.UserVoteHelpful == true ? "text-success" : "text-secondary")" aria-label="Mark this review as helpful">
                                                     <vc:icon symbol="thumb-up" /><span class="small ms-1">@review.UpCount</span>
                                                 </button>
                                             </form>
-                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-isHelpful="false" class="test-downvote-form d-inline">
+                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-embed="@embedRoute" asp-route-isHelpful="false" class="test-downvote-form d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <button type="submit" class="@voteBtn vote-down @(review.UserVoteHelpful == false ? "text-danger" : "text-secondary")" aria-label="Mark this review as not helpful">
                                                     <vc:icon symbol="thumb-down" /><span class="small ms-1">@review.DownCount</span>
@@ -306,7 +328,7 @@
                                         <button type="button" class="btn btn-link btn-sm p-0 text-danger align-self-start ms-2"
                                                 title="Delete" aria-label="Delete review"
                                                 data-bs-toggle="modal" data-bs-target="#ConfirmModal"
-                                                data-action='@Url.EnsureLocal(Url.Action("DeleteReview", "Home", new { pluginSlug = Model.Plugin.ProjectSlug, id = review.Id }), Context.Request)'
+                                                data-action='@Url.EnsureLocal(Url.Action("DeleteReview", "Home", new { pluginSlug = Model.Plugin.ProjectSlug, id = review.Id, embed = embedRoute }), Context.Request)'
                                                 data-title="Delete review"
                                                 data-description="Delete this review? This action cannot be undone."
                                                 data-confirm="Delete">
@@ -330,7 +352,7 @@
                         }
                         else
                         {
-                            <form id="review-form" method="post" asp-action="UpsertReview" asp-controller="Home" asp-route-pluginSlug="@Model.Plugin.ProjectSlug">
+                            <form id="review-form" method="post" asp-action="UpsertReview" asp-controller="Home" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-embed="@embedRoute">
                                 @Html.AntiForgeryToken()
                                 <div id="ratingStars" class="d-inline-flex align-items-center gap-1 fs-4 mb-3" role="radiogroup" aria-label="Rating (1 to 5)" tabindex="0">
                                     @for (var i = 1; i <= 5; i++)
@@ -349,9 +371,12 @@
                     }
                     else
                     {
-                        <div class="alert bg-info text-white">
-                            Please <a class="text-white text-decoration-underline fw-semibold" asp-action="Login" asp-controller="Home">sign in</a> to write a review.
-                        </div>
+                        @if (!Model.EmbedMode)
+                        {
+                            <div class="alert bg-info text-white">
+                                Please <a class="text-white text-decoration-underline fw-semibold" asp-action="Login" asp-controller="Home">sign in</a> to write a review.
+                            </div>
+                        }
                     }
                 </div>
             </div>
@@ -440,11 +465,14 @@
                             </span>
                         </div>
                     </div>
-                    <a id="download-btn"
-                       asp-action="Download" asp-controller="Api"
-                       asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
-                       asp-route-version="@Model.Plugin.Version"
-                       class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
+                    @if (!Model.EmbedMode)
+                    {
+                        <a id="download-btn"
+                           asp-action="Download" asp-controller="Api"
+                           asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                           asp-route-version="@Model.Plugin.Version"
+                           class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
+                    }
                 </div>
             </div>
 

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -60,6 +60,18 @@
     </div>
 }
 
+@if (Model.EmbedMode)
+{
+    <style>
+        @@media (max-width: 991.98px) {
+            /* Let cards from both columns share the same Bootstrap order in narrow embeds. */
+            body.embed-mode .plugin-details-main > .plugin-details-column {
+                display: contents;
+            }
+        }
+    </style>
+}
+
 <div class="@containerClass"
      data-embed-page="details"
      data-plugin-slug="@Model.Plugin.ProjectSlug"
@@ -100,123 +112,18 @@
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-12 col-lg-8">
-            <div class="card">
+    <div class="row plugin-details-main @(Model.EmbedMode ? "gx-0 gx-lg-4" : null)">
+        <div class="col-12 col-lg-8 plugin-details-column">
+            <div class="card plugin-details-description-card @(Model.EmbedMode ? "col-12 order-1" : null)">
                 <div class="card-body">
                     <h4>Description</h4>
                     <p>@Model.Plugin.Description</p>
                 </div>
             </div>
-        </div>
 
-        <div class="col-12 col-lg-4 mt-4 mt-lg-0">
-            <div class="card">
-                <div class="card-body">
-                    <div class="row mb-3">
-                        <div class="col-6 d-flex align-items-center"><strong>Version</strong></div>
-                        <div class="col-6 text-end">
-                            <div class="dropdown d-inline-block">
-                                <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
-                                        data-bs-toggle="dropdown" aria-expanded="false">
-                                    @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
-                                    @foreach (var v in Model.PluginVersions)
-                                    {
-                                        var shortV = string.Join(".", v.Split('.').Take(3));
-                                        <li>
-                                            <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
-                                            href="#" data-version="@v" data-display="@shortV">@shortV</a>
-                                        </li>
-                                    }
-                                </ul>
-                            </div>
-                            <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
-                        </div>
-                    </div>
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Published</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-published-date">@(buildDate != default ? buildDate.ToString("MMM dd, yyyy") : "")</span>
-                        </div>
-                    </div>
-                    <div id="plugin-repository-row" class="row mb-3 @(string.IsNullOrEmpty(sourceUrl) ? "d-none" : "")">
-                        <div class="col-6"><strong>Repository</strong></div>
-                        <div class="col-6 text-end">
-                            <a id="plugin-source-url" href="@sourceUrl" target="_blank" rel="noopener noreferrer">View Source</a>
-                        </div>
-                    </div>
-                    @if (!string.IsNullOrEmpty(Model.Plugin.Documentation))
-                    {
-                        <div class="row mb-3">
-                            <div class="col-6"><strong>Documentation</strong></div>
-                            <div class="col-6 text-end">
-                                <a href="@Model.Plugin.Documentation" target="_blank" rel="noopener noreferrer">View Documentation</a>
-                            </div>
-                        </div>
-                    }
-                    <div id="plugin-min-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMinVersion) ? "d-none" : "")">
-                        <div class="col-6"><strong>Min. BTCPay Version</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-min-btcpay-version">@Model.Plugin.BTCPayMinVersion</span>
-                        </div>
-                    </div>
-                    <div id="plugin-max-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMaxVersion) ? "d-none" : "")">
-                        <div class="col-6"><strong>Max. BTCPay Version</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-max-btcpay-version">@Model.Plugin.BTCPayMaxVersion</span>
-                        </div>
-                    </div>
-                    @if (dependencies != null)
-                    {
-                        foreach (var dep in dependencies)
-                        {
-                            if (string.Equals(dep["Identifier"]?.ToString(), "BTCPayServer", StringComparison.OrdinalIgnoreCase)) continue;
-                            <div class="row mb-3">
-                                <div class="col-6"><strong>@dep["Identifier"]</strong></div>
-                                <div class="col-6 text-end">@dep["Condition"]</div>
-                            </div>
-                        }
-                    }
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Created</strong></div>
-                        <div class="col-6 text-end">@Model.Plugin.CreatedDate.ToString("MMM dd, yyyy")</div>
-                    </div>
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Rating</strong></div>
-                        <div class="col-6 text-end">
-                            <span class="d-inline-flex align-items-center gap-1 lh-1">
-                                <span class="fw-semibold">@((Model.Plugin.RatingSummary?.Average ?? 0m).ToString("0.0"))</span>
-                                <span class="text-warning"><vc:icon symbol="star-fill" /></span>
-                                <span class="text-muted small">(@(Model.Plugin.RatingSummary?.TotalReviews ?? 0))</span>
-                            </span>
-                        </div>
-                    </div>
-                    @if (!Model.EmbedMode)
-                    {
-                        <a id="download-btn"
-                           asp-action="Download" asp-controller="Api"
-                           asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
-                           asp-route-version="@Model.Plugin.Version"
-                           class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
-                    }
-                    else
-                    {
-                        <button type="button"
-                                id="btcpay-install-plugin-btn"
-                                class="btn btn-primary w-100"
-                                data-plugin-install
-                                disabled="@(string.IsNullOrWhiteSpace(pluginIdentifier) ? "disabled" : null)">Install in BTCPay Server</button>
-                    }
-                </div>
-            </div>
-        </div>
-
-        <div class="col-12 col-lg-8">
             @if (mediaItems.Any())
             {
-                <div class="card mt-4">
+                <div class="card mt-4 @(Model.EmbedMode ? "col-12 order-3" : null)">
                     <div class="card-body">
                         <h4 class="mb-3">Media</h4>
                         <div id="plugin-media-carousel" class="plugin-media-carousel" tabindex="0" aria-label="Plugin media carousel">
@@ -280,7 +187,7 @@
                 </div>
             }
 
-            <div class="card mt-4" id="reviews">
+            <div class="card mt-4 plugin-details-reviews-card @(Model.EmbedMode ? "col-12 order-4" : null)" id="reviews">
                 <div class="card-body">
                     <div class="d-flex align-items-center mb-3">
                         <h4 class="mb-0">Reviews</h4>
@@ -488,16 +395,118 @@
             </div>
         </div>
 
-        <div class="col-12 col-lg-4">
-            <div class="card mt-4 @(string.IsNullOrEmpty(Model.Plugin.Changelog) ? "d-none" : "")" id="plugin-changelog-card">
+        <div class="col-12 col-lg-4 mt-4 mt-lg-0 plugin-details-column">
+            <div class="card plugin-details-metadata-card @(Model.EmbedMode ? "col-12 order-2 mt-4 mt-lg-0" : null)">
+                <div class="card-body">
+                    <div class="row mb-3">
+                        <div class="col-6 d-flex align-items-center"><strong>Version</strong></div>
+                        <div class="col-6 text-end">
+                            <div class="dropdown d-inline-block">
+                                <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                    @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
+                                    @foreach (var v in Model.PluginVersions)
+                                    {
+                                        var shortV = string.Join(".", v.Split('.').Take(3));
+                                        <li>
+                                            <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
+                                            href="#" data-version="@v" data-display="@shortV">@shortV</a>
+                                        </li>
+                                    }
+                                </ul>
+                            </div>
+                            <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Published</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-published-date">@(buildDate != default ? buildDate.ToString("MMM dd, yyyy") : "")</span>
+                        </div>
+                    </div>
+                    <div id="plugin-repository-row" class="row mb-3 @(string.IsNullOrEmpty(sourceUrl) ? "d-none" : "")">
+                        <div class="col-6"><strong>Repository</strong></div>
+                        <div class="col-6 text-end">
+                            <a id="plugin-source-url" href="@sourceUrl" target="_blank" rel="noopener noreferrer">View Source</a>
+                        </div>
+                    </div>
+                    @if (!string.IsNullOrEmpty(Model.Plugin.Documentation))
+                    {
+                        <div class="row mb-3">
+                            <div class="col-6"><strong>Documentation</strong></div>
+                            <div class="col-6 text-end">
+                                <a href="@Model.Plugin.Documentation" target="_blank" rel="noopener noreferrer">View Documentation</a>
+                            </div>
+                        </div>
+                    }
+                    <div id="plugin-min-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMinVersion) ? "d-none" : "")">
+                        <div class="col-6"><strong>Min. BTCPay Version</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-min-btcpay-version">@Model.Plugin.BTCPayMinVersion</span>
+                        </div>
+                    </div>
+                    <div id="plugin-max-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMaxVersion) ? "d-none" : "")">
+                        <div class="col-6"><strong>Max. BTCPay Version</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-max-btcpay-version">@Model.Plugin.BTCPayMaxVersion</span>
+                        </div>
+                    </div>
+                    @if (dependencies != null)
+                    {
+                        foreach (var dep in dependencies)
+                        {
+                            if (string.Equals(dep["Identifier"]?.ToString(), "BTCPayServer", StringComparison.OrdinalIgnoreCase)) continue;
+                            <div class="row mb-3">
+                                <div class="col-6"><strong>@dep["Identifier"]</strong></div>
+                                <div class="col-6 text-end">@dep["Condition"]</div>
+                            </div>
+                        }
+                    }
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Created</strong></div>
+                        <div class="col-6 text-end">@Model.Plugin.CreatedDate.ToString("MMM dd, yyyy")</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Rating</strong></div>
+                        <div class="col-6 text-end">
+                            <span class="d-inline-flex align-items-center gap-1 lh-1">
+                                <span class="fw-semibold">@((Model.Plugin.RatingSummary?.Average ?? 0m).ToString("0.0"))</span>
+                                <span class="text-warning"><vc:icon symbol="star-fill" /></span>
+                                <span class="text-muted small">(@(Model.Plugin.RatingSummary?.TotalReviews ?? 0))</span>
+                            </span>
+                        </div>
+                    </div>
+                    @if (!Model.EmbedMode)
+                    {
+                        <a id="download-btn"
+                           asp-action="Download" asp-controller="Api"
+                           asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                           asp-route-version="@Model.Plugin.Version"
+                           class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
+                    }
+                    else
+                    {
+                        <button type="button"
+                                id="btcpay-install-plugin-btn"
+                                class="btn btn-primary w-100"
+                                data-plugin-install
+                                disabled="@(string.IsNullOrWhiteSpace(pluginIdentifier) ? "disabled" : null)">Install in BTCPay Server</button>
+                    }
+                </div>
+            </div>
+
+            <div class="card mt-4 @(string.IsNullOrEmpty(Model.Plugin.Changelog) ? "d-none" : "") @(Model.EmbedMode ? "col-12 order-5" : null)" id="plugin-changelog-card">
                 <div class="card-body">
                     <h4>Release notes</h4>
                     <p id="plugin-changelog-text" class="small mb-0" style="white-space: pre-wrap;">@Model.Plugin.Changelog</p>
                 </div>
             </div>
+
             @if (Model.Contributors?.Any() == true)
             {
-                <div class="card mt-4">
+                <div class="card mt-4 @(Model.EmbedMode ? "col-12 order-5" : null)">
                     <div class="card-body">
                         <h4>Contributors</h4>
                         <div class="row">

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -17,7 +17,7 @@
     var writeReviewTarget = Model.EmbedMode ? "_blank" : null;
     var writeReviewRel = Model.EmbedMode ? "noopener noreferrer" : null;
     var currentRating = Model.RatingFilter;
-    var containerClass = Model.EmbedMode ? "container-fluid px-0 plugin-directory-embed" : "container";
+    var containerClass = Model.EmbedMode ? "container-fluid px-0" : "container";
     DateTimeOffset.TryParse(Model.Plugin.BuildInfo?["buildDate"]?.ToString(), out var buildDate);
 
     var videoEmbedUrl = Model.Plugin.VideoUrl.GetVideoEmbedUrl();
@@ -50,16 +50,6 @@
 }
 
 <partial name="_PublicHeader" />
-
-@if (Model.EmbedMode)
-{
-    <style>
-        .plugin-directory-embed {
-            padding-left: 0;
-            padding-right: 0;
-        }
-    </style>
-}
 
 @if (Model.ShowHiddenNotice)
 {

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -23,6 +23,8 @@
     var currentRating = Model.RatingFilter;
     var containerClass = Model.EmbedMode ? "container-fluid px-0" : "container";
     DateTimeOffset.TryParse(Model.Plugin.BuildInfo?["buildDate"]?.ToString(), out var buildDate);
+    var currentVersion = Model.PluginVersions.FirstOrDefault(v => v.Version == Model.Plugin.Version);
+    var currentShortVersion = string.Join(".", Model.Plugin.Version.Split('.').Take(3));
 
     var videoEmbedUrl = Model.Plugin.VideoUrl.GetVideoEmbedUrl();
     var videoThumbUrl = Model.Plugin.VideoUrl.GetVideoThumbnailUrl();
@@ -77,7 +79,8 @@
 <div class="@containerClass"
      data-embed-page="details"
      data-plugin-slug="@Model.Plugin.ProjectSlug"
-     data-plugin-identifier="@pluginIdentifier">
+     data-plugin-identifier="@pluginIdentifier"
+     data-plugin-pre-release="@((currentVersion?.PreRelease == true).ToString().ToLowerInvariant())">
     <div class="row mb-4">
         <div class="col-12">
             <div class="rounded p-4" style="background: linear-gradient(135deg, var(--btcpay-body-bg) 0%, var(--btcpay-body-bg-medium) 100%);">
@@ -406,18 +409,19 @@
                             <div class="dropdown d-inline-block">
                                 <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
                                         data-bs-toggle="dropdown" aria-expanded="false">
-                                    @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
+                                    @currentShortVersion
                                 </button>
                                 <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
                                     @foreach (var v in Model.PluginVersions)
                                     {
-                                        var shortV = string.Join(".", v.Split('.').Take(3));
+                                        var shortV = string.Join(".", v.Version.Split('.').Take(3));
                                         <li>
-                                            <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
+                                            <a class="dropdown-item @(v.Version == Model.Plugin.Version ? "active" : "")"
+                                               data-version="@v.Version"
                                                asp-action="GetPluginDetails"
                                                asp-controller="Home"
                                                asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
-                                               asp-route-version="@v"
+                                               asp-route-version="@v.Version"
                                                asp-route-btcpayVersion="@btcpayVersionRoute"
                                                asp-route-includePreRelease="@includePreReleaseRoute"
                                                asp-route-embed="@embedRoute"
@@ -496,6 +500,7 @@
                            asp-action="Download" asp-controller="Api"
                            asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
                            asp-route-version="@Model.Plugin.Version"
+                           data-pre-release-confirm="download"
                            class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
                     }
                     else
@@ -504,6 +509,7 @@
                                 id="btcpay-install-plugin-btn"
                                 class="btn btn-primary w-100"
                                 data-plugin-install
+                                data-pre-release-confirm="install"
                                 disabled="@(string.IsNullOrWhiteSpace(pluginIdentifier) ? "disabled" : null)">Install in BTCPay Server</button>
                     }
                 </div>
@@ -540,6 +546,29 @@
         </div>
     </div>
 </div>
+
+@if (currentVersion?.PreRelease == true)
+{
+    <div class="modal fade" id="pre-release-confirm-modal" tabindex="-1" aria-labelledby="pre-release-confirm-title" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title" id="pre-release-confirm-title">Pre-release version</h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                        <vc:icon symbol="close" />
+                    </button>
+                </div>
+                <div class="modal-body">
+                    This version is marked as pre-release and may be intended for testing. Continue only if you trust this plugin version.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="pre-release-confirm-continue">Continue</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
 
 <partial name="_Confirm" model="@(new ConfirmModel("Delete review", "Are you sure?", "Delete"))" />
 
@@ -601,6 +630,38 @@
         group.addEventListener('mouseover', e => { const b = e.target.closest('.star-btn'); if (b) render(b.dataset.value); });
         group.addEventListener('mouseleave', () => render(input.value));
         render(input.value);
+    })();
+
+    (() => {
+        const page = document.querySelector('[data-embed-page="details"]');
+        const modalEl = document.getElementById('pre-release-confirm-modal');
+        const continueButton = document.getElementById('pre-release-confirm-continue');
+        if (!page || page.dataset.pluginPreRelease !== 'true' || !modalEl || !continueButton) return;
+
+        let pendingAction = null;
+
+        document.addEventListener('click', event => {
+            const action = event.target.closest('[data-pre-release-confirm]');
+            if (!action || action.dataset.preReleaseConfirmed === 'true') {
+                if (action) delete action.dataset.preReleaseConfirmed;
+                return;
+            }
+
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            pendingAction = action;
+            window.bootstrap.Modal.getOrCreateInstance(modalEl).show();
+        }, true);
+
+        continueButton.addEventListener('click', () => {
+            if (!pendingAction) return;
+
+            pendingAction.dataset.preReleaseConfirmed = 'true';
+            const action = pendingAction;
+            pendingAction = null;
+            window.bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+            action.click();
+        });
     })();
 
 </script>

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -16,6 +16,8 @@
     var writeReviewUrl = Model.EmbedMode ? $"{pluginUrl}#write-review" : "#write-review";
     var writeReviewTarget = Model.EmbedMode ? "_blank" : null;
     var writeReviewRel = Model.EmbedMode ? "noopener noreferrer" : null;
+    var btcpayVersionRoute = Context.Request.Query["btcpayVersion"].ToString();
+    var includePreReleaseRoute = Context.Request.Query["includePreRelease"].ToString();
     var currentRating = Model.RatingFilter;
     var containerClass = Model.EmbedMode ? "container-fluid px-0" : "container";
     DateTimeOffset.TryParse(Model.Plugin.BuildInfo?["buildDate"]?.ToString(), out var buildDate);
@@ -106,7 +108,112 @@
                     <p>@Model.Plugin.Description</p>
                 </div>
             </div>
+        </div>
 
+        <div class="col-12 col-lg-4 mt-4 mt-lg-0">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row mb-3">
+                        <div class="col-6 d-flex align-items-center"><strong>Version</strong></div>
+                        <div class="col-6 text-end">
+                            <div class="dropdown d-inline-block">
+                                <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                    @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
+                                    @foreach (var v in Model.PluginVersions)
+                                    {
+                                        var shortV = string.Join(".", v.Split('.').Take(3));
+                                        <li>
+                                            <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
+                                            href="#" data-version="@v" data-display="@shortV">@shortV</a>
+                                        </li>
+                                    }
+                                </ul>
+                            </div>
+                            <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Published</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-published-date">@(buildDate != default ? buildDate.ToString("MMM dd, yyyy") : "")</span>
+                        </div>
+                    </div>
+                    <div id="plugin-repository-row" class="row mb-3 @(string.IsNullOrEmpty(sourceUrl) ? "d-none" : "")">
+                        <div class="col-6"><strong>Repository</strong></div>
+                        <div class="col-6 text-end">
+                            <a id="plugin-source-url" href="@sourceUrl" target="_blank" rel="noopener noreferrer">View Source</a>
+                        </div>
+                    </div>
+                    @if (!string.IsNullOrEmpty(Model.Plugin.Documentation))
+                    {
+                        <div class="row mb-3">
+                            <div class="col-6"><strong>Documentation</strong></div>
+                            <div class="col-6 text-end">
+                                <a href="@Model.Plugin.Documentation" target="_blank" rel="noopener noreferrer">View Documentation</a>
+                            </div>
+                        </div>
+                    }
+                    <div id="plugin-min-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMinVersion) ? "d-none" : "")">
+                        <div class="col-6"><strong>Min. BTCPay Version</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-min-btcpay-version">@Model.Plugin.BTCPayMinVersion</span>
+                        </div>
+                    </div>
+                    <div id="plugin-max-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMaxVersion) ? "d-none" : "")">
+                        <div class="col-6"><strong>Max. BTCPay Version</strong></div>
+                        <div class="col-6 text-end">
+                            <span id="plugin-max-btcpay-version">@Model.Plugin.BTCPayMaxVersion</span>
+                        </div>
+                    </div>
+                    @if (dependencies != null)
+                    {
+                        foreach (var dep in dependencies)
+                        {
+                            if (string.Equals(dep["Identifier"]?.ToString(), "BTCPayServer", StringComparison.OrdinalIgnoreCase)) continue;
+                            <div class="row mb-3">
+                                <div class="col-6"><strong>@dep["Identifier"]</strong></div>
+                                <div class="col-6 text-end">@dep["Condition"]</div>
+                            </div>
+                        }
+                    }
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Created</strong></div>
+                        <div class="col-6 text-end">@Model.Plugin.CreatedDate.ToString("MMM dd, yyyy")</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-6"><strong>Rating</strong></div>
+                        <div class="col-6 text-end">
+                            <span class="d-inline-flex align-items-center gap-1 lh-1">
+                                <span class="fw-semibold">@((Model.Plugin.RatingSummary?.Average ?? 0m).ToString("0.0"))</span>
+                                <span class="text-warning"><vc:icon symbol="star-fill" /></span>
+                                <span class="text-muted small">(@(Model.Plugin.RatingSummary?.TotalReviews ?? 0))</span>
+                            </span>
+                        </div>
+                    </div>
+                    @if (!Model.EmbedMode)
+                    {
+                        <a id="download-btn"
+                           asp-action="Download" asp-controller="Api"
+                           asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                           asp-route-version="@Model.Plugin.Version"
+                           class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
+                    }
+                    else
+                    {
+                        <button type="button"
+                                id="btcpay-install-plugin-btn"
+                                class="btn btn-primary w-100"
+                                data-plugin-install
+                                disabled="@(string.IsNullOrWhiteSpace(pluginIdentifier) ? "disabled" : null)">Install in BTCPay Server</button>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 col-lg-8">
             @if (mediaItems.Any())
             {
                 <div class="card mt-4">
@@ -189,6 +296,9 @@
                             <a class="text-decoration-none text-reset d-block"
                                asp-action="GetPluginDetails" asp-controller="Home"
                                asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                               asp-route-version="@Model.Plugin.Version"
+                               asp-route-btcpayVersion="@btcpayVersionRoute"
+                               asp-route-includePreRelease="@includePreReleaseRoute"
                                asp-route-embed="@embedRoute"
                                asp-route-sort="@Model.Sort" asp-route-skip="0" asp-route-count="@Model.Count"
                                asp-route-RatingFilter="@(isActive ? null : star)" asp-fragment="reviews">
@@ -219,12 +329,18 @@
                                 <a class="dropdown-item @(Model.Sort == "newest" ? "active" : null)"
                                    asp-action="GetPluginDetails" asp-controller="Home"
                                    asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-sort="newest"
+                                   asp-route-version="@Model.Plugin.Version"
+                                   asp-route-btcpayVersion="@btcpayVersionRoute"
+                                   asp-route-includePreRelease="@includePreReleaseRoute"
                                    asp-route-embed="@embedRoute"
                                    asp-route-skip="0" asp-route-count="@Model.Count"
                                    asp-route-RatingFilter="@Model.RatingFilter" asp-fragment="reviews">Newest</a>
                                 <a class="dropdown-item @(Model.Sort == "helpful" ? "active" : null)"
                                    asp-action="GetPluginDetails" asp-controller="Home"
                                    asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-sort="helpful"
+                                   asp-route-version="@Model.Plugin.Version"
+                                   asp-route-btcpayVersion="@btcpayVersionRoute"
+                                   asp-route-includePreRelease="@includePreReleaseRoute"
                                    asp-route-embed="@embedRoute"
                                    asp-route-skip="0" asp-route-count="@Model.Count"
                                    asp-route-RatingFilter="@Model.RatingFilter" asp-fragment="reviews">Most helpful</a>
@@ -372,114 +488,13 @@
             </div>
         </div>
 
-        <div class="col-12 col-lg-4 mt-4 mt-lg-0">
-            <div class="card plugin-details-metadata">
-                <div class="card-body">
-                    <div class="row mb-3">
-                        <div class="col-6 d-flex align-items-center"><strong>Version</strong></div>
-                        <div class="col-6 text-end">
-                            @if (Model.EmbedMode)
-                            {
-                                <span>@string.Join(".", Model.Plugin.Version.Split('.').Take(3))</span>
-                            }
-                            else
-                            {
-                                <div class="dropdown d-inline-block">
-                                    <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
-                                            data-bs-toggle="dropdown" aria-expanded="false">
-                                        @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
-                                    </button>
-                                    <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
-                                        @foreach (var v in Model.PluginVersions)
-                                        {
-                                            var shortV = string.Join(".", v.Split('.').Take(3));
-                                            <li>
-                                                <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
-                                                href="#" data-version="@v" data-display="@shortV">@shortV</a>
-                                            </li>
-                                        }
-                                    </ul>
-                                </div>
-                                <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
-                            }
-                        </div>
-                    </div>
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Published</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-published-date">@(buildDate != default ? buildDate.ToString("MMM dd, yyyy") : "")</span>
-                        </div>
-                    </div>
-                    <div id="plugin-repository-row" class="row mb-3 @(string.IsNullOrEmpty(sourceUrl) ? "d-none" : "")">
-                        <div class="col-6"><strong>Repository</strong></div>
-                        <div class="col-6 text-end">
-                            <a id="plugin-source-url" href="@sourceUrl" target="_blank" rel="noopener noreferrer">View Source</a>
-                        </div>
-                    </div>
-                    @if (!string.IsNullOrEmpty(Model.Plugin.Documentation))
-                    {
-                        <div class="row mb-3">
-                            <div class="col-6"><strong>Documentation</strong></div>
-                            <div class="col-6 text-end">
-                                <a href="@Model.Plugin.Documentation" target="_blank" rel="noopener noreferrer">View Documentation</a>
-                            </div>
-                        </div>
-                    }
-                    <div id="plugin-min-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMinVersion) ? "d-none" : "")">
-                        <div class="col-6"><strong>Min. BTCPay Version</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-min-btcpay-version">@Model.Plugin.BTCPayMinVersion</span>
-                        </div>
-                    </div>
-                    <div id="plugin-max-btcpay-row" class="row mb-3 @(string.IsNullOrEmpty(Model.Plugin.BTCPayMaxVersion) ? "d-none" : "")">
-                        <div class="col-6"><strong>Max. BTCPay Version</strong></div>
-                        <div class="col-6 text-end">
-                            <span id="plugin-max-btcpay-version">@Model.Plugin.BTCPayMaxVersion</span>
-                        </div>
-                    </div>
-                    @if (dependencies != null)
-                    {
-                        foreach (var dep in dependencies)
-                        {
-                            if (string.Equals(dep["Identifier"]?.ToString(), "BTCPayServer", StringComparison.OrdinalIgnoreCase)) continue;
-                            <div class="row mb-3">
-                                <div class="col-6"><strong>@dep["Identifier"]</strong></div>
-                                <div class="col-6 text-end">@dep["Condition"]</div>
-                            </div>
-                        }
-                    }
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Created</strong></div>
-                        <div class="col-6 text-end">@Model.Plugin.CreatedDate.ToString("MMM dd, yyyy")</div>
-                    </div>
-                    <div class="row mb-3">
-                        <div class="col-6"><strong>Rating</strong></div>
-                        <div class="col-6 text-end">
-                            <span class="d-inline-flex align-items-center gap-1 lh-1">
-                                <span class="fw-semibold">@((Model.Plugin.RatingSummary?.Average ?? 0m).ToString("0.0"))</span>
-                                <span class="text-warning"><vc:icon symbol="star-fill" /></span>
-                                <span class="text-muted small">(@(Model.Plugin.RatingSummary?.TotalReviews ?? 0))</span>
-                            </span>
-                        </div>
-                    </div>
-                    @if (!Model.EmbedMode)
-                    {
-                        <a id="download-btn"
-                           asp-action="Download" asp-controller="Api"
-                           asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
-                           asp-route-version="@Model.Plugin.Version"
-                           class="btn btn-primary w-100" target="_blank" rel="noopener noreferrer">Download</a>
-                    }
-                </div>
-            </div>
-
+        <div class="col-12 col-lg-4">
             <div class="card mt-4 @(string.IsNullOrEmpty(Model.Plugin.Changelog) ? "d-none" : "")" id="plugin-changelog-card">
                 <div class="card-body">
                     <h4>Release notes</h4>
                     <p id="plugin-changelog-text" class="small mb-0" style="white-space: pre-wrap;">@Model.Plugin.Changelog</p>
                 </div>
             </div>
-
             @if (Model.Contributors?.Any() == true)
             {
                 <div class="card mt-4">

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -16,8 +16,10 @@
     var writeReviewUrl = Model.EmbedMode ? $"{pluginUrl}#write-review" : "#write-review";
     var writeReviewTarget = Model.EmbedMode ? "_blank" : null;
     var writeReviewRel = Model.EmbedMode ? "noopener noreferrer" : null;
-    var btcpayVersionRoute = Context.Request.Query["btcpayVersion"].ToString();
-    var includePreReleaseRoute = Context.Request.Query["includePreRelease"].ToString();
+    var currentBtcpayVersion = Context.Request.Query["btcpayVersion"].ToString();
+    var currentIncludePreRelease = Context.Request.Query["includePreRelease"].ToString();
+    var btcpayVersionRoute = string.IsNullOrEmpty(currentBtcpayVersion) ? null : currentBtcpayVersion;
+    var includePreReleaseRoute = string.IsNullOrEmpty(currentIncludePreRelease) ? null : currentIncludePreRelease;
     var currentRating = Model.RatingFilter;
     var containerClass = Model.EmbedMode ? "container-fluid px-0" : "container";
     DateTimeOffset.TryParse(Model.Plugin.BuildInfo?["buildDate"]?.ToString(), out var buildDate);
@@ -412,7 +414,17 @@
                                         var shortV = string.Join(".", v.Split('.').Take(3));
                                         <li>
                                             <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
-                                            href="#" data-version="@v" data-display="@shortV">@shortV</a>
+                                               asp-action="GetPluginDetails"
+                                               asp-controller="Home"
+                                               asp-route-pluginSlug="@Model.Plugin.ProjectSlug"
+                                               asp-route-version="@v"
+                                               asp-route-btcpayVersion="@btcpayVersionRoute"
+                                               asp-route-includePreRelease="@includePreReleaseRoute"
+                                               asp-route-embed="@embedRoute"
+                                               asp-route-sort="@Model.Sort"
+                                               asp-route-skip="0"
+                                               asp-route-count="@Model.Count"
+                                               asp-route-RatingFilter="@Model.RatingFilter">@shortV</a>
                                         </li>
                                     }
                                 </ul>
@@ -591,72 +603,4 @@
         render(input.value);
     })();
 
-    (() => {
-        const input = document.getElementById('version-selector');
-        const btn = document.getElementById('version-dropdown-btn');
-        if (!input || !btn) return;
-
-        const slug = '@Html.Raw(Model.Plugin.ProjectSlug?.Replace("'", "\\'"))';
-        const base = '/api/v1/plugins/' + encodeURIComponent(slug) + '/versions/';
-        const cache = new Map();
-
-        document.querySelectorAll('[data-version]').forEach(item => {
-            item.addEventListener('click', async function (e) {
-                e.preventDefault();
-                const version = this.dataset.version;
-
-                btn.childNodes[0].textContent = this.dataset.display + ' ';
-                input.value = this.dataset.version;
-
-                document.querySelectorAll('[data-version]').forEach(el =>
-                    el.classList.toggle('active', el.dataset.version === version));
-
-                const downloadBtn = document.getElementById('download-btn');
-                if (downloadBtn) downloadBtn.href = base + encodeURIComponent(version) + '/download';
-
-                let data = cache.get(version);
-                if (!data) {
-                    try {
-                        const res = await fetch(base + encodeURIComponent(version), { headers: { 'Accept': 'application/json' } });
-                        if (!res.ok) return;
-                        data = await res.json();
-                        cache.set(version, data);
-                    } catch { return; }
-                }
-
-                const set = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
-                const toggle = (id, show) => document.getElementById(id)?.classList.toggle('d-none', !show);
-
-                const dt = new Date(data?.buildInfo?.buildDate);
-                set('plugin-published-date', isNaN(dt) ? '' : dt.toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' }));
-
-                const src = (() => {
-                    const b = data?.buildInfo;
-                    if (!b?.gitRepository || !b?.gitCommit) return null;
-                    try {
-                        const u = new URL(b.gitRepository);
-                        if (u.hostname.toLowerCase() !== 'github.com') return null;
-                        const [owner, repo] = u.pathname.split('/').filter(Boolean);
-                        const dir = (b.pluginDir || '').split('/').filter(Boolean).map(encodeURIComponent).join('/');
-                        return `https://github.com/${owner}/${repo.replace(/\.git$/i, '')}/tree/${encodeURIComponent(b.gitCommit)}${dir ? '/' + dir : ''}`;
-                    } catch { return null; }
-                })();
-                const srcEl = document.getElementById('plugin-source-url');
-                if (srcEl) srcEl.href = src || '#';
-                toggle('plugin-repository-row', !!src);
-
-                const min = (data?.btcPayMinVersion || '').trim();
-                set('plugin-min-btcpay-version', min);
-                toggle('plugin-min-btcpay-row', !!min);
-
-                const max = (data?.btcPayMaxVersion || '').trim();
-                set('plugin-max-btcpay-version', max);
-                toggle('plugin-max-btcpay-row', !!max);
-
-                const changelog = (data?.changelog || '').trim();
-                set('plugin-changelog-text', changelog);
-                toggle('plugin-changelog-card', !!changelog);
-            });
-        });
-    })();
 </script>

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -318,13 +318,13 @@
                                         }
                                         else
                                         {
-                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-embed="@embedRoute" asp-route-isHelpful="true" class="test-upvote-form d-inline">
+                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-isHelpful="true" class="test-upvote-form d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <button type="submit" class="@voteBtn vote-up @(review.UserVoteHelpful == true ? "text-success" : "text-secondary")" aria-label="Mark this review as helpful">
                                                     <vc:icon symbol="thumb-up" /><span class="small ms-1">@review.UpCount</span>
                                                 </button>
                                             </form>
-                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-embed="@embedRoute" asp-route-isHelpful="false" class="test-downvote-form d-inline">
+                                            <form method="post" asp-action="VoteReview" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-id="@review.Id" asp-route-isHelpful="false" class="test-downvote-form d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <button type="submit" class="@voteBtn vote-down @(review.UserVoteHelpful == false ? "text-danger" : "text-secondary")" aria-label="Mark this review as not helpful">
                                                     <vc:icon symbol="thumb-down" /><span class="small ms-1">@review.DownCount</span>
@@ -346,7 +346,7 @@
                                         <button type="button" class="btn btn-link btn-sm p-0 text-danger align-self-start ms-2"
                                                 title="Delete" aria-label="Delete review"
                                                 data-bs-toggle="modal" data-bs-target="#ConfirmModal"
-                                                data-action='@Url.EnsureLocal(Url.Action("DeleteReview", "Home", new { pluginSlug = Model.Plugin.ProjectSlug, id = review.Id, embed = embedRoute }), Context.Request)'
+                                                data-action='@Url.EnsureLocal(Url.Action("DeleteReview", "Home", new { pluginSlug = Model.Plugin.ProjectSlug, id = review.Id }), Context.Request)'
                                                 data-title="Delete review"
                                                 data-description="Delete this review? This action cannot be undone."
                                                 data-confirm="Delete">
@@ -370,7 +370,7 @@
                         }
                         else
                         {
-                            <form id="review-form" method="post" asp-action="UpsertReview" asp-controller="Home" asp-route-pluginSlug="@Model.Plugin.ProjectSlug" asp-route-embed="@embedRoute">
+                            <form id="review-form" method="post" asp-action="UpsertReview" asp-controller="Home" asp-route-pluginSlug="@Model.Plugin.ProjectSlug">
                                 @Html.AntiForgeryToken()
                                 <div id="ratingStars" class="d-inline-flex align-items-center gap-1 fs-4 mb-3" role="radiogroup" aria-label="Rating (1 to 5)" tabindex="0">
                                     @for (var i = 1; i <= 5; i++)

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -279,12 +279,12 @@
                                     </div>
 
                                     <div class="ms-auto d-inline-flex align-items-center gap-3">
-                                        @if (review.IsReviewOwner)
+                                        @if (Model.EmbedMode || review.IsReviewOwner)
                                         {
-                                            <span class="test-upvote-disabled @voteBtn text-muted" aria-disabled="true" title="Authors can't vote their own review" style="cursor: default;">
+                                            <span class="test-upvote-disabled @voteBtn text-muted" aria-disabled="true" title="Open the plugin page to vote on reviews" style="cursor: default;">
                                                 <vc:icon symbol="thumb-up" /><span class="small ms-1">@review.UpCount</span>
                                             </span>
-                                            <span class="test-downvote-disabled @voteBtn text-muted" aria-disabled="true" title="Authors can't vote their own review" style="cursor: default;">
+                                            <span class="test-downvote-disabled @voteBtn text-muted" aria-disabled="true" title="Open the plugin page to vote on reviews" style="cursor: default;">
                                                 <vc:icon symbol="thumb-down" /><span class="small ms-1">@review.DownCount</span>
                                             </span>
                                         }
@@ -313,7 +313,7 @@
                                             <partial name="_MarkdownRender" model="review.Body" />
                                         }
                                     </div>
-                                    @if (review.IsReviewOwner || Model.IsAdmin)
+                                    @if (!Model.EmbedMode && (review.IsReviewOwner || Model.IsAdmin))
                                     {
                                         <button type="button" class="btn btn-link btn-sm p-0 text-danger align-self-start ms-2"
                                                 title="Delete" aria-label="Delete review"
@@ -334,7 +334,7 @@
                     <hr class="my-4" />
 
                     <a id="write-review"></a>
-                    @if (User.Identity?.IsAuthenticated == true)
+                    @if (!Model.EmbedMode && User.Identity?.IsAuthenticated == true)
                     {
                         @if (Model.IsOwner == true)
                         {
@@ -378,23 +378,30 @@
                     <div class="row mb-3">
                         <div class="col-6 d-flex align-items-center"><strong>Version</strong></div>
                         <div class="col-6 text-end">
-                            <div class="dropdown d-inline-block">
-                                <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
-                                        data-bs-toggle="dropdown" aria-expanded="false">
-                                    @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
-                                    @foreach (var v in Model.PluginVersions)
-                                    {
-                                        var shortV = string.Join(".", v.Split('.').Take(3));
-                                        <li>
-                                            <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
-                                            href="#" data-version="@v" data-display="@shortV">@shortV</a>
-                                        </li>
-                                    }
-                                </ul>
-                            </div>
-                            <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
+                            @if (Model.EmbedMode)
+                            {
+                                <span>@string.Join(".", Model.Plugin.Version.Split('.').Take(3))</span>
+                            }
+                            else
+                            {
+                                <div class="dropdown d-inline-block">
+                                    <button id="version-dropdown-btn" class="btn btn-secondary btn-sm dropdown-toggle" type="button"
+                                            data-bs-toggle="dropdown" aria-expanded="false">
+                                        @string.Join(".", Model.Plugin.Version.Split('.').Take(3))
+                                    </button>
+                                    <ul class="dropdown-menu dropdown-menu-end" style="max-height: 140px; overflow-y: auto;">
+                                        @foreach (var v in Model.PluginVersions)
+                                        {
+                                            var shortV = string.Join(".", v.Split('.').Take(3));
+                                            <li>
+                                                <a class="dropdown-item @(v == Model.Plugin.Version ? "active" : "")"
+                                                href="#" data-version="@v" data-display="@shortV">@shortV</a>
+                                            </li>
+                                        }
+                                    </ul>
+                                </div>
+                                <input type="hidden" id="version-selector" name="Plugin.Version" value="@Model.Plugin.Version" />
+                            }
                         </div>
                     </div>
                     <div class="row mb-3">

--- a/PluginBuilder/Views/Shared/_CommonHead.cshtml
+++ b/PluginBuilder/Views/Shared/_CommonHead.cshtml
@@ -1,3 +1,6 @@
+@{
+    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
+}
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="icon" href="/favicon.ico" type="image/x-icon">
@@ -9,15 +12,18 @@
 <link href="~/main/site.css" asp-append-version="true" rel="stylesheet" />
 <link href="~/main/themes/default.css" rel="stylesheet" />
 <link href="~/main/themes/default-dark.css" id="DarkThemeLinkTag" rel="stylesheet" disabled asp-append-version="true" />
-<script>
-    (function(){
-        var theme = localStorage.getItem('btcpay-theme');
-        if (theme) document.documentElement.setAttribute('data-btcpay-theme', theme);
-        var isDark = theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
-        if (isDark) document.getElementById('DarkThemeLinkTag').disabled = false;
-    })();
-</script>
-<script src="~/js/theme-switch.js" asp-append-version="true"></script>
+@if (!embedMode)
+{
+    <script>
+        (function(){
+            var theme = localStorage.getItem('btcpay-theme');
+            if (theme) document.documentElement.setAttribute('data-btcpay-theme', theme);
+            var isDark = theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+            if (isDark) document.getElementById('DarkThemeLinkTag').disabled = false;
+        })();
+    </script>
+    <script src="~/js/theme-switch.js" asp-append-version="true"></script>
+}
 <noscript>
     <style>
         .btcpay-theme-switch { 

--- a/PluginBuilder/Views/Shared/_LayoutPublicModal.cshtml
+++ b/PluginBuilder/Views/Shared/_LayoutPublicModal.cshtml
@@ -1,5 +1,6 @@
 @{
     Layout = null;
+    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -24,14 +25,23 @@
         .account-form h4 {
             margin-bottom: 1.5rem;
         }
+
+        body.embed-mode {
+            background: transparent;
+            overflow-x: hidden;
+        }
     </style>
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="d-flex flex-column min-vh-100 @(embedMode ? "embed-mode" : null)">
 <section class="content-wrapper flex-grow-1">
     <div class="navbar-brand d-none"></div>
     <vc:status-message></vc:status-message>
     @RenderBody()
 </section>
 <script src="~/vendor/bootstrap/bootstrap.bundle.min.js" asp-append-version="true"></script>
+@if (embedMode)
+{
+    <script src="~/js/public-embed.js" asp-append-version="true"></script>
+}
 </body>
 </html>

--- a/PluginBuilder/Views/Shared/_PublicHeader.cshtml
+++ b/PluginBuilder/Views/Shared/_PublicHeader.cshtml
@@ -1,39 +1,43 @@
 @{
     var isAuth = User.Identity?.IsAuthenticated == true;
+    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
 }
-<div class="px-4">
-    <div class="d-flex align-items-center justify-content-between py-3">
-        <div class="d-flex align-items-center">
-            <a asp-controller="Home" asp-action="AllPlugins" class="text-decoration-none d-flex align-items-center me-4">
-                <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" height="32" class="me-2">
-                <span class="fw-bold fs-5">BTCPay Plugin Builder</span>
-            </a>
-        </div>
-
-        <div class="d-flex align-items-center gap-3">
-            <div class="dropdown">
-                <button class="btn btn-link text-muted p-0 btcpay-theme-trigger" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Theme">
-                    <vc:icon symbol="themes-system"/>
-                </button>
-                <ul class="dropdown-menu dropdown-menu-end">
-                    <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="light"><vc:icon symbol="themes-light"/> Light theme</button></li>
-                    <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="dark"><vc:icon symbol="themes-dark"/> Dark theme</button></li>
-                    <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="system"><vc:icon symbol="themes-system"/> Device default</button></li>
-                </ul>
-            </div>
-            @if (!isAuth)
-            {
-                <a asp-action="Login"
-                   asp-controller="Home"
-                   class="btn btn-success"
-                   id="login-btn">
-                    Login
+@if (!embedMode)
+{
+    <div class="px-4">
+        <div class="d-flex align-items-center justify-content-between py-3">
+            <div class="d-flex align-items-center">
+                <a asp-controller="Home" asp-action="AllPlugins" class="text-decoration-none d-flex align-items-center me-4">
+                    <img src="~/img/btcpay-logo.svg" alt="BTCPay Server" height="32" class="me-2">
+                    <span class="fw-bold fs-5">BTCPay Plugin Builder</span>
                 </a>
-            }
-            else
-            {
-                <a asp-action="Dashboard" asp-controller="Home" class="btn btn-success">Dashboard</a>
-            }
+            </div>
+
+            <div class="d-flex align-items-center gap-3">
+                <div class="dropdown">
+                    <button class="btn btn-link text-muted p-0 btcpay-theme-trigger" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Theme">
+                        <vc:icon symbol="themes-system"/>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="light"><vc:icon symbol="themes-light"/> Light theme</button></li>
+                        <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="dark"><vc:icon symbol="themes-dark"/> Dark theme</button></li>
+                        <li><button type="button" class="btcpay-theme-switch dropdown-item" data-theme="system"><vc:icon symbol="themes-system"/> Device default</button></li>
+                    </ul>
+                </div>
+                @if (!isAuth)
+                {
+                    <a asp-action="Login"
+                       asp-controller="Home"
+                       class="btn btn-success"
+                       id="login-btn">
+                        Login
+                    </a>
+                }
+                else
+                {
+                    <a asp-action="Dashboard" asp-controller="Home" class="btn btn-success">Dashboard</a>
+                }
+            </div>
         </div>
     </div>
-</div>
+}

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -1,0 +1,191 @@
+(function () {
+    const embedPage = document.querySelector("[data-embed-page]");
+    if (!embedPage || window.parent === window) {
+        return;
+    }
+
+    let lastHeight = 0;
+    let heightPostQueued = false;
+    let hiddenPluginIdentifiers = new Set();
+
+    function applyHostColorMode(colorMode) {
+        if (colorMode !== "light" && colorMode !== "dark") {
+            return;
+        }
+
+        document.documentElement.setAttribute("data-btcpay-theme", colorMode);
+
+        const darkThemeLink = document.getElementById("DarkThemeLinkTag");
+        if (darkThemeLink) {
+            darkThemeLink.disabled = colorMode !== "dark";
+        }
+
+        scheduleHeightPost();
+    }
+
+    function postReady() {
+        window.parent.postMessage({ type: "pb:ready" }, "*");
+    }
+
+    function getContentHeight() {
+        const rectHeight = embedPage.getBoundingClientRect ? embedPage.getBoundingClientRect().height : 0;
+        return Math.max(
+            embedPage.scrollHeight || 0,
+            embedPage.offsetHeight || 0,
+            Math.ceil(rectHeight)
+        );
+    }
+
+    function postHeight() {
+        heightPostQueued = false;
+        const height = Math.ceil(getContentHeight()) + 4;
+        if (!height || Math.abs(height - lastHeight) < 2) {
+            return;
+        }
+
+        lastHeight = height;
+        window.parent.postMessage({
+            type: "pb:content-height",
+            height: height
+        }, "*");
+    }
+
+    function scheduleHeightPost() {
+        if (heightPostQueued) {
+            return;
+        }
+
+        heightPostQueued = true;
+        window.requestAnimationFrame(postHeight);
+    }
+
+    function normalizeIdentifier(identifier) {
+        return typeof identifier === "string" ? identifier.trim().toLowerCase() : "";
+    }
+
+    function normalizeHiddenPluginIdentifiers(value) {
+        const identifiers = new Set();
+        if (!Array.isArray(value)) {
+            return identifiers;
+        }
+
+        value.forEach(function (identifier) {
+            const normalizedIdentifier = normalizeIdentifier(identifier);
+            if (normalizedIdentifier) {
+                identifiers.add(normalizedIdentifier);
+            }
+        });
+
+        return identifiers;
+    }
+
+    function applyHiddenPluginFilter() {
+        if (embedPage.dataset.embedPage !== "list") {
+            return;
+        }
+
+        let visibleCount = 0;
+        document.querySelectorAll("[data-plugin-card]").forEach(function (card) {
+            const identifier = normalizeIdentifier(card.dataset.pluginIdentifier);
+            const shouldHide = identifier && hiddenPluginIdentifiers.has(identifier);
+            card.hidden = shouldHide;
+            if (!shouldHide) {
+                visibleCount += 1;
+            }
+        });
+
+        const emptyState = document.querySelector("[data-plugin-directory-empty-state]");
+        if (emptyState) {
+            emptyState.hidden = visibleCount !== 0;
+        }
+
+        scheduleHeightPost();
+    }
+
+    function postSelection(slug, identifier) {
+        if (!slug) {
+            return;
+        }
+
+        window.parent.postMessage({
+            type: "pb:plugin-selected",
+            slug: slug,
+            identifier: identifier || null
+        }, "*");
+    }
+
+    function buildDetailsUrl(slug) {
+        const url = new URL("/public/plugins/" + encodeURIComponent(slug), window.location.origin);
+        url.searchParams.set("embed", "1");
+        return url.toString();
+    }
+
+    function handleHostContext(event) {
+        const data = event.data;
+        if (!data || typeof data !== "object" || data.type !== "btcpay:host-context") {
+            return;
+        }
+
+        hiddenPluginIdentifiers = normalizeHiddenPluginIdentifiers(data.hiddenPluginIdentifiers);
+        applyHostColorMode(data.colorMode);
+        applyHiddenPluginFilter();
+
+        const currentSlug = embedPage.dataset.pluginSlug || "";
+        const selectedSlug = typeof data.selectedSlug === "string" ? data.selectedSlug : "";
+
+        if (embedPage.dataset.embedPage === "list") {
+            return;
+        }
+
+        if (!selectedSlug || selectedSlug === currentSlug) {
+            return;
+        }
+
+        window.location.replace(buildDetailsUrl(selectedSlug));
+    }
+
+    postReady();
+    scheduleHeightPost();
+
+    if (embedPage.dataset.embedPage === "details") {
+        postSelection(embedPage.dataset.pluginSlug || "", embedPage.dataset.pluginIdentifier || "");
+    }
+
+    document.querySelectorAll("img").forEach(function (image) {
+        image.addEventListener("load", scheduleHeightPost);
+        image.addEventListener("error", scheduleHeightPost);
+    });
+
+    document.querySelectorAll("a[data-plugin-slug]").forEach(function (link) {
+        link.addEventListener("click", function (event) {
+            if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+                return;
+            }
+
+            event.preventDefault();
+            postSelection(link.dataset.pluginSlug || "", link.dataset.pluginIdentifier || "");
+        });
+    });
+
+    window.addEventListener("message", handleHostContext);
+    window.addEventListener("load", scheduleHeightPost);
+    window.addEventListener("resize", scheduleHeightPost);
+
+    if (window.ResizeObserver) {
+        const resizeObserver = new window.ResizeObserver(scheduleHeightPost);
+        resizeObserver.observe(embedPage);
+    }
+
+    if (window.MutationObserver) {
+        const mutationObserver = new window.MutationObserver(scheduleHeightPost);
+        mutationObserver.observe(embedPage, { childList: true, subtree: true, attributes: true });
+    }
+
+    if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(scheduleHeightPost);
+    }
+
+    window.setTimeout(scheduleHeightPost, 0);
+    window.setTimeout(scheduleHeightPost, 150);
+    window.setTimeout(scheduleHeightPost, 500);
+})();

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -121,6 +121,10 @@
     }
 
     function handleHostContext(event) {
+        if (event.source !== window.parent) {
+            return;
+        }
+
         const data = event.data;
         if (!data || typeof data !== "object" || data.type !== "btcpay:host-context") {
             return;

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -134,6 +134,13 @@
 
     function buildDetailsUrl(slug) {
         const url = new URL("/public/plugins/" + encodeURIComponent(slug), window.location.origin);
+        const currentUrl = new URL(window.location.href);
+        ["btcpayVersion", "includePreRelease"].forEach(function (param) {
+            const value = currentUrl.searchParams.get(param);
+            if (value) {
+                url.searchParams.set(param, value);
+            }
+        });
         url.searchParams.set("embed", "1");
         return url.toString();
     }

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -128,7 +128,8 @@
             type: "pb:install-requested",
             identifier: identifier,
             slug: slug || null,
-            version: version
+            version: version,
+            preRelease: embedPage.dataset.pluginPreRelease === "true"
         }, hostOrigin);
     }
 

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -172,7 +172,6 @@
     });
 
     window.addEventListener("message", handleHostContext);
-    window.addEventListener("load", scheduleHeightPost);
     window.addEventListener("resize", scheduleHeightPost);
 
     if (window.ResizeObserver) {
@@ -180,16 +179,7 @@
         resizeObserver.observe(embedPage);
     }
 
-    if (window.MutationObserver) {
-        const mutationObserver = new window.MutationObserver(scheduleHeightPost);
-        mutationObserver.observe(embedPage, { childList: true, subtree: true, attributes: true });
-    }
-
     if (document.fonts && document.fonts.ready) {
         document.fonts.ready.then(scheduleHeightPost);
     }
-
-    window.setTimeout(scheduleHeightPost, 0);
-    window.setTimeout(scheduleHeightPost, 150);
-    window.setTimeout(scheduleHeightPost, 500);
 })();

--- a/PluginBuilder/wwwroot/js/public-embed.js
+++ b/PluginBuilder/wwwroot/js/public-embed.js
@@ -7,6 +7,7 @@
     let lastHeight = 0;
     let heightPostQueued = false;
     let hiddenPluginIdentifiers = new Set();
+    let hostOrigin = null;
 
     function applyHostColorMode(colorMode) {
         if (colorMode !== "light" && colorMode !== "dark") {
@@ -114,6 +115,23 @@
         }, "*");
     }
 
+    function postInstallRequest() {
+        const identifier = embedPage.dataset.pluginIdentifier || "";
+        const slug = embedPage.dataset.pluginSlug || "";
+        const versionInput = document.getElementById("version-selector");
+        const version = versionInput ? versionInput.value : "";
+        if (!hostOrigin || !identifier || !version) {
+            return;
+        }
+
+        window.parent.postMessage({
+            type: "pb:install-requested",
+            identifier: identifier,
+            slug: slug || null,
+            version: version
+        }, hostOrigin);
+    }
+
     function buildDetailsUrl(slug) {
         const url = new URL("/public/plugins/" + encodeURIComponent(slug), window.location.origin);
         url.searchParams.set("embed", "1");
@@ -130,6 +148,7 @@
             return;
         }
 
+        hostOrigin = event.origin;
         hiddenPluginIdentifiers = normalizeHiddenPluginIdentifiers(data.hiddenPluginIdentifiers);
         applyHostColorMode(data.colorMode);
         applyHiddenPluginFilter();
@@ -168,6 +187,13 @@
 
             event.preventDefault();
             postSelection(link.dataset.pluginSlug || "", link.dataset.pluginIdentifier || "");
+        });
+    });
+
+    document.querySelectorAll("[data-plugin-install]").forEach(function (button) {
+        button.addEventListener("click", function (event) {
+            event.preventDefault();
+            postInstallRequest();
         });
     });
 


### PR DESCRIPTION
## Summary

Adds an embedded mode for the public plugin directory so BTCPay Server can render the Plugin Builder catalog inside Manage Plugins.

Resolves #114 

## Changes

- Adds `embed=1` support for the public directory list.
- Adds embedded plugin details rendering for BTCPay drawer usage.
- Supports host context messages for hidden plugin identifiers, selected plugin, color mode, BTCPay version, and pre-release state.
- Filters installed/disabled plugins from the embedded directory.
- Keeps the standalone public directory unchanged.