### PR TITLE
Add email verification and password reset flow tests

### DIFF
--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -125,7 +125,7 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.Page.FillAsync("#Password", "123456");
         await tester.Page.FillAsync("#ConfirmPassword", "123456");
         await tester.Page.ClickAsync("#RegisterButton");
-        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Assertions.Expect(tester.Page).Not.ToHaveURLAsync(new Regex(".*/register$", RegexOptions.IgnoreCase));
     }
 
     private static async Task<bool> IsEmailConfirmed(PlaywrightTester tester, string email)

--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -112,11 +112,9 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.GoToEmailLink(link.Value);
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        using var scope = tester.Server.WebApp.Services.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
-        var updated = await userManager.FindByIdAsync(userId);
-        Assert.NotNull(updated);
-        Assert.Equal(newEmail, updated!.Email);
+        await tester.Logout();
+        await tester.LogIn(newEmail);
+        await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/dashboard$", RegexOptions.IgnoreCase));
     }
 
     private static async Task RegisterViaUi(PlaywrightTester tester, string email)

--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -98,20 +98,22 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.LogIn(await tester.CreateServerAdminAsync());
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail, async () =>
-        {
-            await tester.GoToUrl($"/admin/userchangeemail?userId={userId}");
-            await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-            await tester.Page.FillAsync("#NewEmail", newEmail);
-            await tester.Page.ClickAsync("#Submit");
-            await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/admin/users$", RegexOptions.IgnoreCase));
-        });
+        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail,
+            () => SubmitEmailChangeViaUi(tester, userId, newEmail));
 
         var link = UpdateEmailLink.Match(message.Text);
         Assert.True(link.Success, $"No UpdateEmail link found in body:\n{message.Text}");
 
         await tester.GoToEmailLink(link.Value);
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        using (var scope = tester.Server.WebApp.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+            var user = await userManager.FindByIdAsync(userId);
+            Assert.NotNull(user);
+            Assert.Equal(newEmail, user.UserName);
+        }
 
         await tester.Logout();
         await tester.LogIn(newEmail);
@@ -134,14 +136,8 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.LogIn(await tester.CreateServerAdminAsync());
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail, async () =>
-        {
-            await tester.GoToUrl($"/admin/userchangeemail?userId={userId}");
-            await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
-            await tester.Page.FillAsync("#NewEmail", newEmail);
-            await tester.Page.ClickAsync("#Submit");
-            await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/admin/users$", RegexOptions.IgnoreCase));
-        });
+        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail,
+            () => SubmitEmailChangeViaUi(tester, userId, newEmail));
 
         var link = UpdateEmailLink.Match(message.Text);
         Assert.True(link.Success, $"No UpdateEmail link found in body:\n{message.Text}");
@@ -163,6 +159,15 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         Assert.NotNull(user);
         Assert.Equal(oldEmail, user.Email);
         Assert.Equal(oldEmail, user.UserName);
+    }
+
+    private static async Task SubmitEmailChangeViaUi(PlaywrightTester tester, string userId, string newEmail)
+    {
+        await tester.GoToUrl($"/admin/userchangeemail?userId={userId}");
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.Page.FillAsync("#NewEmail", newEmail);
+        await tester.Page.ClickAsync("#Submit");
+        await Assertions.Expect(tester.Page).ToHaveURLAsync(new Regex(".*/admin/users$", RegexOptions.IgnoreCase));
     }
 
     private static async Task RegisterViaUi(PlaywrightTester tester, string email)

--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -104,6 +104,7 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
             await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
             await tester.Page.FillAsync("#NewEmail", newEmail);
             await tester.Page.ClickAsync("#Submit");
+            await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/admin/users$", RegexOptions.IgnoreCase));
         });
 
         var link = UpdateEmailLink.Match(message.Text);
@@ -115,6 +116,53 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.Logout();
         await tester.LogIn(newEmail);
         await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/dashboard$", RegexOptions.IgnoreCase));
+    }
+
+    [Fact]
+    public async Task EmailChange_InvalidToken_DoesNotChangeEmailOrUsername()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await tester.ConfigureMailpitSmtp();
+
+        var oldEmail = $"old-bad-{Guid.NewGuid():N}@test.com";
+        var newEmail = $"new-bad-{Guid.NewGuid():N}@test.com";
+        var userId = await tester.CreateConfirmedUser(oldEmail);
+
+        await tester.LogIn(await tester.CreateServerAdminAsync());
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail, async () =>
+        {
+            await tester.GoToUrl($"/admin/userchangeemail?userId={userId}");
+            await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+            await tester.Page.FillAsync("#NewEmail", newEmail);
+            await tester.Page.ClickAsync("#Submit");
+            await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/admin/users$", RegexOptions.IgnoreCase));
+        });
+
+        var link = UpdateEmailLink.Match(message.Text);
+        Assert.True(link.Success, $"No UpdateEmail link found in body:\n{message.Text}");
+
+        var tampered = Regex.Replace(link.Value, @"token=[^&]+", "token=not-a-valid-token");
+        Assert.NotEqual(link.Value, tampered);
+
+        var response = await tester.GoToEmailLink(tampered);
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        Assert.NotNull(response);
+        Assert.True(response.Ok, $"Expected rejection page, got HTTP {response.Status}");
+        await Expect(tester.Page.Locator("body")).ToContainTextAsync("We couldn't verify your email");
+
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByIdAsync(userId);
+
+        Assert.NotNull(user);
+        Assert.Equal(oldEmail, user.Email);
+        Assert.Equal(oldEmail, user.UserName);
     }
 
     private static async Task RegisterViaUi(PlaywrightTester tester, string email)

