### PR TITLE
feat: improve the plugin listing request experience

### DIFF
--- a/PluginBuilder.Tests/PluginTests/OwnersUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/OwnersUITests.cs
@@ -42,7 +42,9 @@ public class OwnersUITests(ITestOutputHelper output) : PageTest
         await t.GoToUrl($"/plugins/{slug}/owners");
         await t.AssertNoError();
         await Expect(t.Page.Locator("table tbody tr")).ToContainTextAsync(userA);
-        await Expect(t.Page.Locator("table tbody tr")).ToContainTextAsync("Primary Owner");
+        var primaryOwnerBadge = t.Page.Locator(".badge:text-is('Primary Owner')");
+        await Expect(primaryOwnerBadge).ToHaveClassAsync(new Regex("\\bbg-primary\\b"));
+        await Expect(primaryOwnerBadge).ToHaveClassAsync(new Regex("\\btext-black\\b"));
 
         await t.Logout();
         await t.GoToUrl("/register");

--- a/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
@@ -21,9 +21,12 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
 
     [Theory]
     [InlineData("https://t.me/btcpayserver/1234", true)]
+    [InlineData("https://t.me/BTCPayServer/1234", true)]
     [InlineData("http://t.me/btcpayserver/1234", false)]
     [InlineData("https://example.com/btcpayserver/1234", false)]
     [InlineData("https://t.me/not-btcpayserver/1234", false)]
