### PR TITLE
fix: allow cross-origin plugin details embeds

### DIFF
--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -60,6 +60,12 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         const string slug = "plugin-details-embed-layout";
         await tester.Server.CreateAndBuildPluginAsync(ownerId, slug);
 
+        using (var client = tester.Server.CreateHttpClient())
+        using (var response = await client.GetAsync($"/public/plugins/{slug}?embed=1"))
+        {
+            Assert.False(response.Headers.Contains("X-Frame-Options"));
+        }
+
         await tester.Page!.SetViewportSizeAsync(700, 1000);
         await tester.GoToUrl($"/public/plugins/{slug}?embed=1");
         await tester.AssertNoError();

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -570,7 +570,10 @@
     </div>
 }
 
-<partial name="_Confirm" model="@(new ConfirmModel("Delete review", "Are you sure?", "Delete"))" />
+@if (!Model.EmbedMode)
+{
+    <partial name="_Confirm" model="@(new ConfirmModel("Delete review", "Are you sure?", "Delete"))" />
+}
 
 <script>
     (() => {


### PR DESCRIPTION
## What changed

- Skip the delete-review confirmation partial in read-only embed mode.
- Add regression coverage ensuring embedded plugin details do not emit the `X-Frame-Options` header.

## Why

Rendering the confirmation partial generates antiforgery markup, which adds `X-Frame-Options: SAMEORIGIN` and prevents BTCPay Server from loading Plugin Builder details across origins.

The confirmation modal is not needed in embed mode because review mutations are already disabled there.