--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -3,29 +3,20 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
 using Microsoft.Playwright.Xunit;
-using PluginBuilder.DataModels;
-using PluginBuilder.Services;
-using PluginBuilder.Util;
-using PluginBuilder.Util.Extensions;
-using PluginBuilder.ViewModels.Admin;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace PluginBuilder.Tests.AuthTests;
 
 /// <summary>
-/// End-to-end coverage of the email-verification flows, captured via the Mailpit test harness
-/// (see PluginBuilder.Tests/docker-compose.yml). Each flow mints an identity token, sends a link by
-/// email, and a consumer route redeems it: registration → ConfirmEmail (initial confirmation), and an
-/// email-change → VerifyEmailUpdate (swaps the account's address). Also covers the SMTP-not-configured
-/// gate that skips verification entirely.
+/// End-to-end email-verification flows (registration confirmation and email change), captured via Mailpit.
 /// </summary>
 [Collection("Playwright Tests")]
 public class EmailVerificationTests(ITestOutputHelper output) : PageTest
 {
     private readonly XUnitLogger _log = new("EmailVerificationTests", output);
 
-    // Matches the plain-text link EmailService.SendVerifyEmail embeds in the body.
+    private const string VerifySubject = "Verify your account on BTCPay Server Plugin Builder";
     private static readonly Regex ConfirmLink = new(@"https?://\S+/ConfirmEmail\S*", RegexOptions.IgnoreCase);
     private static readonly Regex UpdateEmailLink = new(@"https?://\S+/UpdateEmail\S*", RegexOptions.IgnoreCase);
 
@@ -36,22 +27,17 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        // An admin must already exist so the new registration is treated as a normal (non-admin) user;
-        // otherwise the first account is auto-promoted to admin and skips email verification.
-        await ConfigureMailpitSmtp(tester);
+        // The first registered account is auto-promoted to admin and skips verification.
+        await tester.ConfigureMailpitSmtp();
         await tester.CreateServerAdminAsync();
 
         var email = $"verify-{Guid.NewGuid():N}@test.com";
-        var message = await tester.Server.AssertHasEmail(
-            "Verify your account on BTCPay Server Plugin Builder",
-            () => RegisterViaUi(tester, email));
+        var message = await tester.Server.AssertHasEmail(VerifySubject, email, () => RegisterViaUi(tester, email));
 
-        Assert.Contains(message.To, t => t.Address == email);
         var link = ConfirmLink.Match(message.Text);
         Assert.True(link.Success, $"No ConfirmEmail link found in body:\n{message.Text}");
 
-        // Following the link consumes the token and confirms the account.
-        await tester.GoToUrl(ToRelative(tester, link.Value));
+        await tester.GoToEmailLink(link.Value);
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
         Assert.True(await IsEmailConfirmed(tester, email), "Account should be confirmed after following the verify link");
@@ -64,20 +50,17 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        await ConfigureMailpitSmtp(tester);
+        await tester.ConfigureMailpitSmtp();
         await tester.CreateServerAdminAsync();
 
         var email = $"verify-bad-{Guid.NewGuid():N}@test.com";
-        var message = await tester.Server.AssertHasEmail(
-            "Verify your account on BTCPay Server Plugin Builder",
-            () => RegisterViaUi(tester, email));
+        var message = await tester.Server.AssertHasEmail(VerifySubject, email, () => RegisterViaUi(tester, email));
 
         var link = ConfirmLink.Match(message.Text);
         Assert.True(link.Success, $"No ConfirmEmail link found in body:\n{message.Text}");
 
-        // Corrupt the token portion of the link; the identity token must fail validation.
         var tampered = Regex.Replace(link.Value, @"token=[^&]+", "token=not-a-valid-token");
-        await tester.GoToUrl(ToRelative(tester, tampered));
+        await tester.GoToEmailLink(tampered);
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
         Assert.False(await IsEmailConfirmed(tester, email), "Account must not be confirmed by an invalid token");
@@ -90,14 +73,11 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        // No SMTP settings saved: emailSettings?.PasswordSet is false, so the verification branch
-        // is skipped and the user is signed in directly.
         await tester.CreateServerAdminAsync();
 
         var email = $"nosmtp-{Guid.NewGuid():N}@test.com";
         await RegisterViaUi(tester, email);
 
-        // Signed in and landed off the verify page (no "confirm your email" gate).
         await Expect(tester.Page!).Not.ToHaveURLAsync(new Regex("/verifyemail", RegexOptions.IgnoreCase));
         Assert.False(await IsEmailConfirmed(tester, email), "No verification email means the account stays unconfirmed");
     }
@@ -109,52 +89,34 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        await ConfigureMailpitSmtp(tester);
+        await tester.ConfigureMailpitSmtp();
 
         var oldEmail = $"old-{Guid.NewGuid():N}@test.com";
         var newEmail = $"new-{Guid.NewGuid():N}@test.com";
-        var userId = await CreateConfirmedUser(tester, oldEmail);
+        var userId = await tester.CreateConfirmedUser(oldEmail);
 