+    [InlineData("https://t.me/btcpayserver-fake/1234", false)]
+    [InlineData("https://t.me/btcpayserver", false)]
     public void TelegramVerificationMessageValidation_MatchesServerContract(string value, bool expected)
     {
         Assert.Equal(expected, RequestListingViewModel.IsValidTelegramVerificationMessage(value));
@@ -205,7 +208,9 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         {
             "http://t.me/btcpayserver/1234",
             "https://example.com/btcpayserver/1234",
-            "https://t.me/not-btcpayserver/1234"
+            "https://t.me/not-btcpayserver/1234",
+            "https://t.me/btcpayserver-fake/1234",
+            "https://t.me/btcpayserver"
         };
         foreach (var invalidTelegramUrl in invalidTelegramUrls)
         {

--- a/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
@@ -1,11 +1,14 @@
 using System.Text.RegularExpressions;
+using Dapper;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
 using Microsoft.Playwright.Xunit;
 using PluginBuilder.Controllers.Logic;
 using PluginBuilder.DataModels;
 using PluginBuilder.Services;
 using PluginBuilder.Util;
 using PluginBuilder.Util.Extensions;
+using PluginBuilder.ViewModels;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,6 +19,15 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
 {
     private readonly XUnitLogger _log = new("PluginRequestListingUITest", output);
 
+    [Theory]
+    [InlineData("https://t.me/btcpayserver/1234", true)]
+    [InlineData("http://t.me/btcpayserver/1234", false)]
+    [InlineData("https://example.com/btcpayserver/1234", false)]
+    [InlineData("https://t.me/not-btcpayserver/1234", false)]
+    public void TelegramVerificationMessageValidation_MatchesServerContract(string value, bool expected)
+    {
+        Assert.Equal(expected, RequestListingViewModel.IsValidTelegramVerificationMessage(value));
+    }
 
     [Fact]
     public async Task RequestListing_Tests()
@@ -23,7 +35,8 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         await using var t = new PlaywrightTester(_log);
         t.Server.ReuseDatabase = false;
         await t.StartAsync();
-        await using var conn = await t.Server.GetService<DBConnectionFactory>().Open();
+        var connectionFactory = t.Server.GetService<DBConnectionFactory>();
+        await using var conn = await connectionFactory.Open();
         await t.EnableGithubVerificationAsync(conn);
 
         await t.GoToUrl("/register");
@@ -36,7 +49,6 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         await t.Page.FillAsync("#PluginSlug", pluginSlug);
         await t.Page!.FillAsync("#PluginTitle", pluginSlug);
         await t.Page!.FillAsync("#Description", "Test");
-        await t.Page!.FillAsync("#VideoUrl", "https://www.youtube.com/watch?v=Z78ZbPcsc3g&t=1228s");
         await t.Page.ClickAsync("#Create");
         await t.AssertNoError();
 
@@ -64,6 +76,15 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         await Expect(t.Page.Locator("#pluginSettingsHeader")).ToContainTextAsync("Update Plugin Settings");
         await Expect(t.Page.Locator("#collapseOwnerSettings")).Not.ToBeVisibleAsync();
         await Expect(t.Page.Locator("#collapseRequestForm")).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+        var requestFormToggle = t.Page.Locator("#requestFormHeader button");
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await requestFormToggle.ClickAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#UserReviews")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#AnnouncementDate")).ToBeEditableAsync();
         await t.Page!.ClickAsync("#StoreNav-Settings");
 
         var testImagePath = Path.Combine(Path.GetTempPath(), "test-logo2.png");
@@ -79,34 +100,288 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
 
         await t.Page!.ClickAsync("#StoreNav-Dashboard");
         await t.Page.ClickAsync("#StoreNav-RequestListing");
+        await Expect(t.Page.Locator("#plugin-settings-status")).ToContainTextAsync("Incomplete");
+        await Expect(t.Page.Locator("#owner-settings-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#plugin-requirement-description")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#plugin-requirement-git-repository")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#plugin-requirement-documentation")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#plugin-requirement-video-url")).ToContainTextAsync("Missing");
+        await Expect(t.Page.Locator("#plugin-requirement-logo")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#UpdatePluginSettingsLink")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#collapsePluginSettings")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#collapseOwnerSettings")).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await requestFormToggle.ClickAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        await t.Page.FillAsync("#TelegramVerificationMessage", "https://t.me/btcpayserver/1234");
+        await t.Page.FillAsync("#UserReviews", "https://example.com/review");
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+
+        var incompleteSettingsResponse = await PostListingRequest(t.Page);
+        Assert.True(incompleteSettingsResponse.Ok);
+        Assert.Contains("Complete every required field in your plugin settings before submitting.", await incompleteSettingsResponse.TextAsync());
+        Assert.Null(await conn.GetPendingListingRequestForPlugin(new PluginSlug(pluginSlug)));
+
+        await t.Page.ClickAsync("#StoreNav-Settings");
+        await t.Page.FillAsync("#VideoUrl", "https://www.youtube.com/watch?v=Z78ZbPcsc3g&t=1228s");
+        await t.Page.Locator("button[type='submit'][form='plugin-setting-form']").ClickAsync();
+        await t.AssertNoError();
+
+        await t.Page.ClickAsync("#StoreNav-Dashboard");
+        await t.Page.ClickAsync("#StoreNav-RequestListing");
+        await Expect(t.Page.Locator("#plugin-settings-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#owner-settings-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#plugin-settings-status")).ToHaveClassAsync(new Regex("\\btext-black\\b"));
+        await Expect(t.Page.Locator("#owner-settings-status")).ToHaveClassAsync(new Regex("\\btext-black\\b"));
         await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
         await Expect(t.Page.Locator("#collapsePluginSettings")).Not.ToBeVisibleAsync();
         await Expect(t.Page.Locator("#collapseOwnerSettings")).Not.ToBeVisibleAsync();
-        await t.Page.FillAsync("textarea[name='ReleaseNote']", "Testing release note entry");
-        await t.Page.FillAsync("input[name='TelegramVerificationMessage']", "https://t.me/btcpayserver/1234");
-        await t.Page.FillAsync("textarea[name='UserReviews']", "Great plugin, works as expected!");
-        await t.Page.ClickAsync("button[type='submit']:text('Submit')");
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Incomplete");
+        await Expect(t.Page.Locator("#ReleaseNote")).ToHaveValueAsync("Testing logo upload with description");
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#request-listing-form .badge")).ToHaveCountAsync(0);
+        await Expect(t.Page.Locator("#request-listing-form")).Not.ToContainTextAsync("Missing");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+        var currentOwnerId = (await conn.GetPluginOwners(new PluginSlug(pluginSlug))).Single(owner => owner.Email == user).UserId;
+        var currentOwner = t.Page.Locator($"[data-owner-id='{currentOwnerId}']");
+        await Expect(currentOwner).ToContainTextAsync("You");
+        var primaryBadge = currentOwner.Locator(".badge:text-is('Primary')");
+        await Expect(primaryBadge).ToHaveClassAsync(new Regex("\\bbg-primary\\b"));
+        await Expect(primaryBadge).ToHaveClassAsync(new Regex("\\btext-black\\b"));
+
+        var currentOwnerAccount = await conn.GetAccountDetailSettings(currentOwnerId);
+        Assert.NotNull(currentOwnerAccount);
+        currentOwnerAccount.Nostr = null;
+        await conn.SetAccountDetailSettings(currentOwnerAccount, currentOwnerId);
+        await t.Page.ReloadAsync();
+
+        await Expect(t.Page.Locator("#owner-settings-status")).ToContainTextAsync("Incomplete");
+        await Expect(currentOwner.Locator("[data-verification='nostr']")).ToContainTextAsync("Not verified");
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        var verifyMyAccounts = t.Page.Locator("a:text-is('Verify my accounts')");
+        await Expect(verifyMyAccounts).ToBeVisibleAsync();
+        await Expect(verifyMyAccounts).ToHaveAttributeAsync("href", "/account/details");
+        await t.VerifyUserAccounts(user);
+
+        var partialOwnerId = await t.Server.CreateFakeUserAsync(confirmEmail: true, githubVerified: true);
+        await conn.AddUserPlugin(new PluginSlug(pluginSlug), partialOwnerId);
+        await t.Page.ReloadAsync();
+
+        await Expect(t.Page.Locator("#plugin-settings-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#owner-settings-status")).ToContainTextAsync("Incomplete");
+        await Expect(t.Page.Locator("#collapseOwnerSettings")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).Not.ToBeVisibleAsync();
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        var partialOwner = t.Page.Locator($"[data-owner-id='{partialOwnerId}']");
+        await Expect(partialOwner).ToBeVisibleAsync();
+        await Expect(partialOwner.Locator("[data-verification='email']")).ToContainTextAsync("Verified");
+        await Expect(partialOwner.Locator("[data-verification='github']")).ToContainTextAsync("Verified");
+        await Expect(partialOwner.Locator("[data-verification='nostr']")).ToContainTextAsync("Not verified");
+        await Expect(t.Page.Locator("a:text-is('Verify my accounts')")).ToHaveCountAsync(0);
+
+        var incompleteOwnersResponse = await PostListingRequest(t.Page);
+        Assert.True(incompleteOwnersResponse.Ok);
+        Assert.Contains("Every plugin owner must verify Email, GitHub, and Nostr before submitting.", await incompleteOwnersResponse.TextAsync());
+        Assert.Null(await conn.GetPendingListingRequestForPlugin(new PluginSlug(pluginSlug)));
+
+        await conn.RemovePluginOwner(new PluginSlug(pluginSlug), partialOwnerId);
+        await t.Page.ReloadAsync();
+        await Expect(t.Page.Locator("#owner-settings-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+
+        await t.Page.FillAsync("#ReleaseNote", "Testing release note entry");
+        await t.Page.FillAsync("#UserReviews", "https://example.com/review");
+        var telegramInput = t.Page.Locator("#TelegramVerificationMessage");
+        var invalidTelegramUrls = new[]
+        {
+            "http://t.me/btcpayserver/1234",
+            "https://example.com/btcpayserver/1234",
+            "https://t.me/not-btcpayserver/1234"
+        };
+        foreach (var invalidTelegramUrl in invalidTelegramUrls)
+        {
+            await telegramInput.FillAsync(invalidTelegramUrl);
+            await Expect(telegramInput).ToHaveAttributeAsync("aria-invalid", "true");
+            await Expect(telegramInput).ToHaveClassAsync(new Regex("\\bis-invalid\\b"));
+            await Expect(t.Page.Locator("#telegram-verification-message-error")).ToBeVisibleAsync();
+            await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Incomplete");
+            await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+        }
+
+        await t.Page.FillAsync("#TelegramVerificationMessage", "https://t.me/btcpayserver/1234");
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToHaveAttributeAsync("aria-invalid", "false");
+        await Expect(t.Page.Locator("#telegram-verification-message-error")).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#request-form-status")).ToHaveClassAsync(new Regex("\\btext-black\\b"));
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+
+        await t.Page.FillAsync("#ReleaseNote", "");
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Incomplete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+        await t.Page.FillAsync("#ReleaseNote", "Testing release note entry");
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+
+        await t.Page.EvaluateAsync("document.getElementById('TelegramVerificationMessage').value = 'https://example.com/not-a-telegram-message';");
+        await t.Page.ClickAsync("#SubmitListing");
+        var telegramFeedback = t.Page.Locator("#telegram-verification-message-error");
+        await Expect(telegramFeedback).ToBeVisibleAsync();
+        await Expect(telegramFeedback).ToContainTextAsync("Use a BTCPay Server Telegram message link");
+
+        await t.Page.FillAsync("#TelegramVerificationMessage", "https://t.me/btcpayserver/1234");
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToHaveAttributeAsync("aria-invalid", "false");
+        await Expect(telegramFeedback).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+
+        await t.Page.FillAsync("#UserReviews", "");
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Incomplete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeDisabledAsync();
+
+        await t.Page.FillAsync("#UserReviews", "https://example.com/review");
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+        await t.Page.ClickAsync("#SubmitListing");
         await t.AssertNoError();
         await t.Page.ClickAsync("#StoreNav-RequestListing");
 
         await Expect(t.Page.Locator("#collapsePluginSettings")).Not.ToBeVisibleAsync();
         await Expect(t.Page.Locator("#collapseOwnerSettings")).Not.ToBeVisibleAsync();
         await Expect(t.Page.Locator("#collapseRequestForm")).Not.ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Submitted");
+        await Expect(t.Page.Locator("#request-form-status")).ToHaveClassAsync(new Regex("\\bbg-success\\b"));
+        await Expect(t.Page.Locator("#request-form-status")).ToHaveClassAsync(new Regex("\\btext-black\\b"));
+        await Expect(t.Page.Locator("#SubmitListing")).ToHaveCountAsync(0);
+        await Expect(requestFormToggle).ToBeEnabledAsync();
+        await requestFormToggle.ClickAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToHaveValueAsync("Testing release note entry");
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToHaveValueAsync("https://t.me/btcpayserver/1234");
+        await Expect(t.Page.Locator("#UserReviews")).ToHaveValueAsync("https://example.com/review");
+        await Expect(t.Page.Locator("#ReleaseNote")).Not.ToBeEditableAsync();
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).Not.ToBeEditableAsync();
+        await Expect(t.Page.Locator("#UserReviews")).Not.ToBeEditableAsync();
+        await Expect(t.Page.Locator("#AnnouncementDate")).Not.ToBeEditableAsync();
         await Expect(t.Page.Locator(".alert-warning")).ToContainTextAsync("Your listing request has been sent and is pending validation");
 
+        var duplicateRequestResponse = await PostListingRequest(t.Page);
+        Assert.True(duplicateRequestResponse.Ok);
+        var requests = await conn.GetAllListingRequestsForPlugin(new PluginSlug(pluginSlug));
+        var pendingRequest = Assert.Single(requests);
+
         // Verify the listing request was created in the database
-        var pendingRequest = await conn.GetPendingListingRequestForPlugin(pluginSlug);
-        Assert.NotNull(pendingRequest);
         Assert.Equal("Testing release note entry", pendingRequest.ReleaseNote);
         Assert.Equal("https://t.me/btcpayserver/1234", pendingRequest.TelegramVerificationMessage);
-        Assert.Equal("Great plugin, works as expected!", pendingRequest.UserReviews);
+        Assert.Equal("https://example.com/review", pendingRequest.UserReviews);
         Assert.Equal(PluginListingRequestStatus.Pending, pendingRequest.Status);
+        Assert.Null(pendingRequest.LastReminderAt);
+        await Expect(t.Page.Locator("#send-listing-reminder-form")).ToHaveCountAsync(0);
 
-        // Simulate admin approval by setting plugin to listed
-        await conn.SetPluginSettings(pluginSlug, null, PluginVisibilityEnum.Listed);
-        await t.Page!.ClickAsync("#StoreNav-Dashboard");
-        var buttonCount = await t.Page.Locator("a.btn.btn-primary:has-text('Request Listing')").CountAsync();
-        Assert.Equal(0, buttonCount);
+        await conn.ExecuteAsync(
+            "UPDATE plugin_listing_requests SET submitted_at = CURRENT_TIMESTAMP - INTERVAL '8 days' WHERE id = @requestId",
+            new { requestId = pendingRequest.Id });
+
+        await using var firstReminderConnection = await connectionFactory.Open();
+        await using var secondReminderConnection = await connectionFactory.Open();
+        var reminderReservations = await Task.WhenAll(
+            firstReminderConnection.TryReserveListingRequestReminder(pendingRequest.Id, TimeSpan.FromDays(7)),
+            secondReminderConnection.TryReserveListingRequestReminder(pendingRequest.Id, TimeSpan.FromDays(7)));
+        Assert.Single(reminderReservations, reserved => reserved);
+
+        await conn.ExecuteAsync(
+            "UPDATE plugin_listing_requests SET last_reminder_at = NULL WHERE id = @requestId",
+            new { requestId = pendingRequest.Id });
+        await t.Page.ReloadAsync();
+
+        var reminderForm = t.Page.Locator("#send-listing-reminder-form");
+        await Expect(reminderForm).ToBeVisibleAsync();
+        var reminderAction = await reminderForm.GetAttributeAsync("action");
+        Assert.NotNull(reminderAction);
+        var reminderUrl = new Uri(new Uri(t.Page.Url), reminderAction).ToString();
+        var reminderToken = await reminderForm
+            .Locator("input[name='__RequestVerificationToken']")
+            .InputValueAsync();
+
+        var reminderStartedAt = DateTimeOffset.UtcNow;
+        await reminderForm.Locator("button[type='submit']").ClickAsync();
+        await Expect(t.Page.Locator(".alert-success")).ToContainTextAsync("Request listing reminders sent to admins");
+
+        var remindedRequest = await conn.GetPendingListingRequestForPlugin(pluginSlug);
+        Assert.NotNull(remindedRequest);
+        Assert.NotNull(remindedRequest.LastReminderAt);
+        var lastReminderAt = remindedRequest.LastReminderAt.Value;
+        Assert.InRange(lastReminderAt, reminderStartedAt, DateTimeOffset.UtcNow);
+        await Expect(t.Page.Locator("#send-listing-reminder-form")).ToHaveCountAsync(0);
+
+        var reminderFormData = t.Page.Context.APIRequest.CreateFormData();
+        reminderFormData.Set("__RequestVerificationToken", reminderToken);
+        var blockedReminderResponse = await t.Page.Context.APIRequest.PostAsync(
+            reminderUrl,
+            new APIRequestContextOptions { Form = reminderFormData });
+        Assert.True(blockedReminderResponse.Ok);
+        Assert.Contains("Please wait 7 days before sending another reminder", await blockedReminderResponse.TextAsync());
+
+        var blockedReminderRequest = await conn.GetPendingListingRequestForPlugin(pluginSlug);
+        Assert.Equal(lastReminderAt, blockedReminderRequest?.LastReminderAt);
+
+        await conn.ExecuteAsync(
+            "UPDATE plugin_listing_requests SET last_reminder_at = CURRENT_TIMESTAMP - INTERVAL '8 days' WHERE id = @requestId",
+            new { requestId = pendingRequest.Id });
+        await t.Page.ReloadAsync();
+        await Expect(reminderForm).ToBeVisibleAsync();
+
+        var secondReminderStartedAt = DateTimeOffset.UtcNow;
+        await reminderForm.Locator("button[type='submit']").ClickAsync();
+        await Expect(t.Page.Locator(".alert-success")).ToContainTextAsync("Request listing reminders sent to admins");
+
+        var secondRemindedRequest = await conn.GetPendingListingRequestForPlugin(pluginSlug);
+        Assert.NotNull(secondRemindedRequest);
+        Assert.NotNull(secondRemindedRequest.LastReminderAt);
+        var secondLastReminderAt = secondRemindedRequest.LastReminderAt.Value;
+        Assert.InRange(secondLastReminderAt, secondReminderStartedAt, DateTimeOffset.UtcNow);
+        await Expect(reminderForm).ToHaveCountAsync(0);
+
+        var longRejectionReason = new string('x', 1_000);
+        Assert.True(await conn.RejectListingRequest(pendingRequest.Id, partialOwnerId, longRejectionReason));
+        await t.Page.ReloadAsync();
+        await Expect(t.Page.Locator("#collapseRequestForm")).ToBeVisibleAsync();
+        await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Complete");
+        await Expect(t.Page.Locator("#SubmitListing")).ToContainTextAsync("Re-submit");
+        await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+        await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#UserReviews")).ToBeEditableAsync();
+
+        await t.Page.ClickAsync("a:text-is('View History')");
+        var rejectionReasonPreview = t.Page.Locator(".listing-history-rejection-preview");
+        await Expect(rejectionReasonPreview).ToHaveTextAsync(longRejectionReason);
+        Assert.Equal("ellipsis", await rejectionReasonPreview.EvaluateAsync<string>(
+            "element => getComputedStyle(element).textOverflow"));
+        var collapsedHeight = (await rejectionReasonPreview.BoundingBoxAsync())!.Height;
+        var rejectionReasonToggle = t.Page.Locator(".listing-history-rejection-toggle");
+        await Expect(rejectionReasonToggle).ToHaveAttributeAsync("aria-expanded", "false");
+        await rejectionReasonToggle.ClickAsync();
+        await Expect(rejectionReasonPreview).ToHaveClassAsync(new Regex("\\bis-expanded\\b"));
+        await Expect(rejectionReasonToggle).ToHaveAttributeAsync("aria-expanded", "true");
+        await Expect(rejectionReasonToggle).ToHaveAttributeAsync("aria-label", "Collapse rejection reason");
+        var expandedReasonBounds = (await rejectionReasonPreview.BoundingBoxAsync())!;
+        var expandedToggleBounds = (await rejectionReasonToggle.BoundingBoxAsync())!;
+        Assert.True(expandedReasonBounds.Height > collapsedHeight);
+        Assert.True(expandedToggleBounds.Width >= 24 && expandedToggleBounds.Height >= 24,
+            $"Expected a touch target of at least 24x24px, got {expandedToggleBounds.Width}x{expandedToggleBounds.Height}px.");
+        await Expect(t.Page.Locator(".listing-history-rejection-preview")).ToHaveCountAsync(1);
+        await rejectionReasonToggle.ClickAsync();
+        await Expect(rejectionReasonPreview).Not.ToHaveClassAsync(new Regex("\\bis-expanded\\b"));
+        await Expect(rejectionReasonToggle).ToHaveAttributeAsync("aria-expanded", "false");
+
     }
 
     [Fact]
@@ -120,7 +395,7 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         // Create a plugin with a pending listing request
         var pluginSlug = "test-plugin-" + PlaywrightTester.GetRandomUInt256()[..8];
         var userId = await t.Server.CreateFakeUserAsync();
-        var fullBuildId = await t.Server.CreateAndBuildPluginAsync(userId, pluginSlug);
+        await t.Server.CreateAndBuildPluginAsync(userId, pluginSlug);
 
         // Create a listing request
         var requestId = await conn.CreateListingRequest(
@@ -138,6 +413,10 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         // Navigate to listing requests page
         await t.GoToUrl("/admin/listing-requests");
         await Expect(t.Page!).ToHaveURLAsync(new Regex(".*/admin/listing-requests", RegexOptions.IgnoreCase));
+        var pendingRequestsBadge = t.Page.Locator("#AdminNav-ListingRequests .badge");
+        await Expect(pendingRequestsBadge).ToHaveTextAsync("1");
+        await Expect(pendingRequestsBadge).ToHaveClassAsync(new Regex("\\bbg-warning\\b"));
+        await Expect(pendingRequestsBadge).ToHaveClassAsync(new Regex("\\btext-black\\b"));
 
         // Verify the request is visible in the list - use table row to avoid ambiguity
         var row = t.Page.Locator($"tbody tr:has-text('{pluginSlug}')");
@@ -170,44 +449,6 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         // Verify plugin visibility was updated to listed
         var plugin = await conn.GetPluginDetails(pluginSlug);
         Assert.Equal(PluginVisibilityEnum.Listed, plugin!.Visibility);
-    }
-
-    [Fact]
-    public async Task Admin_Can_Reject_Pending_ListingRequest()
-    {
-        await using var t = new PlaywrightTester(_log);
-        t.Server.ReuseDatabase = false;
-        await t.StartAsync();
-        await using var conn = await t.Server.GetService<DBConnectionFactory>().Open();
-
-        var pluginSlug = "test-plugin-" + PlaywrightTester.GetRandomUInt256()[..8];
-        var userId = await t.Server.CreateFakeUserAsync();
-        await t.Server.CreateAndBuildPluginAsync(userId, pluginSlug);
-
-        var requestId = await conn.CreateListingRequest(
-            pluginSlug,
-            "Test plugin release note",
-            "https://t.me/btcpayserver/12345",
-            "https://example.com/review",
-            null);
-
-        var adminEmail = await t.CreateServerAdminAsync();
-        await t.LogIn(adminEmail);
-        await t.GoToUrl($"/admin/listing-requests/{requestId}");
-
-        await t.Page.ClickAsync("button.btn.btn-danger:text('Reject')");
-        await t.Page.FillAsync("#rejectionReason", "Plugin does not meet quality standards");
-        await t.Page.ClickAsync("button[type='submit'].btn.btn-danger:text('Reject')");
-
-        await Expect(t.Page).ToHaveURLAsync(new Regex(".*/admin/listing-requests$", RegexOptions.IgnoreCase));
-
-        var rejected = await conn.GetListingRequest(requestId);
-        Assert.NotNull(rejected);
-        Assert.Equal(PluginListingRequestStatus.Rejected, rejected.Status);
-        Assert.Equal("Plugin does not meet quality standards", rejected.RejectionReason);
-
-        var plugin = await conn.GetPluginDetails(pluginSlug);
-        Assert.Equal(PluginVisibilityEnum.Unlisted, plugin!.Visibility);
     }
 
     [Fact]
@@ -257,6 +498,26 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         // Verify plugin visibility was NOT changed
         var plugin = await conn.GetPluginDetails(pluginSlug);
         Assert.Equal(PluginVisibilityEnum.Unlisted, plugin!.Visibility);
+    }
+
+    private static async Task<IAPIResponse> PostListingRequest(IPage page)
+    {
+        var form = page.Locator("#request-listing-form");
+        var requestVerificationToken = await form
+            .Locator("input[name='__RequestVerificationToken']")
+            .InputValueAsync();
+        var action = await form.GetAttributeAsync("action");
+        Assert.NotNull(action);
+
+        var formData = page.Context.APIRequest.CreateFormData();
+        formData.Set("__RequestVerificationToken", requestVerificationToken);
+        formData.Set("ReleaseNote", "Crafted release note");
+        formData.Set("TelegramVerificationMessage", "https://t.me/btcpayserver/1234");
+        formData.Set("UserReviews", "https://example.com/review");
+
+        return await page.Context.APIRequest.PostAsync(
+            new Uri(new Uri(page.Url), action).ToString(),
+            new APIRequestContextOptions { Form = formData });
     }
 
 }

--- a/PluginBuilder/Components/MainNav/Default.cshtml
+++ b/PluginBuilder/Components/MainNav/Default.cshtml
@@ -125,7 +125,7 @@
                                         <span text-translate="true">Listing Requests</span>
                                         @if (Model.PendingListingRequestsCount > 0)
                                         {
-                                            <span class="badge bg-warning text-dark ms-1">@Model.PendingListingRequestsCount</span>
+                                            <span class="badge bg-warning text-black ms-1">@Model.PendingListingRequestsCount</span>
                                         }
                                     </a>
                                 </li>

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Npgsql;
 using PluginBuilder.Components.PluginVersion;
 using PluginBuilder.Controllers.Logic;
@@ -35,6 +34,8 @@ public class PluginController(
     ILogger<PluginController> logger)
     : Controller
 {
+    private static readonly TimeSpan _listingReminderCooldown = TimeSpan.FromDays(7);
+
     [HttpGet("settings")]
     public async Task<IActionResult> Settings(
         [ModelBinder(typeof(PluginSlugModelBinder))]
@@ -324,25 +325,11 @@ public class PluginController(
     PluginSlug pluginSlug)
     {
         await using var conn = await connectionFactory.Open();
-        var plugin = await conn.GetPluginDetails(pluginSlug);
-        if (plugin is null)
-            return NotFound();
-
-        var pluginSettings = SafeJson.Deserialize<PluginSettings>(plugin.Settings);
         var requests = await conn.GetAllListingRequestsForPlugin(pluginSlug);
         var vm = new ListingHistoryViewModel
         {
             PluginSlug = pluginSlug.ToString(),
-            PluginTitle = pluginSettings?.PluginTitle,
-            Requests = requests.Select(r => new ListingHistoryItemViewModel
-            {
-                Id = r.Id,
-                Status = r.Status,
-                ReleaseNote = r.ReleaseNote,
-                SubmittedAt = r.SubmittedAt,
-                ReviewedAt = r.ReviewedAt,
-                RejectionReason = r.RejectionReason
-            }).ToList()
+            Requests = requests
         };
         return View(vm);
     }
@@ -353,6 +340,7 @@ public class PluginController(
         PluginSlug pluginSlug)
     {
         var model = new RequestListingViewModel { PluginSlug = pluginSlug.ToString() };
+        var currentUserId = userManager.GetUserId(User) ?? string.Empty;
         await using var conn = await connectionFactory.Open();
         var plugin = await conn.GetPluginDetails(pluginSlug);
         if (plugin is null)
@@ -367,12 +355,12 @@ public class PluginController(
         var allRequests = await conn.GetAllListingRequestsForPlugin(pluginSlug);
         var pluginOwners = await conn.GetPluginOwners(pluginSlug);
         var pluginSettings = SafeJson.Deserialize<PluginSettings>(plugin.Settings);
-        var pendingRequest = await conn.GetPendingListingRequestForPlugin(pluginSlug);
-        var rejectedRequest = await conn.GetLatestRejectedListingRequestForPlugin(pluginSlug);
+        var pendingRequest = allRequests.FirstOrDefault(request => request.Status == PluginListingRequestStatus.Pending);
+        var rejectedRequest = allRequests.FirstOrDefault(request => request.Status == PluginListingRequestStatus.Rejected);
 
-        model.ReleaseNote = pluginSettings?.Description;
+        model.ReleaseNote = pluginSettings.Description;
         model.HasPreviousRejection = rejectedRequest != null;
-        model.HasRequests = allRequests.Any();
+        model.HasRequests = allRequests.Count != 0;
 
         if (pendingRequest != null)
         {
@@ -381,8 +369,8 @@ public class PluginController(
             model.UserReviews = pendingRequest.UserReviews;
             model.ReleaseNote = pendingRequest.ReleaseNote;
             model.AnnouncementDate = pendingRequest.AnnouncementDate;
-            var now = DateTimeOffset.UtcNow;
-            model.CanSendEmailReminder = now >= pendingRequest.SubmittedAt.AddDays(1);
+            var reminderCooldownStartedAt = pendingRequest.LastReminderAt ?? pendingRequest.SubmittedAt;
+            model.CanSendEmailReminder = DateTimeOffset.UtcNow >= reminderCooldownStartedAt.Add(_listingReminderCooldown);
             TempData[TempDataConstant.WarningMessage] = "Your listing request has been sent and is pending validation";
         }
         else if (rejectedRequest != null)
@@ -394,7 +382,7 @@ public class PluginController(
             model.AnnouncementDate = rejectedRequest.AnnouncementDate;
         }
 
-        model = await ListingRequirementsMet(conn, pluginSettings, pluginOwners, model);
+        PopulateListingRequirements(pluginSettings, pluginOwners, model, currentUserId);
         return View(model);
     }
 
@@ -405,75 +393,73 @@ public class PluginController(
     {
         await using var conn = await connectionFactory.Open();
         var plugin = await conn.GetPluginDetails(pluginSlug);
-        if (plugin is null)
-            return NotFound();
-
-        var pluginSettings = SafeJson.Deserialize<PluginSettings>(plugin.Settings);
-        if (plugin.Visibility == PluginVisibilityEnum.Hidden)
+        if (plugin is null || plugin.Visibility == PluginVisibilityEnum.Hidden)
             return NotFound();
 
         if (plugin.Visibility == PluginVisibilityEnum.Listed)
             return RedirectToAction(nameof(Dashboard), new { pluginSlug });
 
-        if (string.IsNullOrWhiteSpace(model.ReleaseNote))
-            ModelState.AddModelError(nameof(model.ReleaseNote), "Description is required.");
+        var pluginSettings = SafeJson.Deserialize<PluginSettings>(plugin.Settings);
+        if (await conn.HasPendingListingRequest(pluginSlug))
+            return RedirectToAction(nameof(RequestListing), new { pluginSlug });
 
-        if (string.IsNullOrWhiteSpace(model.TelegramVerificationMessage) ||
-            !Uri.TryCreate(model.TelegramVerificationMessage, UriKind.Absolute, out var telegramUri) ||
-            telegramUri.Scheme != Uri.UriSchemeHttps ||
-            !telegramUri.Host.Equals("t.me", StringComparison.OrdinalIgnoreCase) ||
-            !telegramUri.AbsolutePath.Trim('/').StartsWith("btcpayserver", StringComparison.OrdinalIgnoreCase))
+        var owners = await conn.GetPluginOwners(pluginSlug);
+        model.PluginSlug = pluginSlug.ToString();
+        var currentUserId = userManager.GetUserId(User) ?? string.Empty;
+        PopulateListingRequirements(pluginSettings, owners, model, currentUserId);
+
+        if (!model.PluginSettingsComplete)
+            ModelState.AddModelError(string.Empty, "Complete every required field in your plugin settings before submitting.");
+
+        if (!model.OwnerAccountsComplete)
+            ModelState.AddModelError(string.Empty, "Every plugin owner must verify Email, GitHub, and Nostr before submitting.");
+
+        if (!string.IsNullOrWhiteSpace(model.TelegramVerificationMessage) &&
+            !RequestListingViewModel.IsValidTelegramVerificationMessage(model.TelegramVerificationMessage))
             ModelState.AddModelError(nameof(model.TelegramVerificationMessage),
-                "Telegram verification message on BTCPay Server telegram (https://t.me/btcpayserver/... ) channel is required.");
-        if (string.IsNullOrWhiteSpace(model.UserReviews))
-            ModelState.AddModelError(nameof(model.UserReviews), "User-reviews link is required and must be an HTTPS URL.");
+                "Use a BTCPay Server Telegram message link (https://t.me/btcpayserver/...).");
 
         if (!ModelState.IsValid)
         {
-            var owners = await conn.GetPluginOwners(pluginSlug);
-            model.PendingListing = await conn.HasPendingListingRequest(pluginSlug);
-            model = await ListingRequirementsMet(conn, pluginSettings, owners, model);
+            var allRequests = await conn.GetAllListingRequestsForPlugin(pluginSlug);
+            model.HasRequests = allRequests.Count > 0;
+            model.HasPreviousRejection = allRequests.Any(request => request.Status == PluginListingRequestStatus.Rejected);
             return View(model);
         }
 
         await conn.CreateListingRequest(pluginSlug, model.ReleaseNote.Trim(), model.TelegramVerificationMessage.Trim(), model.UserReviews.Trim(),
             model.AnnouncementDate);
-        await SendRequestListingEmail(conn, pluginSlug.ToString());
+        await SendRequestListingEmail(conn, pluginSlug);
         TempData[TempDataConstant.SuccessMessage] = "Your listing request has been sent and is pending validation";
         return RedirectToAction(nameof(Dashboard), new { pluginSlug });
     }
 
-    private async Task<RequestListingViewModel> ListingRequirementsMet(NpgsqlConnection conn, PluginSettings pluginSettings, List<OwnerVm> owners,
-        RequestListingViewModel model)
+    private static void PopulateListingRequirements(PluginSettings pluginSettings, IReadOnlyCollection<OwnerVm> owners,
+        RequestListingViewModel model, string currentUserId)
     {
-        if (pluginSettings == null || owners == null || owners.Count == 0)
+        model.HasDescription = !string.IsNullOrWhiteSpace(pluginSettings.Description);
+        model.HasGitRepository = !string.IsNullOrWhiteSpace(pluginSettings.GitRepository);
+        model.HasDocumentation = !string.IsNullOrWhiteSpace(pluginSettings.Documentation);
+        model.HasVideoUrl = !string.IsNullOrWhiteSpace(pluginSettings.VideoUrl);
+        model.HasLogo = !string.IsNullOrWhiteSpace(pluginSettings.Logo);
+
+        model.Owners = owners.Select(owner =>
         {
-            model.Step = RequestListingViewModel.State.Invalid;
-            return model;
-        }
-
-        var docsMissing = string.IsNullOrWhiteSpace(pluginSettings?.GitRepository) || string.IsNullOrWhiteSpace(pluginSettings?.Documentation)
-                                                                                        || string.IsNullOrWhiteSpace(pluginSettings?.Logo)
-                                                                                        || string.IsNullOrWhiteSpace(pluginSettings?.Description)
-                                                                                        || string.IsNullOrWhiteSpace(pluginSettings?.VideoUrl);
-
-        var ownerNotVerified = false;
-        foreach (var owner in owners)
-            if (!await conn.IsSocialAccountsVerified(owner.UserId))
+            var accountSettings = SafeJson.Deserialize<AccountSettings>(owner.AccountDetail);
+            return new RequestListingOwnerViewModel
             {
-                ownerNotVerified = true;
-                break;
-            }
-
-        model.Step = (docsMissing, ownerNotVerified) switch
-        {
-            (true, _) => RequestListingViewModel.State.UpdatePluginSettings,
-            (false, true) => RequestListingViewModel.State.UpdateOwnerAccountSettings,
-            (false, false) => RequestListingViewModel.State.Done
-        };
-        return model;
+                UserId = owner.UserId,
+                Email = owner.Email,
+                IsPrimary = owner.IsPrimary,
+                IsCurrentUser = string.Equals(owner.UserId, currentUserId, StringComparison.Ordinal),
+                EmailVerified = owner.EmailConfirmed,
+                GithubVerified = !string.IsNullOrEmpty(owner.GithubGistUrl),
+                NostrVerified = !string.IsNullOrWhiteSpace(accountSettings.Nostr?.Npub)
+            };
+        }).ToList();
     }
 
+    [HttpPost]
     public async Task<IActionResult> SendReminder([ModelBinder(typeof(PluginSlugModelBinder))] PluginSlug pluginSlug)
     {
         await using var conn = await connectionFactory.Open();
@@ -488,21 +474,21 @@ public class PluginController(
             return RedirectToAction(nameof(Dashboard), new { pluginSlug });
         }
 
-        var now = DateTimeOffset.UtcNow;
-        if (now < request.SubmittedAt.AddDays(1))
+        if (!await conn.TryReserveListingRequestReminder(request.Id, _listingReminderCooldown))
         {
-            TempData[TempDataConstant.WarningMessage] = "Please wait 24 hours before sending another reminder";
+            TempData[TempDataConstant.WarningMessage] = "Please wait 7 days before sending another reminder";
             return RedirectToAction(nameof(Dashboard), new { pluginSlug });
         }
 
-        await SendRequestListingEmail(conn, pluginSlug.ToString());
+        await SendRequestListingEmail(conn, pluginSlug);
         TempData[TempDataConstant.SuccessMessage] = "Request listing reminders sent to admins";
         return RedirectToAction(nameof(RequestListing), new { pluginSlug });
     }
 
-    private async Task SendRequestListingEmail(NpgsqlConnection conn, string pluginSlug)
+    private async Task SendRequestListingEmail(NpgsqlConnection conn, PluginSlug pluginSlug)
     {
-        var pluginPublicUrl = Url.Action(nameof(HomeController.GetPluginDetails), "Home", new { pluginSlug }, Request.Scheme);
+        var pluginPublicUrl = Url.Action(nameof(HomeController.GetPluginDetails), "Home",
+            new { pluginSlug = pluginSlug.ToString() }, Request.Scheme);
         var listingReviewUrl = Url.Action(nameof(AdminController.ListingRequests), "Admin", new { }, Request.Scheme);
         await emailService.NotifyAdminOnNewRequestListing(conn, pluginSlug, pluginPublicUrl!, listingReviewUrl!);
     }

--- a/PluginBuilder/Data/Scripts/23.PluginListingReminderCooldown.sql
+++ b/PluginBuilder/Data/Scripts/23.PluginListingReminderCooldown.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plugin_listing_requests ADD COLUMN last_reminder_at TIMESTAMPTZ;

--- a/PluginBuilder/DataModels/PluginListingRequest.cs
+++ b/PluginBuilder/DataModels/PluginListingRequest.cs
@@ -10,6 +10,7 @@ public class PluginListingRequest
     public DateTimeOffset? AnnouncementDate { get; set; }
     public PluginListingRequestStatus Status { get; set; }
     public DateTimeOffset SubmittedAt { get; set; }
+    public DateTimeOffset? LastReminderAt { get; set; }
     public DateTimeOffset? ReviewedAt { get; set; }
     public string? ReviewedBy { get; set; }
     public string? RejectionReason { get; set; }
@@ -18,18 +19,7 @@ public class PluginListingRequest
 public class ListingHistoryViewModel
 {
     public string PluginSlug { get; set; } = null!;
-    public string? PluginTitle { get; set; }
-    public List<ListingHistoryItemViewModel> Requests { get; set; } = new();
-}
-
-public class ListingHistoryItemViewModel
-{
-    public int Id { get; set; }
-    public PluginListingRequestStatus Status { get; set; }
-    public string ReleaseNote { get; set; } = null!;
-    public DateTimeOffset SubmittedAt { get; set; }
-    public DateTimeOffset? ReviewedAt { get; set; }
-    public string? RejectionReason { get; set; }
+    public List<PluginListingRequest> Requests { get; set; } = new();
 }
 
 public enum PluginListingRequestStatus

--- a/PluginBuilder/PluginSettings.cs
+++ b/PluginBuilder/PluginSettings.cs
@@ -35,15 +35,4 @@ public class PluginSettings
 
     public List<string> Images { get; set; } = [];
     public bool RequireGPGSignatureForRelease { get; set; }
-    public PluginRequestListingRecord RequestListing { get; set; }
-}
-
-public class PluginRequestListingRecord
-{
-    public string ReleaseNote { get; set; }
-    public string TelegramVerificationMessage { get; set; }
-    public string UserReviews { get; set; }
-    public DateTimeOffset DateAdded { get; set; }
-    public DateTimeOffset LastReminderEmailSent { get; set; }
-    public DateTimeOffset? AnnouncementDate { get; set; }
 }

--- a/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
+++ b/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
@@ -118,19 +118,6 @@ public static class NpgsqlConnectionExtensions
         return !string.IsNullOrEmpty(githubGistUrl);
     }
 
-    public static async Task<bool> IsSocialAccountsVerified(this NpgsqlConnection connection, string userId)
-    {
-        var result = await connection.QuerySingleOrDefaultAsync<(string GithubGistUrl, string AccountDetail)>(
-            "SELECT \"GithubGistUrl\", \"AccountDetail\" FROM \"AspNetUsers\" WHERE \"Id\" = @userId AND \"EmailConfirmed\" = true",
-            new { userId });
-
-        if (string.IsNullOrEmpty(result.AccountDetail) || string.IsNullOrEmpty(result.GithubGistUrl))
-            return false;
-
-        var accountSettings = SafeJson.Deserialize<AccountSettings>(result.AccountDetail);
-        return !string.IsNullOrWhiteSpace(accountSettings?.Nostr?.Npub);
-    }
-
     #endregion
 
 
@@ -192,7 +179,8 @@ public static class NpgsqlConnectionExtensions
                                up.is_primary_owner  AS "IsPrimary",
                                u."Email",
                                u."AccountDetail",
-                               u."EmailConfirmed"
+                               u."EmailConfirmed",
+                               u."GithubGistUrl"
                            FROM users_plugins up
                            JOIN "AspNetUsers" u ON u."Id" = up.user_id
                            WHERE up.plugin_slug = @slug
@@ -780,6 +768,7 @@ public static class NpgsqlConnectionExtensions
                                   announcement_date AS "AnnouncementDate",
                                   status AS "Status",
                                   submitted_at AS "SubmittedAt",
+                                  last_reminder_at AS "LastReminderAt",
                                   reviewed_at AS "ReviewedAt",
                                   reviewed_by AS "ReviewedBy",
                                   rejection_reason AS "RejectionReason"
@@ -801,6 +790,7 @@ public static class NpgsqlConnectionExtensions
                                   announcement_date AS "AnnouncementDate",
                                   status AS "Status",
                                   submitted_at AS "SubmittedAt",
+                                  last_reminder_at AS "LastReminderAt",
                                   reviewed_at AS "ReviewedAt",
                                   reviewed_by AS "ReviewedBy",
                                   rejection_reason AS "RejectionReason"
@@ -845,27 +835,17 @@ public static class NpgsqlConnectionExtensions
         return await connection.ExecuteScalarAsync<bool>(sql, new { pluginSlug = pluginSlug.ToString() });
     }
 
-    public static async Task<PluginListingRequest?> GetLatestRejectedListingRequestForPlugin(this NpgsqlConnection connection, PluginSlug pluginSlug)
+    public static async Task<bool> TryReserveListingRequestReminder(this NpgsqlConnection connection, int requestId, TimeSpan cooldown)
     {
         const string sql = """
-                           SELECT id AS "Id",
-                                  plugin_slug AS "PluginSlug",
-                                  release_note AS "ReleaseNote",
-                                  telegram_verification_message AS "TelegramVerificationMessage",
-                                  user_reviews AS "UserReviews",
-                                  announcement_date AS "AnnouncementDate",
-                                  status AS "Status",
-                                  submitted_at AS "SubmittedAt",
-                                  reviewed_at AS "ReviewedAt",
-                                  reviewed_by AS "ReviewedBy",
-                                  rejection_reason AS "RejectionReason"
-                           FROM plugin_listing_requests
-                           WHERE plugin_slug = @pluginSlug AND status = 'rejected'
-                           ORDER BY submitted_at DESC
-                           LIMIT 1
+                           UPDATE plugin_listing_requests
+                           SET last_reminder_at = CURRENT_TIMESTAMP
+                           WHERE id = @requestId
+                             AND status = 'pending'
+                             AND COALESCE(last_reminder_at, submitted_at) <= CURRENT_TIMESTAMP - @cooldown
                            """;
 
-        return await connection.QueryFirstOrDefaultAsync<PluginListingRequest>(sql, new { pluginSlug = pluginSlug.ToString() });
+        return await connection.ExecuteAsync(sql, new { requestId, cooldown }) == 1;
     }
 
     public static async Task<List<PluginListingRequest>> GetAllListingRequestsForPlugin(this NpgsqlConnection connection, PluginSlug pluginSlug)
@@ -879,6 +859,7 @@ public static class NpgsqlConnectionExtensions
                               announcement_date AS "AnnouncementDate",
                               status AS "Status",
                               submitted_at AS "SubmittedAt",
+                              last_reminder_at AS "LastReminderAt",
                               reviewed_at AS "ReviewedAt",
                               reviewed_by AS "ReviewedBy",
                               rejection_reason AS "RejectionReason"

--- a/PluginBuilder/ViewModels/Plugin/PluginOwnersPageViewModel.cs
+++ b/PluginBuilder/ViewModels/Plugin/PluginOwnersPageViewModel.cs
@@ -6,8 +6,6 @@ public class PluginOwnersPageViewModel
     public string CurrentUserId { get; set; } = string.Empty;
     public bool IsPrimaryOwner { get; set; }
     public List<OwnerVm> Owners { get; set; } = new();
-
-    public OwnerVm? PrimaryOwner => Owners.FirstOrDefault(o => o.IsPrimary);
 }
 
-public record OwnerVm(string UserId, bool IsPrimary, string? Email, string? AccountDetail, bool EmailConfirmed);
+public record OwnerVm(string UserId, bool IsPrimary, string? Email, string? AccountDetail, bool EmailConfirmed, string? GithubGistUrl);

--- a/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
+++ b/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
@@ -4,31 +4,60 @@ namespace PluginBuilder.ViewModels;
 
 public class RequestListingViewModel
 {
-    public enum State
-    {
-        Invalid,
-        UpdateOwnerAccountSettings,
-        UpdatePluginSettings,
-        Done
-    }
-
     public string PluginSlug { get; set; } = string.Empty;
 
     [MaxLength(200)]
-    [Required]
+    [Required(ErrorMessage = "Release note is required.")]
     public string ReleaseNote { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Telegram verification message is required.")]
     [Display(Name = "Telegram Verification Message")]
     public string TelegramVerificationMessage { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "User reviews are required.")]
     [Display(Name = "User Reviews")]
     public string UserReviews { get; set; } = string.Empty;
     public bool HasRequests { get; set; }
     public bool PendingListing { get; set; }
     public bool HasPreviousRejection { get; set; }
     public bool CanSendEmailReminder { get; set; }
-    public State Step { get; set; }
     public DateTimeOffset? AnnouncementDate { get; set; }
+
+    public bool HasDescription { get; set; }
+    public bool HasGitRepository { get; set; }
+    public bool HasDocumentation { get; set; }
+    public bool HasVideoUrl { get; set; }
+    public bool HasLogo { get; set; }
+    public List<RequestListingOwnerViewModel> Owners { get; set; } = [];
+
+    public bool PluginSettingsComplete =>
+        HasDescription && HasGitRepository && HasDocumentation && HasVideoUrl && HasLogo;
+
+    public bool OwnerAccountsComplete => Owners.Count > 0 && Owners.All(owner => owner.Complete);
+    public bool ListingFormComplete =>
+        !string.IsNullOrWhiteSpace(ReleaseNote) &&
+        IsValidTelegramVerificationMessage(TelegramVerificationMessage) &&
+        !string.IsNullOrWhiteSpace(UserReviews);
+    public bool CanSubmit => !PendingListing && PluginSettingsComplete && OwnerAccountsComplete && ListingFormComplete;
+
+    public static bool IsValidTelegramVerificationMessage(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+               Uri.TryCreate(value, UriKind.Absolute, out var telegramUri) &&
+               telegramUri.Scheme == Uri.UriSchemeHttps &&
+               telegramUri.Host.Equals("t.me", StringComparison.OrdinalIgnoreCase) &&
+               telegramUri.AbsolutePath.Trim('/').StartsWith("btcpayserver", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+public class RequestListingOwnerViewModel
+{
+    public string UserId { get; set; } = string.Empty;
+    public string? Email { get; set; }
+    public bool IsPrimary { get; set; }
+    public bool IsCurrentUser { get; set; }
+    public bool EmailVerified { get; set; }
+    public bool GithubVerified { get; set; }
+    public bool NostrVerified { get; set; }
+    public bool Complete => EmailVerified && GithubVerified && NostrVerified;
 }

--- a/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
+++ b/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
@@ -42,11 +42,15 @@ public class RequestListingViewModel
 
     public static bool IsValidTelegramVerificationMessage(string? value)
     {
-        return !string.IsNullOrWhiteSpace(value) &&
-               Uri.TryCreate(value, UriKind.Absolute, out var telegramUri) &&
-               telegramUri.Scheme == Uri.UriSchemeHttps &&
+        if (string.IsNullOrWhiteSpace(value) ||
+            !Uri.TryCreate(value, UriKind.Absolute, out var telegramUri))
+            return false;
+
+        var segments = telegramUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return telegramUri.Scheme == Uri.UriSchemeHttps &&
                telegramUri.Host.Equals("t.me", StringComparison.OrdinalIgnoreCase) &&
-               telegramUri.AbsolutePath.Trim('/').StartsWith("btcpayserver", StringComparison.OrdinalIgnoreCase);
+               segments.Length >= 2 &&
+               segments[0].Equals("btcpayserver", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/PluginBuilder/Views/Plugin/ListingHistory.cshtml
+++ b/PluginBuilder/Views/Plugin/ListingHistory.cshtml
@@ -3,7 +3,7 @@
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(PluginNavPages.RequestListing, "Listing History");
-    ViewData["Title"] = "Listing History";
+    const int rejectionPreviewLength = 160;
 }
 <div class="d-flex align-items-center justify-content-between mb-4">
     <h2 class="mb-0">@ViewData["Title"]</h2>
@@ -32,13 +32,35 @@ else
             <tbody>
                 @foreach (var request in Model.Requests)
                 {
+                    var rejectionReason = request.RejectionReason;
+                    var showExpandableRejectionReason = !string.IsNullOrEmpty(rejectionReason) &&
+                                                        (rejectionReason.Length > rejectionPreviewLength ||
+                                                         rejectionReason.Contains('\n') ||
+                                                         rejectionReason.Contains('\r'));
                     <tr>
                         <td class="text-nowrap small">@request.SubmittedAt.UtcDateTime.ToString("MMM dd, yyyy · HH:mm UTC")</td>
                         <td>@request.ReleaseNote</td>
                         <td>
-                            @if (!string.IsNullOrEmpty(request.RejectionReason))
+                            @if (!string.IsNullOrEmpty(rejectionReason))
                             {
-                                <span class="text-danger" style="white-space: pre-wrap;">@request.RejectionReason</span>
+                                @if (showExpandableRejectionReason)
+                                {
+                                    <div class="listing-history-rejection-summary d-flex align-items-start gap-2">
+                                        <div id="rejectionReason-@request.Id"
+                                             class="listing-history-rejection-preview text-truncate text-break flex-grow-1">@rejectionReason</div>
+                                        <button type="button"
+                                                class="listing-history-rejection-toggle btn btn-sm p-1 border-0 text-muted flex-shrink-0"
+                                                data-rejection-reason-toggle
+                                                aria-expanded="false" aria-controls="rejectionReason-@request.Id"
+                                                aria-label="Expand rejection reason">
+                                            <vc:icon symbol="caret-down" />
+                                        </button>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="listing-history-rejection text-break">@rejectionReason</div>
+                                }
                             }
                             else
                             {
@@ -59,10 +81,10 @@ else
                             @switch (request.Status)
                             {
                                 case PluginListingRequestStatus.Pending:
-                                    <span class="badge bg-warning">Pending</span>
+                                    <span class="badge bg-warning text-black">Pending</span>
                                     break;
                                 case PluginListingRequestStatus.Approved:
-                                    <span class="badge bg-success">Approved</span>
+                                    <span class="badge bg-success text-black">Approved</span>
                                     break;
                                 case PluginListingRequestStatus.Rejected:
                                     <span class="badge bg-danger">Rejected</span>
@@ -74,4 +96,48 @@ else
             </tbody>
         </table>
     </div>
+}
+
+@section HeaderScripts {
+    <style>
+        .listing-history-rejection,
+        .listing-history-rejection-summary {
+            max-width: 40rem;
+        }
+
+        .listing-history-rejection {
+            white-space: pre-wrap;
+        }
+
+        .listing-history-rejection-preview {
+            min-width: 0;
+        }
+
+        .listing-history-rejection-preview.is-expanded {
+            overflow: visible;
+            text-overflow: clip;
+            white-space: pre-wrap;
+        }
+
+        .listing-history-rejection-toggle svg.icon {
+            width: 1rem;
+            height: 1rem;
+            margin-left: 0;
+        }
+    </style>
+}
+
+@section FooterScripts {
+    <script>
+        document.querySelectorAll("[data-rejection-reason-toggle]").forEach(toggle => {
+            toggle.addEventListener("click", () => {
+                const reason = document.getElementById(toggle.getAttribute("aria-controls"));
+                const expanded = toggle.getAttribute("aria-expanded") === "true";
+
+                reason.classList.toggle("is-expanded", !expanded);
+                toggle.setAttribute("aria-expanded", (!expanded).toString());
+                toggle.setAttribute("aria-label", expanded ? "Expand rejection reason" : "Collapse rejection reason");
+            });
+        });
+    </script>
 }

--- a/PluginBuilder/Views/Plugin/RequestListing.cshtml
+++ b/PluginBuilder/Views/Plugin/RequestListing.cshtml
@@ -306,10 +306,11 @@
 
                     try {
                         const url = new URL(trimmed);
-                        const path = url.pathname.split("/").filter(Boolean).join("/");
+                        const segments = url.pathname.split("/").filter(Boolean);
                         return url.protocol === "https:" &&
                                url.hostname.toLowerCase() === "t.me" &&
-                               path.toLowerCase().startsWith("btcpayserver");
+                               segments.length >= 2 &&
+                               segments[0].toLowerCase() === "btcpayserver";
                     } catch {
                         return false;
                     }

--- a/PluginBuilder/Views/Plugin/RequestListing.cshtml
+++ b/PluginBuilder/Views/Plugin/RequestListing.cshtml
@@ -70,7 +70,7 @@
         <h3 class="accordion-header" id="pluginSettingsHeader">
             <button class="accordion-button @(settingsExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
                     data-bs-target="#collapsePluginSettings"
-                    aria-expanded="@settingsExpanded" aria-controls="collapsePluginSettings">
+                    aria-expanded="@(settingsExpanded ? "true" : "false")" aria-controls="collapsePluginSettings">
                 <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
                     <span class="requirement-status-icon @(settingsComplete ? "text-success" : "text-danger")" aria-hidden="true">
                         <vc:icon symbol="@(settingsComplete ? "checkmark" : "cross")" />
@@ -113,7 +113,7 @@
         <h3 class="accordion-header" id="ownerSettingsHeader">
             <button class="accordion-button @(ownersExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
                     data-bs-target="#collapseOwnerSettings"
-                    aria-expanded="@ownersExpanded" aria-controls="collapseOwnerSettings">
+                    aria-expanded="@(ownersExpanded ? "true" : "false")" aria-controls="collapseOwnerSettings">
                 <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
                     <span class="requirement-status-icon @(ownersComplete ? "text-success" : "text-danger")" aria-hidden="true">
                         <vc:icon symbol="@(ownersComplete ? "checkmark" : "cross")" />
@@ -192,7 +192,7 @@
         <h3 class="accordion-header" id="requestFormHeader">
             <button class="accordion-button @(formExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
                     data-bs-target="#collapseRequestForm"
-                    aria-expanded="@formExpanded" aria-controls="collapseRequestForm">
+                    aria-expanded="@(formExpanded ? "true" : "false")" aria-controls="collapseRequestForm">
                 <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
                     <span class="requirement-status-icon" aria-hidden="true">
                         <span id="request-form-icon-complete" class="text-success @(formComplete ? "" : "d-none")">

--- a/PluginBuilder/Views/Plugin/RequestListing.cshtml
+++ b/PluginBuilder/Views/Plugin/RequestListing.cshtml
@@ -2,32 +2,63 @@
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(PluginNavPages.RequestListing, "Plugin Listing Request");
-    var step3Completed = Model.PendingListing;
-    var step1Completed = Model.Step != RequestListingViewModel.State.UpdatePluginSettings;
-    var step2Completed = Model.Step != RequestListingViewModel.State.UpdateOwnerAccountSettings && Model.Step != RequestListingViewModel.State.UpdatePluginSettings;
-    var step1Expanded = !step1Completed;
-    var step2Expanded = step1Completed && !step2Completed;
-    var step3Expanded = step1Completed && step2Completed && !step3Completed;
+
+    var settingsComplete = Model.PluginSettingsComplete;
+    var ownersComplete = Model.OwnerAccountsComplete;
+    var formSubmitted = Model.PendingListing;
+    var prerequisitesComplete = settingsComplete && ownersComplete;
+
+    var listingFormFields = new[]
+    {
+        nameof(Model.ReleaseNote),
+        nameof(Model.TelegramVerificationMessage),
+        nameof(Model.UserReviews),
+        nameof(Model.AnnouncementDate)
+    };
+    var formHasErrors = listingFormFields.Any(field =>
+        ViewData.ModelState.TryGetValue(field, out var state) && state.Errors.Count > 0);
+    var formComplete = formSubmitted || (Model.ListingFormComplete && !formHasErrors);
+    var canSubmit = Model.CanSubmit && !formHasErrors;
+
+    var settingsRequirements = new[]
+    {
+        (Id: "plugin-requirement-description", Label: "Description", Complete: Model.HasDescription, HasDivider: true),
+        (Id: "plugin-requirement-git-repository", Label: "Git Repository", Complete: Model.HasGitRepository, HasDivider: true),
+        (Id: "plugin-requirement-documentation", Label: "Documentation URL", Complete: Model.HasDocumentation, HasDivider: true),
+        (Id: "plugin-requirement-video-url", Label: "Video URL", Complete: Model.HasVideoUrl, HasDivider: true),
+        (Id: "plugin-requirement-logo", Label: "Logo", Complete: Model.HasLogo, HasDivider: false)
+    };
+
+    var settingsExpanded = !formSubmitted && !settingsComplete;
+    var ownersExpanded = !formSubmitted && settingsComplete && !ownersComplete;
+    var formExpanded = !formSubmitted && settingsComplete && ownersComplete;
 }
 
-<div class="d-flex align-items-center justify-content-between mb-4">
-    <h2 class="mb-0">@ViewData["Title"]</h2>
-    <div class="d-flex align-items-center gap-3 mt-3 mt-sm-0">
+<div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-4">
+    <div>
+        <h2 class="mb-2">@ViewData["Title"]</h2>
+        <p class="text-muted mb-0">
+            Complete all required steps below to submit your plugin for listing.
+        </p>
+    </div>
+    <div class="d-flex flex-wrap align-items-center justify-content-end gap-3 mt-1 ms-auto">
         @if (Model.HasRequests)
-		{
-			<a asp-action="ListingHistory" asp-route-pluginSlug="@Model.PluginSlug" class="btn btn-outline-secondary btn-sm">
-				View History
-			</a>
-		}
+        {
+            <a asp-action="ListingHistory" asp-route-pluginSlug="@Model.PluginSlug" class="btn btn-outline-secondary btn-sm">
+                View History
+            </a>
+        }
         @if (!Model.PendingListing)
         {
-            <button type="submit" form="request-listing-form" class="btn btn-success" @(Model.Step == RequestListingViewModel.State.Done ? "" : "disabled")>
+            <button id="SubmitListing" type="submit" form="request-listing-form" class="btn btn-success"
+                    disabled="@(!canSubmit)">
                 @(Model.HasPreviousRejection ? "Re-submit" : "Submit")
             </button>
         }
         @if (Model.PendingListing && Model.CanSendEmailReminder)
         {
-            <form asp-controller="Plugin" asp-action="SendReminder" asp-route-pluginSlug="@Model.PluginSlug" method="post" class="d-inline">
+            <form id="send-listing-reminder-form" asp-controller="Plugin" asp-action="SendReminder"
+                  asp-route-pluginSlug="@Model.PluginSlug" method="post" class="d-inline">
                 <button type="submit" class="btn btn-success">Send Reminder</button>
             </form>
         }
@@ -37,120 +68,197 @@
 <div class="accordion" id="requestListingAccordion">
     <div class="accordion-item">
         <h3 class="accordion-header" id="pluginSettingsHeader">
-            <button class="accordion-button @(step1Expanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
+            <button class="accordion-button @(settingsExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
                     data-bs-target="#collapsePluginSettings"
-                    aria-expanded="@step1Expanded" aria-controls="collapsePluginSettings">
-                <h5>
-                    @if (step1Completed)
-                    {
-                        <vc:icon symbol="checkmark" />
-                    }
-                    else
-                    {
-                        <vc:icon symbol="cross" />
-                    }
-                    <span>Update Plugin Settings</span>
-                </h5>
-                <vc:icon symbol="caret-down" />
+                    aria-expanded="@settingsExpanded" aria-controls="collapsePluginSettings">
+                <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
+                    <span class="requirement-status-icon @(settingsComplete ? "text-success" : "text-danger")" aria-hidden="true">
+                        <vc:icon symbol="@(settingsComplete ? "checkmark" : "cross")" />
+                    </span>
+                    <span class="fw-semibold">Update Plugin Settings</span>
+                    <span id="plugin-settings-status" class="badge @(settingsComplete ? "bg-success text-black" : "bg-danger")">
+                        @(settingsComplete ? "Complete" : "Incomplete")
+                    </span>
+                </span>
+                <span class="ms-auto" aria-hidden="true"><vc:icon symbol="caret-down" /></span>
             </button>
         </h3>
-        <div id="collapsePluginSettings" class="accordion-collapse collapse @(step1Expanded ? "show" : "")" aria-labelledby="pluginSettingsHeader"
-             data-bs-parent="#requestListingAccordion">
+        <div id="collapsePluginSettings" class="accordion-collapse collapse @(settingsExpanded ? "show" : "")"
+            aria-labelledby="pluginSettingsHeader" data-bs-parent="#requestListingAccordion">
             <div class="accordion-body">
-                <p>
-                    Your plugin must include Logo, Documentation URL, Video URL and Git Repository. Click
-                    <a asp-controller="Plugin" asp-action="Settings" asp-route-pluginSlug="@Model.PluginSlug" class="text-success text-decoration-none">this
-                        link</a>
-                    to go to your plugin settings to complete the process
+                <p class="text-muted mb-3">
+                    Complete every required field in your
+                    <a id="UpdatePluginSettingsLink" asp-controller="Plugin" asp-action="Settings"
+                       asp-route-pluginSlug="@Model.PluginSlug">plugin settings</a>.
                 </p>
+                <div class="d-flex flex-column mb-3">
+                    @foreach (var requirement in settingsRequirements)
+                    {
+                        <div id="@requirement.Id" class="d-flex flex-wrap align-items-center justify-content-between gap-2 py-2 @(requirement.HasDivider ? "border-bottom" : "")">
+                            <span class="d-inline-flex align-items-center gap-2 fw-semibold">
+                                <span class="@(requirement.Complete ? "text-success" : "text-danger")" aria-hidden="true">
+                                    <vc:icon symbol="@(requirement.Complete ? "checkmark" : "cross")" />
+                                </span>
+                                @requirement.Label
+                            </span>
+                            <span class="small @(requirement.Complete ? "text-success" : "text-danger")">@(requirement.Complete ? "Complete" : "Missing")</span>
+                        </div>
+                    }
+                </div>
             </div>
         </div>
     </div>
 
     <div class="accordion-item">
         <h3 class="accordion-header" id="ownerSettingsHeader">
-            <button class="accordion-button @(step2Expanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOwnerSettings"
-                    aria-expanded="@step2Expanded" aria-controls="collapseOwnerSettings">
-                <h5>
-                    @if (step2Completed)
-                    {
-                        <vc:icon symbol="checkmark" />
-                    }
-                    else
-                    {
-                        <vc:icon symbol="cross" />
-                    }
-                    <span>Verify Social Accounts for Plugin Owners</span>
-                </h5>
-                <vc:icon symbol="caret-down" />
+            <button class="accordion-button @(ownersExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#collapseOwnerSettings"
+                    aria-expanded="@ownersExpanded" aria-controls="collapseOwnerSettings">
+                <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
+                    <span class="requirement-status-icon @(ownersComplete ? "text-success" : "text-danger")" aria-hidden="true">
+                        <vc:icon symbol="@(ownersComplete ? "checkmark" : "cross")" />
+                    </span>
+                    <span class="fw-semibold">Verify Social Accounts for Plugin Owners</span>
+                    <span id="owner-settings-status" class="badge @(ownersComplete ? "bg-success text-black" : "bg-danger")">
+                        @(ownersComplete ? "Complete" : "Incomplete")
+                    </span>
+                </span>
+                <span class="ms-auto" aria-hidden="true"><vc:icon symbol="caret-down" /></span>
             </button>
         </h3>
-        <div id="collapseOwnerSettings" class="accordion-collapse collapse @(step2Expanded ? "show" : "")" aria-labelledby="ownerSettingsHeader"
-             data-bs-parent="#requestListingAccordion">
+        <div id="collapseOwnerSettings" class="accordion-collapse collapse @(ownersExpanded ? "show" : "")"
+             aria-labelledby="ownerSettingsHeader" data-bs-parent="#requestListingAccordion">
             <div class="accordion-body">
-                <p>
-                    All plugin owners must verify Email, Nostr, and GitHub. Click
-                    <a asp-controller="Account" asp-action="AccountDetails" class="text-success text-decoration-none">this link</a> to verify your accounts.
-                    If you have other owners, kindly ask them to do the same.
-                </p>
+                <p class="text-muted mb-3">Every plugin owner must verify Email, GitHub, and Nostr.</p>
+                @if (Model.Owners.Count == 0)
+                {
+                    <p class="text-danger mb-3">At least one plugin owner is required.</p>
+                }
+                else
+                {
+                    <div class="d-flex flex-column mb-3">
+                        @for (var ownerIndex = 0; ownerIndex < Model.Owners.Count; ownerIndex++)
+                        {
+                            var owner = Model.Owners[ownerIndex];
+                            var ownerLabel = string.IsNullOrWhiteSpace(owner.Email) ? owner.UserId : owner.Email;
+                            var ownerVerifications = new[]
+                            {
+                                (Key: "email", Label: "Email", Verified: owner.EmailVerified),
+                                (Key: "github", Label: "GitHub", Verified: owner.GithubVerified),
+                                (Key: "nostr", Label: "Nostr", Verified: owner.NostrVerified)
+                            };
+                            <div class="py-3 @(ownerIndex < Model.Owners.Count - 1 ? "border-bottom" : "")" data-owner-id="@owner.UserId">
+                                <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                                    <span class="fw-semibold text-break">@ownerLabel</span>
+                                    @if (owner.IsCurrentUser)
+                                    {
+                                        <span class="badge bg-secondary">You</span>
+                                    }
+                                    @if (owner.IsPrimary)
+                                    {
+                                        <span class="badge bg-primary text-black">Primary</span>
+                                    }
+                                </div>
+                                <div class="d-flex flex-column gap-1">
+                                    @foreach (var verification in ownerVerifications)
+                                    {
+                                        <div data-verification="@verification.Key" class="d-flex flex-wrap align-items-center justify-content-between gap-2 small">
+                                            <span class="d-inline-flex align-items-center gap-2">
+                                                <span class="@(verification.Verified ? "text-success" : "text-danger")" aria-hidden="true">
+                                                    <vc:icon symbol="@(verification.Verified ? "checkmark" : "cross")" />
+                                                </span>
+                                                @verification.Label
+                                            </span>
+                                            <span class="@(verification.Verified ? "text-success" : "text-danger")">@(verification.Verified ? "Verified" : "Not verified")</span>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+
+                @if (Model.Owners.Any(owner => owner.IsCurrentUser && !owner.Complete))
+                {
+                    <a asp-controller="Account" asp-action="AccountDetails" class="btn btn-outline-secondary btn-sm">
+                        Verify my accounts
+                    </a>
+                }
             </div>
         </div>
     </div>
 
     <div class="accordion-item">
         <h3 class="accordion-header" id="requestFormHeader">
-            <button class="accordion-button @(step3Expanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRequestForm"
-                    aria-expanded="@step3Expanded" aria-controls="collapseRequestForm">
-                <h5>
-                    @if (step3Completed)
-                    {
-                        <vc:icon symbol="checkmark" />
-                    }
-                    else
-                    {
-                        <vc:icon symbol="cross" />
-                    }
-                    <span>Plugin Listing Form</span>
-                </h5>
-                <vc:icon symbol="caret-down" />
+            <button class="accordion-button @(formExpanded ? "" : "collapsed")" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#collapseRequestForm"
+                    aria-expanded="@formExpanded" aria-controls="collapseRequestForm">
+                <span class="d-flex flex-wrap align-items-center gap-2 flex-grow-1">
+                    <span class="requirement-status-icon" aria-hidden="true">
+                        <span id="request-form-icon-complete" class="text-success @(formComplete ? "" : "d-none")">
+                            <vc:icon symbol="checkmark" />
+                        </span>
+                        <span id="request-form-icon-incomplete" class="text-danger @(formComplete ? "d-none" : "")">
+                            <vc:icon symbol="cross" />
+                        </span>
+                    </span>
+                    <span class="fw-semibold">Plugin Listing Form</span>
+                    <span id="request-form-status"
+                          class="badge @(formComplete ? "bg-success text-black" : "bg-danger")"
+                          aria-live="polite">
+                        @(formSubmitted ? "Submitted" : formComplete ? "Complete" : "Incomplete")
+                    </span>
+                </span>
+                <span class="ms-auto" aria-hidden="true"><vc:icon symbol="caret-down" /></span>
             </button>
         </h3>
 
-        <div id="collapseRequestForm" class="accordion-collapse collapse @(step3Expanded ? "show" : "")" aria-labelledby="requestFormHeader"
-             data-bs-parent="#requestListingAccordion">
+        <div id="collapseRequestForm" class="accordion-collapse collapse @(formExpanded ? "show" : "")"
+             aria-labelledby="requestFormHeader" data-bs-parent="#requestListingAccordion">
             <div class="accordion-body">
                 <div class="col-xl-8 col-xxl-constrain">
-                    <form id="request-listing-form" asp-action="RequestListing" method="post" enctype="multipart/form-data">
+                    <form id="request-listing-form" asp-action="RequestListing" method="post">
                         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                         <div class="form-group">
-                            <label asp-for="ReleaseNote" class="form-label" data-required>Release Note <span
-                                    class="text-muted">(max 200 characters)</span></label>
-                            <textarea asp-for="ReleaseNote" rows="2" maxlength="200" class="form-control" required></textarea>
+                            <label asp-for="ReleaseNote" class="form-label" data-required>
+                                Release Note <span class="text-muted">(max 200 characters)</span>
+                            </label>
+                            <textarea asp-for="ReleaseNote" rows="2" maxlength="200" class="form-control" required
+                                      readonly="@formSubmitted"></textarea>
                             <span asp-validation-for="ReleaseNote" class="text-danger"></span>
                             <div class="text-muted">We will use this in BTCPay Server's social post. Refine it as an elevator pitch.
-                                <a href="https://x.com/BtcpayServer/status/1981029395818025195" target="_blank">Example</a>
+                                <a href="https://x.com/BtcpayServer/status/1981029395818025195" target="_blank" rel="noopener">Example</a>
                             </div>
                         </div>
                         <div class="form-group">
                             <label asp-for="TelegramVerificationMessage" class="form-label" data-required></label>
-                            <input asp-for="TelegramVerificationMessage" class="form-control" required />
-                            <span asp-validation-for="TelegramVerificationMessage" class="text-danger"></span>
+                            <input asp-for="TelegramVerificationMessage" type="url" class="form-control" required
+                                   readonly="@formSubmitted"
+                                   aria-describedby="telegram-verification-message-error" />
+                            <span asp-validation-for="TelegramVerificationMessage" id="telegram-verification-message-error"
+                                  class="text-danger"
+                                  data-client-message="Use a BTCPay Server Telegram message link (https://t.me/btcpayserver/...)."></span>
                             <div class="text-muted">Join our Telegram channel so we can be in touch and post a bit about your plugin.
-                                <a href="https://t.me/btcpayserver/91512" target="_blank">Example</a>
+                                <a href="https://t.me/btcpayserver/91512" target="_blank" rel="noopener">Example</a>
                             </div>
                         </div>
                         <div class="form-group">
                             <label asp-for="UserReviews" class="form-label" data-required></label>
-                            <textarea asp-for="UserReviews" class="form-control" rows="4" required></textarea>
+                            <textarea asp-for="UserReviews" class="form-control" rows="4" required
+                                      readonly="@formSubmitted"></textarea>
                             <span asp-validation-for="UserReviews" class="text-danger"></span>
                             <div class="text-muted">Link at least one publicly posted review (Nostr, X, or user websites) from a reputable Bitcoiner who tested
                                 the plugin.
-                                <a href="https://primal.net/e/nevent1qqsqkw7c5qmlue0qvyz784ywrpkvnz2v33js4ajkj2dj0xdjdn6n2qqem7auc" target="_blank">Example</a>
+                                <a href="https://primal.net/e/nevent1qqsqkw7c5qmlue0qvyz784ywrpkvnz2v33js4ajkj2dj0xdjdn6n2qqem7auc"
+                                   target="_blank" rel="noopener">Example</a>
                             </div>
                         </div>
                         <div class="form-group">
-                            <label asp-for="AnnouncementDate" class="form-label">Announcement Date & Time (optional)</label>
-                            <input asp-for="AnnouncementDate" type="datetime-local" class="form-control" />
+                            <label asp-for="AnnouncementDate" class="form-label">
+                                Announcement Date &amp; Time <span class="text-muted">(optional)</span>
+                            </label>
+                            <input asp-for="AnnouncementDate" type="datetime-local" class="form-control"
+                                   readonly="@formSubmitted" />
                             <span asp-validation-for="AnnouncementDate" class="text-danger"></span>
                             <div class="text-muted">
                                 You may specify when this announcement should go live (include date, time)<br />
@@ -166,21 +274,79 @@
 
 @section HeaderScripts {
     <style>
-        .accordion-button h5 svg {
-            transition: none !important;
-            transform: none !important;
-        }
-
-        .accordion-button h5 svg.icon-checkmark {
-            color: var(--btcpay-success, #28a745);
-        }
-
-        .accordion-button h5 svg.icon-cross {
-            color: var(--btcpay-danger, #dc3545);
+        #requestListingAccordion .requirement-status-icon svg.icon {
+            width: 1.25rem;
+            height: 1.25rem;
+            margin-left: 0;
+            transform: none;
         }
     </style>
 }
 
 @section FooterScripts {
-    <partial name="_ValidationScriptsPartial" />
+    @if (!formSubmitted)
+    {
+        <script>
+            document.addEventListener("DOMContentLoaded", () => {
+                const form = document.getElementById("request-listing-form");
+                const releaseNote = document.getElementById("ReleaseNote");
+                const telegram = document.getElementById("TelegramVerificationMessage");
+                const telegramFeedback = document.getElementById("telegram-verification-message-error");
+                const userReviews = document.getElementById("UserReviews");
+                const formStatus = document.getElementById("request-form-status");
+                const completeIcon = document.getElementById("request-form-icon-complete");
+                const incompleteIcon = document.getElementById("request-form-icon-incomplete");
+                const submitButton = document.getElementById("SubmitListing");
+                const prerequisitesComplete = @(prerequisitesComplete ? "true" : "false");
+                let telegramHasServerError = telegramFeedback.textContent.trim().length > 0;
+
+                const telegramIsValid = value => {
+                    const trimmed = value.trim();
+                    if (!trimmed) return false;
+
+                    try {
+                        const url = new URL(trimmed);
+                        const path = url.pathname.split("/").filter(Boolean).join("/");
+                        return url.protocol === "https:" &&
+                               url.hostname.toLowerCase() === "t.me" &&
+                               path.toLowerCase().startsWith("btcpayserver");
+                    } catch {
+                        return false;
+                    }
+                };
+
+                const updateFormState = () => {
+                    const releaseNoteValue = releaseNote.value.trim();
+                    const telegramValue = telegram.value.trim();
+                    const telegramValid = telegramIsValid(telegramValue);
+                    const telegramInvalid = telegramValue.length > 0 && !telegramValid;
+                    if (!telegramHasServerError) {
+                        telegramFeedback.textContent = telegramInvalid ? telegramFeedback.dataset.clientMessage : "";
+                    }
+                    const telegramHasError = telegramHasServerError || telegramInvalid;
+                    const complete = form.checkValidity() && releaseNoteValue.length > 0 &&
+                                     telegramValid && !telegramHasError &&
+                                     userReviews.value.trim().length > 0;
+
+                    telegram.classList.toggle("is-invalid", telegramHasError);
+                    telegram.setAttribute("aria-invalid", telegramHasError.toString());
+
+                    formStatus.textContent = complete ? "Complete" : "Incomplete";
+                    formStatus.classList.toggle("bg-success", complete);
+                    formStatus.classList.toggle("bg-danger", !complete);
+                    formStatus.classList.toggle("text-black", complete);
+                    completeIcon.classList.toggle("d-none", !complete);
+                    incompleteIcon.classList.toggle("d-none", complete);
+
+                    submitButton.disabled = !complete || !prerequisitesComplete;
+                };
+
+                form.addEventListener("input", event => {
+                    if (event.target === telegram) telegramHasServerError = false;
+                    updateFormState();
+                });
+                updateFormState();
+            });
+        </script>
+    }
 }

--- a/PluginBuilder/Views/Shared/_PluginOwnersTable.cshtml
+++ b/PluginBuilder/Views/Shared/_PluginOwnersTable.cshtml
@@ -37,7 +37,7 @@
                                 @(!string.IsNullOrEmpty(o.Email) ? o.Email : o.UserId)
                                 @if (o.IsPrimary)
                                 {
-                                    <span class="badge bg-warning text-dark ms-2">Primary Owner</span>
+                                    <span class="badge bg-primary text-black ms-2">Primary Owner</span>
                                 }
                             </td>
                             <td class="text-end text-nowrap align-middle">


### PR DESCRIPTION
This PR makes the plugin listing request process clearer and easier to follow.

Plugin owners can now:

- See exactly which plugin settings are complete or still missing
- Check the verification status of every owner account
- Read long rejection reasons without breaking the history page layout

The update also improves badge readability in dark mode and limits reminder emails to once every seven days.