### PR TITLE
Allow pages to be embedded without allow-same-origin

### DIFF
--- a/PluginBuilder/Components/Icon/Default.cshtml
+++ b/PluginBuilder/Components/Icon/Default.cshtml
@@ -2,11 +2,13 @@
 @model PluginBuilder.Components.Icon.IconViewModel
 
 @{
-    var requestPathBase = ViewContext.HttpContext.Request.PathBase;
-    var spritePath = FileVersionProvider.AddFileVersionToPath(
-        requestPathBase,
-        "/img/icon-sprite.svg"
-    );
+    var embedMode = ViewContext.HttpContext.Request.IsEmbeddedMode();
+    var spritePath = embedMode
+        ? string.Empty
+        : FileVersionProvider.AddFileVersionToPath(
+            ViewContext.HttpContext.Request.PathBase,
+            "/img/icon-sprite.svg"
+        );
 }
 <svg role="img" class="icon icon-@Model.Symbol">
     <use href="@spritePath#@Model.Symbol"></use>

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -553,7 +553,7 @@ public class HomeController(
             RatingFilter = model.RatingFilter,
             OwnerGithubUrl = ownerGithubUrl,
             OwnerNostrUrl = ownerNostrUrl,
-            EmbedMode = string.Equals(Request.Query["embed"], "1", StringComparison.Ordinal)
+            EmbedMode = Request.IsEmbeddedMode()
         };
         return View(vm);
     }

--- a/PluginBuilder/PluginBuilder.csproj
+++ b/PluginBuilder/PluginBuilder.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-PluginBuilder-4D3592EF-6E6A-41BD-960D-231C299188A2</UserSecretsId>
-    <RazorCompileOnBuild Condition="'$(Configuration)' == 'Debug'">false</RazorCompileOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Condition="'$(GitCommit)' != ''" Include="PluginBuilder.GitCommitAttribute">
@@ -18,7 +17,6 @@
     <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Npgsql;
@@ -129,7 +130,16 @@ public class Program
         });
 
         app.UseDefaultFiles();
-        app.UseStaticFiles();
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            OnPrepareResponse = ctx =>
+            {
+                // This allows resources such as fonts to load in an iframe
+                // we use iframes in BTCPay Server plugin page.
+                ctx.Context.Response.Headers.AccessControlAllowOrigin = "*";
+                ctx.Context.Response.Headers["Cross-Origin-Resource-Policy"] = "cross-origin";
+            }
+        });
         app.UseRouting();
         app.UseRateLimiter();
         app.UseAuthentication();

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -148,7 +148,6 @@ public class Program
             {
                 options.Filters.Add(new UIControllerAntiforgeryTokenAttribute());
             })
-            .AddRazorRuntimeCompilation()
             .AddRazorOptions(options =>
             {
                 options.ViewLocationFormats.Add("/{0}.cshtml");

--- a/PluginBuilder/Util/Extensions/HttpRequestExtensions.cs
+++ b/PluginBuilder/Util/Extensions/HttpRequestExtensions.cs
@@ -2,6 +2,8 @@ namespace PluginBuilder.Util.Extensions;
 
 public static class HttpRequestExtensions
 {
+    public static bool IsEmbeddedMode(this HttpRequest request)
+        => string.Equals(request.Query["embed"], "1", StringComparison.Ordinal);
     public static string GetCurrentUrlWithQueryString(this HttpRequest request)
     {
         return string.Concat(

--- a/PluginBuilder/Views/Home/AllPlugins.cshtml
+++ b/PluginBuilder/Views/Home/AllPlugins.cshtml
@@ -6,7 +6,7 @@
     const string title = "BTCPay Server Plugin Directory";
     const string desc = "Extend and customize your BTCPay Server with community and official plugins.";
     ViewData["Title"] = title;
-    var embedMode = Context.Request.Query["embed"] == "1";
+    var embedMode = Context.Request.IsEmbeddedMode();
     var embedRoute = embedMode ? "1" : null;
 
     var currentSearch = Context.Request.Query["searchPluginName"].ToString();

--- a/PluginBuilder/Views/Shared/_CommonHead.cshtml
+++ b/PluginBuilder/Views/Shared/_CommonHead.cshtml
@@ -1,5 +1,5 @@
 @{
-    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
+    var embedMode = Context.Request.IsEmbeddedMode();
 }
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -26,14 +26,14 @@
 }
 <noscript>
     <style>
-        .btcpay-theme-switch { 
-            display: none !important; 
+        .btcpay-theme-switch {
+            display: none !important;
         }
-        .hide-when-js, [v-cloak] { 
-            display: block !important; 
+        .hide-when-js, [v-cloak] {
+            display: block !important;
         }
-        .only-for-js { 
-            display: none !important; 
+        .only-for-js {
+            display: none !important;
         }
     </style>
 </noscript>

--- a/PluginBuilder/Views/Shared/_IconSprite.cshtml
+++ b/PluginBuilder/Views/Shared/_IconSprite.cshtml
@@ -1,0 +1,7 @@
+@inject IWebHostEnvironment WebHostEnvironment
+@{
+    var spriteFile = WebHostEnvironment.WebRootFileProvider.GetFileInfo("img/icon-sprite.svg");
+    await using var spriteStream = spriteFile.CreateReadStream();
+    using var reader = new System.IO.StreamReader(spriteStream);
+}
+@Html.Raw(await reader.ReadToEndAsync())

--- a/PluginBuilder/Views/Shared/_LayoutPublicModal.cshtml
+++ b/PluginBuilder/Views/Shared/_LayoutPublicModal.cshtml
@@ -1,6 +1,6 @@
 @{
     Layout = null;
-    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
+    var embedMode = Context.Request.IsEmbeddedMode();
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -33,6 +33,10 @@
     </style>
 </head>
 <body class="d-flex flex-column min-vh-100 @(embedMode ? "embed-mode" : null)">
+@if (embedMode)
+{
+    <partial name="_IconSprite"></partial>
+}
 <section class="content-wrapper flex-grow-1">
     <div class="navbar-brand d-none"></div>
     <vc:status-message></vc:status-message>

--- a/PluginBuilder/Views/Shared/_PublicHeader.cshtml
+++ b/PluginBuilder/Views/Shared/_PublicHeader.cshtml
@@ -1,6 +1,6 @@
 @{
     var isAuth = User.Identity?.IsAuthenticated == true;
-    var embedMode = string.Equals(Context.Request.Query["embed"], "1", StringComparison.Ordinal);
+    var embedMode = Context.Request.IsEmbeddedMode();
 }
 @if (!embedMode)
 {


### PR DESCRIPTION
Build upon https://github.com/btcpayserver/btcpayserver-plugin-builder/pull/236

This is to avoid the need for `allow-same-origin` in iframes embedding the plugin builder.