-        // Drive the same producer path as AdminController.UserChangeEmail: stage the pending address,
-        // mint a change-email token, and mail the /UpdateEmail link.
-        var message = await tester.Server.AssertHasEmail(
-            "Verify your account on BTCPay Server Plugin Builder",
-            async () => await SendEmailChangeVerification(tester, userId, newEmail));
+        await tester.LogIn(await tester.CreateServerAdminAsync());
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        Assert.Contains(message.To, t => t.Address == newEmail);
+        var message = await tester.Server.AssertHasEmail(VerifySubject, newEmail, async () =>
+        {
+            await tester.GoToUrl($"/admin/userchangeemail?userId={userId}");
+            await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+            await tester.Page.FillAsync("#NewEmail", newEmail);
+            await tester.Page.ClickAsync("#Submit");
+        });
+
         var link = UpdateEmailLink.Match(message.Text);
         Assert.True(link.Success, $"No UpdateEmail link found in body:\n{message.Text}");
 
-        // Following the link redeems the change-email token and swaps the account's address.
-        await tester.GoToUrl(ToRelative(tester, link.Value));
-        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.GoToEmailLink(link.Value);
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
         using var scope = tester.Server.WebApp.Services.CreateScope();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
         var updated = await userManager.FindByIdAsync(userId);
         Assert.NotNull(updated);
         Assert.Equal(newEmail, updated!.Email);
-    }
-
-    // Replicates AdminController.UserChangeEmail's producer: persist PendingNewEmail, generate the
-    // ChangeEmail token bound to the new address, and send the /UpdateEmail verification link.
-    private static async Task SendEmailChangeVerification(PlaywrightTester tester, string userId, string newEmail)
-    {
-        using var scope = tester.Server.WebApp.Services.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
-        var emailService = scope.ServiceProvider.GetRequiredService<EmailService>();
-
-        var user = await userManager.FindByIdAsync(userId);
-        Assert.NotNull(user);
-
-        await using var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
-        var settings = await conn.GetAccountDetailSettings(userId) ?? new AccountSettings();
-        settings.PendingNewEmail = newEmail;
-        await conn.SetAccountDetailSettings(settings, userId);
-
-        var token = await userManager.GenerateChangeEmailTokenAsync(user!, newEmail);
-        var link = $"{tester.ServerUri}UpdateEmail?uid={user!.Id}&token={Uri.EscapeDataString(token)}";
-        await emailService.SendVerifyEmail(newEmail, link);
     }
 
     private static async Task RegisterViaUi(PlaywrightTester tester, string email)
@@ -168,17 +130,6 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
     }
 
-    private static Task ConfigureMailpitSmtp(PlaywrightTester tester) =>
-        tester.Server.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
-        {
-            Server = MailpitDevSettings.Host,
-            Port = MailpitDevSettings.SmtpPort,
-            Username = "plugin-builder@example.com",
-            From = "plugin-builder@example.com",
-            Password = "password",
-            DisableCertificateCheck = true
-        });
-
     private static async Task<bool> IsEmailConfirmed(PlaywrightTester tester, string email)
     {
         using var scope = tester.Server.WebApp.Services.CreateScope();
@@ -187,19 +138,4 @@ public class EmailVerificationTests(ITestOutputHelper output) : PageTest
         Assert.NotNull(user);
         return user!.EmailConfirmed;
     }
-
-    private static async Task<string> CreateConfirmedUser(PlaywrightTester tester, string email)
-    {
-        using var scope = tester.Server.WebApp.Services.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
-        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
-        var result = await userManager.CreateAsync(user, "123456");
-        Assert.True(result.Succeeded, string.Join(", ", result.Errors.Select(e => e.Description)));
-        return user.Id;
-    }
-
-    // The email carries an absolute URL bound to the test server's ephemeral port; drive it as a
-    // server-relative path so Playwright navigates within the same origin.
-    private static string ToRelative(PlaywrightTester tester, string absoluteUrl) =>
-        new Uri(absoluteUrl).PathAndQuery;
 }

--- a/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
+++ b/PluginBuilder.Tests/AuthTests/EmailVerificationTests.cs
@@ -1,0 +1,205 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+using PluginBuilder.DataModels;
+using PluginBuilder.Services;
+using PluginBuilder.Util;
+using PluginBuilder.Util.Extensions;
+using PluginBuilder.ViewModels.Admin;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.AuthTests;
+
+/// <summary>
+/// End-to-end coverage of the email-verification flows, captured via the Mailpit test harness
+/// (see PluginBuilder.Tests/docker-compose.yml). Each flow mints an identity token, sends a link by
+/// email, and a consumer route redeems it: registration → ConfirmEmail (initial confirmation), and an
+/// email-change → VerifyEmailUpdate (swaps the account's address). Also covers the SMTP-not-configured
+/// gate that skips verification entirely.
+/// </summary>
+[Collection("Playwright Tests")]
+public class EmailVerificationTests(ITestOutputHelper output) : PageTest
+{
+    private readonly XUnitLogger _log = new("EmailVerificationTests", output);
+
+    // Matches the plain-text link EmailService.SendVerifyEmail embeds in the body.
+    private static readonly Regex ConfirmLink = new(@"https?://\S+/ConfirmEmail\S*", RegexOptions.IgnoreCase);
+    private static readonly Regex UpdateEmailLink = new(@"https?://\S+/UpdateEmail\S*", RegexOptions.IgnoreCase);
+
+    [Fact]
+    public async Task Registration_SendsVerifyEmail_AndValidTokenConfirms()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        // An admin must already exist so the new registration is treated as a normal (non-admin) user;
+        // otherwise the first account is auto-promoted to admin and skips email verification.
+        await ConfigureMailpitSmtp(tester);
+        await tester.CreateServerAdminAsync();
+
+        var email = $"verify-{Guid.NewGuid():N}@test.com";
+        var message = await tester.Server.AssertHasEmail(
+            "Verify your account on BTCPay Server Plugin Builder",
+            () => RegisterViaUi(tester, email));
+
+        Assert.Contains(message.To, t => t.Address == email);
+        var link = ConfirmLink.Match(message.Text);
+        Assert.True(link.Success, $"No ConfirmEmail link found in body:\n{message.Text}");
+
+        // Following the link consumes the token and confirms the account.
+        await tester.GoToUrl(ToRelative(tester, link.Value));
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        Assert.True(await IsEmailConfirmed(tester, email), "Account should be confirmed after following the verify link");
+    }
+
+    [Fact]
+    public async Task ConfirmEmail_InvalidToken_DoesNotConfirm()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await ConfigureMailpitSmtp(tester);
+        await tester.CreateServerAdminAsync();
+
+        var email = $"verify-bad-{Guid.NewGuid():N}@test.com";
+        var message = await tester.Server.AssertHasEmail(
+            "Verify your account on BTCPay Server Plugin Builder",
+            () => RegisterViaUi(tester, email));
+
+        var link = ConfirmLink.Match(message.Text);
+        Assert.True(link.Success, $"No ConfirmEmail link found in body:\n{message.Text}");
+
+        // Corrupt the token portion of the link; the identity token must fail validation.
+        var tampered = Regex.Replace(link.Value, @"token=[^&]+", "token=not-a-valid-token");
+        await tester.GoToUrl(ToRelative(tester, tampered));
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        Assert.False(await IsEmailConfirmed(tester, email), "Account must not be confirmed by an invalid token");
+    }
+
+    [Fact]
+    public async Task Registration_WithoutSmtpConfigured_SkipsVerification()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        // No SMTP settings saved: emailSettings?.PasswordSet is false, so the verification branch
+        // is skipped and the user is signed in directly.
+        await tester.CreateServerAdminAsync();
+
+        var email = $"nosmtp-{Guid.NewGuid():N}@test.com";
+        await RegisterViaUi(tester, email);
+
+        // Signed in and landed off the verify page (no "confirm your email" gate).
+        await Expect(tester.Page!).Not.ToHaveURLAsync(new Regex("/verifyemail", RegexOptions.IgnoreCase));
+        Assert.False(await IsEmailConfirmed(tester, email), "No verification email means the account stays unconfirmed");
+    }
+
+    [Fact]
+    public async Task EmailChange_SendsVerifyLink_AndValidTokenUpdatesAddress()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await ConfigureMailpitSmtp(tester);
+
+        var oldEmail = $"old-{Guid.NewGuid():N}@test.com";
+        var newEmail = $"new-{Guid.NewGuid():N}@test.com";
+        var userId = await CreateConfirmedUser(tester, oldEmail);
+
+        // Drive the same producer path as AdminController.UserChangeEmail: stage the pending address,
+        // mint a change-email token, and mail the /UpdateEmail link.
+        var message = await tester.Server.AssertHasEmail(
+            "Verify your account on BTCPay Server Plugin Builder",
+            async () => await SendEmailChangeVerification(tester, userId, newEmail));
+
+        Assert.Contains(message.To, t => t.Address == newEmail);
+        var link = UpdateEmailLink.Match(message.Text);
+        Assert.True(link.Success, $"No UpdateEmail link found in body:\n{message.Text}");
+
+        // Following the link redeems the change-email token and swaps the account's address.
+        await tester.GoToUrl(ToRelative(tester, link.Value));
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var updated = await userManager.FindByIdAsync(userId);
+        Assert.NotNull(updated);
+        Assert.Equal(newEmail, updated!.Email);
+    }
+
+    // Replicates AdminController.UserChangeEmail's producer: persist PendingNewEmail, generate the
+    // ChangeEmail token bound to the new address, and send the /UpdateEmail verification link.
+    private static async Task SendEmailChangeVerification(PlaywrightTester tester, string userId, string newEmail)
+    {
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var emailService = scope.ServiceProvider.GetRequiredService<EmailService>();
+
+        var user = await userManager.FindByIdAsync(userId);
+        Assert.NotNull(user);
+
+        await using var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
+        var settings = await conn.GetAccountDetailSettings(userId) ?? new AccountSettings();
+        settings.PendingNewEmail = newEmail;
+        await conn.SetAccountDetailSettings(settings, userId);
+
+        var token = await userManager.GenerateChangeEmailTokenAsync(user!, newEmail);
+        var link = $"{tester.ServerUri}UpdateEmail?uid={user!.Id}&token={Uri.EscapeDataString(token)}";
+        await emailService.SendVerifyEmail(newEmail, link);
+    }
+
+    private static async Task RegisterViaUi(PlaywrightTester tester, string email)
+    {
+        await tester.GoToUrl("/register");
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.Page.FillAsync("#Email", email);
+        await tester.Page.FillAsync("#Password", "123456");
+        await tester.Page.FillAsync("#ConfirmPassword", "123456");
+        await tester.Page.ClickAsync("#RegisterButton");
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+    }
+
+    private static Task ConfigureMailpitSmtp(PlaywrightTester tester) =>
+        tester.Server.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
+        {
+            Server = MailpitDevSettings.Host,
+            Port = MailpitDevSettings.SmtpPort,
+            Username = "plugin-builder@example.com",
+            From = "plugin-builder@example.com",
+            Password = "password",
+            DisableCertificateCheck = true
+        });
+
+    private static async Task<bool> IsEmailConfirmed(PlaywrightTester tester, string email)
+    {
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+        return user!.EmailConfirmed;
+    }
+
+    private static async Task<string> CreateConfirmedUser(PlaywrightTester tester, string email)
+    {
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
+        var result = await userManager.CreateAsync(user, "123456");
+        Assert.True(result.Succeeded, string.Join(", ", result.Errors.Select(e => e.Description)));
+        return user.Id;
+    }
+
+    // The email carries an absolute URL bound to the test server's ephemeral port; drive it as a
+    // server-relative path so Playwright navigates within the same origin.
+    private static string ToRelative(PlaywrightTester tester, string absoluteUrl) =>
+        new Uri(absoluteUrl).PathAndQuery;
+}

--- a/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
+++ b/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
@@ -43,8 +43,11 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page.ClickAsync("#ResetPassword");
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        Assert.True(await CheckPassword(tester, email, newPassword), "New password should be valid after reset");
-        Assert.False(await CheckPassword(tester, email, "123456"), "Old password should no longer be valid");
+        await tester.LogIn(email, newPassword);
+        await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/dashboard$", RegexOptions.IgnoreCase));
+
+        await tester.LogIn(email, "123456");
+        await Expect(tester.Page.Locator(".validation-summary-errors")).ToBeVisibleAsync();
     }
 
     [Fact]

--- a/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
+++ b/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+using PluginBuilder.Services;
+using PluginBuilder.Util;
+using PluginBuilder.ViewModels.Admin;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.AuthTests;
+
+/// <summary>
+/// End-to-end coverage of the password-reset flow, captured via the Mailpit test harness
+/// (see PluginBuilder.Tests/docker-compose.yml). ForgotPassword mints a reset token and emails a link;
+/// PasswordReset consumes it. Also asserts the anti-enumeration property: an unknown email produces a
+/// success page but no email.
+/// </summary>
+[Collection("Playwright Tests")]
+public class PasswordResetTests(ITestOutputHelper output) : PageTest
+{
+    private readonly XUnitLogger _log = new("PasswordResetTests", output);
+
+    // Matches the plain-text link EmailService.ResetPasswordEmail embeds in the body.
+    private static readonly Regex ResetLink = new(@"https?://\S+/passwordreset\S*", RegexOptions.IgnoreCase);
+
+    [Fact]
+    public async Task ForgotPassword_SendsResetEmail_AndValidTokenResetsPassword()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await ConfigureMailpitSmtp(tester);
+        var email = $"reset-{Guid.NewGuid():N}@test.com";
+        await CreateConfirmedUser(tester, email, "123456");
+
+        var message = await tester.Server.AssertHasEmail(
+            "Reset your password on BTCPay Server Plugin Builder",
+            () => SubmitForgotPassword(tester, email));
+
+        Assert.Contains(message.To, t => t.Address == email);
+        var link = ResetLink.Match(message.Text);
+        Assert.True(link.Success, $"No passwordreset link found in body:\n{message.Text}");
+
+        // Follow the emailed link (token arrives in the query and pre-fills the hidden field), set a
+        // new password, and submit.
+        const string newPassword = "new-password-123";
+        await tester.GoToUrl(ToRelative(tester, link.Value));
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.Page.FillAsync("#Password", newPassword);
+        await tester.Page.FillAsync("#ConfirmPassword", newPassword);
+        await tester.Page.ClickAsync("#ResetPassword");
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        // The new password must now authenticate; the old one must not.
+        Assert.True(await CheckPassword(tester, email, newPassword), "New password should be valid after reset");
+        Assert.False(await CheckPassword(tester, email, "123456"), "Old password should no longer be valid");
+    }
+
+    [Fact]
+    public async Task ForgotPassword_UnknownEmail_SendsNoEmail_ButShowsSuccess()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await ConfigureMailpitSmtp(tester);
+        var unknown = $"nobody-{Guid.NewGuid():N}@test.com";
+
+        await SubmitForgotPassword(tester, unknown);
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        // Anti-enumeration: the form reports success regardless of whether the account exists.
+        await Expect(tester.Page.Locator("body")).ToContainTextAsync(new Regex("check your email|email", RegexOptions.IgnoreCase));
+
+        // But no reset email should have been sent for a non-existent account.
+        using var client = tester.Server.GetMailPitClient();
+        var search = await client.Search($"to:\"{unknown}\"");
+        Assert.Empty(search.Messages);
+    }
+
+    [Fact]
+    public async Task PasswordReset_InvalidToken_ReturnsError_PasswordUnchanged()
+    {
+        await using var tester = new PlaywrightTester(_log);
+        tester.Server.ReuseDatabase = false;
+        await tester.StartAsync();
+
+        await ConfigureMailpitSmtp(tester);
+        var email = $"reset-bad-{Guid.NewGuid():N}@test.com";
+        await CreateConfirmedUser(tester, email, "123456");
+
+        // Land on the reset page with a bogus token (as if from a tampered/expired link).
+        await tester.GoToUrl($"/passwordreset?email={Uri.EscapeDataString(email)}&code=not-a-valid-token");
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.Page.FillAsync("#Password", "new-password-123");
+        await tester.Page.FillAsync("#ConfirmPassword", "new-password-123");
+        await tester.Page.ClickAsync("#ResetPassword");
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+        // ResetPasswordAsync fails, so the page redisplays with the "Invalid token." validation error
+        // and the password stays unchanged.
+        await Expect(tester.Page.Locator(".validation-summary-errors")).ToContainTextAsync("Invalid token");
+        Assert.True(await CheckPassword(tester, email, "123456"), "Password must be unchanged after an invalid-token reset");
+    }
+
+    private static async Task SubmitForgotPassword(PlaywrightTester tester, string email)
+    {
+        await tester.GoToUrl("/forgotpassword");
+        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await tester.Page.FillAsync("#Email", email);
+        await tester.Page.ClickAsync("#ResetPassword");
+        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+    }
+
+    private static async Task CreateConfirmedUser(PlaywrightTester tester, string email, string password)
+    {
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
+        var result = await userManager.CreateAsync(user, password);
+        Assert.True(result.Succeeded, string.Join(", ", result.Errors.Select(e => e.Description)));
+    }
+
+    private static async Task<bool> CheckPassword(PlaywrightTester tester, string email, string password)
+    {
+        using var scope = tester.Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+        return await userManager.CheckPasswordAsync(user!, password);
+    }
+
+    private static Task ConfigureMailpitSmtp(PlaywrightTester tester) =>
+        tester.Server.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
+        {
+            Server = MailpitDevSettings.Host,
+            Port = MailpitDevSettings.SmtpPort,
+            Username = "plugin-builder@example.com",
+            From = "plugin-builder@example.com",
+            Password = "password",
+            DisableCertificateCheck = true
+        });
+
+    // The email carries an absolute URL bound to the test server's ephemeral port; drive it as a
+    // server-relative path so Playwright navigates within the same origin.
+    private static string ToRelative(PlaywrightTester tester, string absoluteUrl) =>
+        new Uri(absoluteUrl).PathAndQuery;
+}

--- a/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
+++ b/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
@@ -41,7 +41,7 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page.FillAsync("#Password", newPassword);
         await tester.Page.FillAsync("#ConfirmPassword", newPassword);
         await tester.Page.ClickAsync("#ResetPassword");
-        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/login$", RegexOptions.IgnoreCase));
 
         await tester.LogIn(email, newPassword);
         await Expect(tester.Page).ToHaveURLAsync(new Regex(".*/dashboard$", RegexOptions.IgnoreCase));
@@ -61,10 +61,9 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         var unknown = $"nobody-{Guid.NewGuid():N}@test.com";
 
         await SubmitForgotPassword(tester, unknown);
-        await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
         // Success is shown regardless of account existence, but no email is sent.
-        await Expect(tester.Page.Locator("body"))
+        await Expect(tester.Page!.Locator("body"))
             .ToContainTextAsync("If an account exists for the email address you entered");
 
         using var client = tester.Server.GetMailPitClient();
@@ -88,7 +87,6 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page.FillAsync("#Password", "new-password-123");
         await tester.Page.FillAsync("#ConfirmPassword", "new-password-123");
         await tester.Page.ClickAsync("#ResetPassword");
-        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
         await Expect(tester.Page.Locator(".validation-summary-errors")).ToContainTextAsync("Invalid token");
         Assert.True(await CheckPassword(tester, email, "123456"), "Password must be unchanged after an invalid-token reset");
@@ -100,7 +98,8 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
         await tester.Page.FillAsync("#Email", email);
         await tester.Page.ClickAsync("#ResetPassword");
-        await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        await Assertions.Expect(tester.Page.Locator("body"))
+            .ToContainTextAsync("If an account exists for the email address you entered");
     }
 
     private static async Task<bool> CheckPassword(PlaywrightTester tester, string email, string password)

--- a/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
+++ b/PluginBuilder.Tests/AuthTests/PasswordResetTests.cs
@@ -3,26 +3,20 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
 using Microsoft.Playwright.Xunit;
-using PluginBuilder.Services;
-using PluginBuilder.Util;
-using PluginBuilder.ViewModels.Admin;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace PluginBuilder.Tests.AuthTests;
 
 /// <summary>
-/// End-to-end coverage of the password-reset flow, captured via the Mailpit test harness
-/// (see PluginBuilder.Tests/docker-compose.yml). ForgotPassword mints a reset token and emails a link;
-/// PasswordReset consumes it. Also asserts the anti-enumeration property: an unknown email produces a
-/// success page but no email.
+/// End-to-end password-reset flow, captured via Mailpit.
 /// </summary>
 [Collection("Playwright Tests")]
 public class PasswordResetTests(ITestOutputHelper output) : PageTest
 {
     private readonly XUnitLogger _log = new("PasswordResetTests", output);
 
-    // Matches the plain-text link EmailService.ResetPasswordEmail embeds in the body.
+    private const string ResetSubject = "Reset your password on BTCPay Server Plugin Builder";
     private static readonly Regex ResetLink = new(@"https?://\S+/passwordreset\S*", RegexOptions.IgnoreCase);
 
     [Fact]
@@ -32,29 +26,23 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        await ConfigureMailpitSmtp(tester);
+        await tester.ConfigureMailpitSmtp();
         var email = $"reset-{Guid.NewGuid():N}@test.com";
-        await CreateConfirmedUser(tester, email, "123456");
+        await tester.CreateConfirmedUser(email);
 
-        var message = await tester.Server.AssertHasEmail(
-            "Reset your password on BTCPay Server Plugin Builder",
-            () => SubmitForgotPassword(tester, email));
+        var message = await tester.Server.AssertHasEmail(ResetSubject, email, () => SubmitForgotPassword(tester, email));
 
-        Assert.Contains(message.To, t => t.Address == email);
         var link = ResetLink.Match(message.Text);
         Assert.True(link.Success, $"No passwordreset link found in body:\n{message.Text}");
 
-        // Follow the emailed link (token arrives in the query and pre-fills the hidden field), set a
-        // new password, and submit.
         const string newPassword = "new-password-123";
-        await tester.GoToUrl(ToRelative(tester, link.Value));
+        await tester.GoToEmailLink(link.Value);
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
         await tester.Page.FillAsync("#Password", newPassword);
         await tester.Page.FillAsync("#ConfirmPassword", newPassword);
         await tester.Page.ClickAsync("#ResetPassword");
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        // The new password must now authenticate; the old one must not.
         Assert.True(await CheckPassword(tester, email, newPassword), "New password should be valid after reset");
         Assert.False(await CheckPassword(tester, email, "123456"), "Old password should no longer be valid");
     }
@@ -66,16 +54,16 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        await ConfigureMailpitSmtp(tester);
+        await tester.ConfigureMailpitSmtp();
         var unknown = $"nobody-{Guid.NewGuid():N}@test.com";
 
         await SubmitForgotPassword(tester, unknown);
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        // Anti-enumeration: the form reports success regardless of whether the account exists.
-        await Expect(tester.Page.Locator("body")).ToContainTextAsync(new Regex("check your email|email", RegexOptions.IgnoreCase));
+        // Success is shown regardless of account existence, but no email is sent.
+        await Expect(tester.Page.Locator("body"))
+            .ToContainTextAsync("If an account exists for the email address you entered");
 
-        // But no reset email should have been sent for a non-existent account.
         using var client = tester.Server.GetMailPitClient();
         var search = await client.Search($"to:\"{unknown}\"");
         Assert.Empty(search.Messages);
@@ -88,11 +76,10 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         tester.Server.ReuseDatabase = false;
         await tester.StartAsync();
 
-        await ConfigureMailpitSmtp(tester);
+        await tester.ConfigureMailpitSmtp();
         var email = $"reset-bad-{Guid.NewGuid():N}@test.com";
-        await CreateConfirmedUser(tester, email, "123456");
+        await tester.CreateConfirmedUser(email);
 
-        // Land on the reset page with a bogus token (as if from a tampered/expired link).
         await tester.GoToUrl($"/passwordreset?email={Uri.EscapeDataString(email)}&code=not-a-valid-token");
         await tester.Page!.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
         await tester.Page.FillAsync("#Password", "new-password-123");
@@ -100,8 +87,6 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page.ClickAsync("#ResetPassword");
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-        // ResetPasswordAsync fails, so the page redisplays with the "Invalid token." validation error
-        // and the password stays unchanged.
         await Expect(tester.Page.Locator(".validation-summary-errors")).ToContainTextAsync("Invalid token");
         Assert.True(await CheckPassword(tester, email, "123456"), "Password must be unchanged after an invalid-token reset");
     }
@@ -115,15 +100,6 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         await tester.Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
     }
 
-    private static async Task CreateConfirmedUser(PlaywrightTester tester, string email, string password)
-    {
-        using var scope = tester.Server.WebApp.Services.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
-        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
-        var result = await userManager.CreateAsync(user, password);
-        Assert.True(result.Succeeded, string.Join(", ", result.Errors.Select(e => e.Description)));
-    }
-
     private static async Task<bool> CheckPassword(PlaywrightTester tester, string email, string password)
     {
         using var scope = tester.Server.WebApp.Services.CreateScope();
@@ -132,20 +108,4 @@ public class PasswordResetTests(ITestOutputHelper output) : PageTest
         Assert.NotNull(user);
         return await userManager.CheckPasswordAsync(user!, password);
     }
-
-    private static Task ConfigureMailpitSmtp(PlaywrightTester tester) =>
-        tester.Server.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
-        {
-            Server = MailpitDevSettings.Host,
-            Port = MailpitDevSettings.SmtpPort,
-            Username = "plugin-builder@example.com",
-            From = "plugin-builder@example.com",
-            Password = "password",
-            DisableCertificateCheck = true
-        });
-
-    // The email carries an absolute URL bound to the test server's ephemeral port; drive it as a
-    // server-relative path so Playwright navigates within the same origin.
-    private static string ToRelative(PlaywrightTester tester, string absoluteUrl) =>
-        new Uri(absoluteUrl).PathAndQuery;
 }

--- a/PluginBuilder.Tests/PlaywrightTester.cs
+++ b/PluginBuilder.Tests/PlaywrightTester.cs
@@ -12,6 +12,7 @@ using PluginBuilder.DataModels;
 using PluginBuilder.Services;
 using PluginBuilder.Util;
 using PluginBuilder.Util.Extensions;
+using PluginBuilder.ViewModels.Admin;
 using Xunit;
 
 namespace PluginBuilder.Tests;
@@ -141,6 +142,36 @@ public class PlaywrightTester : IAsyncDisposable
         }
         return email;
     }
+
+    /// <summary>Creates a user with a confirmed email and returns its id.</summary>
+    public async Task<string> CreateConfirmedUser(string email, string password = "123456")
+    {
+        using var scope = Server.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
+        var result = await userManager.CreateAsync(user, password);
+        if (!result.Succeeded)
+        {
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            throw new InvalidOperationException($"Failed to create user {email}: {errors}");
+        }
+        return user.Id;
+    }
+
+    /// <summary>Points outgoing email at the local Mailpit instance.</summary>
+    public Task ConfigureMailpitSmtp() =>
+        Server.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
+        {
+            Server = MailpitDevSettings.Host,
+            Port = MailpitDevSettings.SmtpPort,
+            Username = "plugin-builder@example.com",
+            From = "plugin-builder@example.com",
+            Password = "password",
+            DisableCertificateCheck = true
+        });
+
+    /// <summary>Navigates to an emailed absolute link by its path, staying on the test server's origin.</summary>
+    public Task<IResponse?> GoToEmailLink(string absoluteUrl) => GoToUrl(new Uri(absoluteUrl).PathAndQuery);
 
     public async Task EnableGithubVerificationAsync(NpgsqlConnection conn)
     {

--- a/PluginBuilder.Tests/PlaywrightTester.cs
+++ b/PluginBuilder.Tests/PlaywrightTester.cs
@@ -144,19 +144,8 @@ public class PlaywrightTester : IAsyncDisposable
     }
 
     /// <summary>Creates a user with a confirmed email and returns its id.</summary>
-    public async Task<string> CreateConfirmedUser(string email, string password = "123456")
-    {
-        using var scope = Server.WebApp.Services.CreateScope();
-        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
-        var user = new IdentityUser { UserName = email, Email = email, EmailConfirmed = true };
-        var result = await userManager.CreateAsync(user, password);
-        if (!result.Succeeded)
-        {
-            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
-            throw new InvalidOperationException($"Failed to create user {email}: {errors}");
-        }
-        return user.Id;
-    }
+    public Task<string> CreateConfirmedUser(string email, string password = "123456") =>
+        Server.CreateFakeUserAsync(email, password, confirmEmail: true, githubVerified: false);
 
     /// <summary>Points outgoing email at the local Mailpit instance.</summary>
     public Task ConfigureMailpitSmtp() =>

--- a/PluginBuilder.Tests/ServerTester.cs
+++ b/PluginBuilder.Tests/ServerTester.cs
@@ -286,21 +286,25 @@ public class ServerTester : IAsyncDisposable
     }
 
     /// <summary>
-    /// Runs <paramref name="action"/> (which should trigger an email send with the given
-    /// <paramref name="subject"/>), then polls Mailpit until a message with that subject appears and
-    /// returns it. Throws on timeout.
+    /// Runs <paramref name="action"/>, then polls Mailpit until a message matching the subject (and
+    /// optional recipient) appears and returns it. Throws on timeout. Mailpit is shared and never
+    /// cleared, so pass <paramref name="to"/> when the subject is not unique to the test.
     /// </summary>
-    public async Task<MailPitClient.Message> AssertHasEmail(string subject, Func<Task> action, TimeSpan? timeout = null)
+    public Task<MailPitClient.Message> AssertHasEmail(string subject, Func<Task> action, TimeSpan? timeout = null) =>
+        AssertHasEmail(subject, null, action, timeout);
+
+    public async Task<MailPitClient.Message> AssertHasEmail(string subject, string? to, Func<Task> action, TimeSpan? timeout = null)
     {
         timeout ??= TimeSpan.FromSeconds(30);
         using var client = GetMailPitClient();
 
         await action();
 
+        var query = $"subject:\"{subject}\"" + (to is null ? "" : $" to:\"{to}\"");
         using var cts = new CancellationTokenSource(timeout.Value);
         while (true)
         {
-            var search = await client.Search($"subject:\"{subject}\"");
+            var search = await client.Search(query);
             var summary = search.Messages.FirstOrDefault();
             if (summary is not null)
                 return await client.GetMessage(summary.Id);
@@ -311,7 +315,7 @@ public class ServerTester : IAsyncDisposable
             }
             catch (TaskCanceledException)
             {
-                throw new InvalidOperationException($"No Mailpit message with subject '{subject}' arrived within {timeout.Value.TotalSeconds:0}s");
+                throw new InvalidOperationException($"No Mailpit message matching '{query}' arrived within {timeout.Value.TotalSeconds:0}s");
             }
         }
     }

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -705,9 +705,12 @@ public class HomeController(
             return View("ConfirmEmail", model);
 
         var result = await userManager.ChangeEmailAsync(user, settings.PendingNewEmail, token);
-        var setUsernameResult = await userManager.SetUserNameAsync(user, settings.PendingNewEmail);
         model.Email = settings.PendingNewEmail;
-        model.EmailConfirmed = result.Succeeded && setUsernameResult.Succeeded;
+        if (!result.Succeeded)
+            return View("ConfirmEmail", model);
+
+        var setUsernameResult = await userManager.SetUserNameAsync(user, settings.PendingNewEmail);
+        model.EmailConfirmed = setUsernameResult.Succeeded;
         if (model.EmailConfirmed)
         {
             settings.PendingNewEmail = string.Empty;


### PR DESCRIPTION
End-to-end tests for the account email-verification and password-reset flows, using the Mailpit test harness from #231. Each test triggers the flow, captures the email via Mailpit, follows the emitted link, and asserts the state change. Seven tests, no production code changes.

**`EmailVerificationTests.cs`**
- Registration → verify email → valid token confirms the account
- Invalid confirmation token does not confirm
- No SMTP configured skips verification
- Email change via `/admin/userchangeemail` → verify link → valid token swaps the address

**`PasswordResetTests.cs`**
- Forgot password → reset email → valid token resets the password
- Unknown email sends no mail but still shows success
- Invalid reset token errors and leaves the password unchanged

**Harness changes**
- `ServerTester.AssertHasEmail` takes an optional recipient and adds it to the Mailpit search query — the shared Mailpit instance is never cleared, so subject-only searches could match stale messages from earlier tests
- Shared setup helpers (`ConfigureMailpitSmtp`, `CreateConfirmedUser`, `GoToEmailLink`) moved into `PlaywrightTester`