### PR TITLE
feat: support digest-pinned plugin build images

### DIFF
--- a/PluginBuilder.Tests/PluginProjectMetadataTests.cs
+++ b/PluginBuilder.Tests/PluginProjectMetadataTests.cs
@@ -1,0 +1,39 @@
+using PluginBuilder.Services;
+using Xunit;
+
+namespace PluginBuilder.Tests;
+
+public class PluginProjectMetadataTests
+{
+    [Fact]
+    public void ParsesIdentifierAndCustomBuildImage()
+    {
+        const string buildImage =
+            "docker.io/boltz/btcpay-arkade-builder@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        var metadata = PluginProjectMetadata.Parse(
+            $"""
+            <Project>
+              <PropertyGroup>
+                <AssemblyName>Boltz.Arkade</AssemblyName>
+                <PluginBuildImage>
+                  {buildImage}
+                </PluginBuildImage>
+              </PropertyGroup>
+            </Project>
+            """,
+            "Arkade.csproj");
+
+        Assert.Equal("Boltz.Arkade", metadata.Identifier);
+        Assert.Equal(buildImage, metadata.BuildImage);
+    }
+
+    [Fact]
+    public void RejectsMutableCustomBuildImage()
+    {
+        var exception = Assert.Throws<BuildServiceException>(() => PluginProjectMetadata.Parse(
+            "<Project><PropertyGroup><PluginBuildImage>docker.io/example/plugin-builder:v1</PluginBuildImage></PropertyGroup></Project>",
+            "Example.csproj"));
+
+        Assert.Contains("must be an immutable repository@sha256 digest", exception.Message);
+    }
+}

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -327,17 +327,18 @@ public class ApiController(
         if (!ModelState.IsValid)
             return ValidationErrorResult(ModelState);
 
+        PluginProjectMetadata metadata;
         try
         {
-            var identifier = await buildService.FetchIdentifierFromCsprojAsync(
+            metadata = await buildService.FetchProjectMetadataFromCsprojAsync(
                 model.GitRepository,
                 model.GitRef,
                 model.PluginDirectory);
 
-            var owns = await conn.EnsureIdentifierOwnership(pluginSlug, identifier);
+            var owns = await conn.EnsureIdentifierOwnership(pluginSlug, metadata.Identifier);
             if (!owns)
             {
-                ModelState.AddModelError(string.Empty, $"The plugin identifier {identifier} does not belong to plugin slug {pluginSlug}.");
+                ModelState.AddModelError(string.Empty, $"The plugin identifier {metadata.Identifier} does not belong to plugin slug {pluginSlug}.");
                 return ValidationErrorResult(ModelState);
             }
         }
@@ -347,7 +348,9 @@ public class ApiController(
             return ValidationErrorResult(ModelState);
         }
 
-        var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
+        var buildParameters = model.ToBuildParameter();
+        buildParameters.BuildImage = metadata.BuildImage;
+        var buildId = await conn.NewBuild(pluginSlug, buildParameters);
         var buildUrl = Url.ActionLink(nameof(PluginController.Build), "Plugin",
             new { pluginSlug = pluginSlug.ToString(), buildId });
 

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -288,13 +288,14 @@ public class PluginController(
             return RedirectToAction("AccountDetails", "Account");
         }
 
+        PluginProjectMetadata metadata;
         try
         {
-            var identifier = await buildService.FetchIdentifierFromCsprojAsync(model.GitRepository, model.GitRef, model.PluginDirectory);
-            var owns = await conn.EnsureIdentifierOwnership(pluginSlug, identifier);
+            metadata = await buildService.FetchProjectMetadataFromCsprojAsync(model.GitRepository, model.GitRef, model.PluginDirectory);
+            var owns = await conn.EnsureIdentifierOwnership(pluginSlug, metadata.Identifier);
             if (!owns)
             {
-                TempData[TempDataConstant.WarningMessage] = $"The plugin identifier '{identifier}' does not belong to plugin slug '{pluginSlug}'.";
+                TempData[TempDataConstant.WarningMessage] = $"The plugin identifier '{metadata.Identifier}' does not belong to plugin slug '{pluginSlug}'.";
                 return View(model);
             }
         }
@@ -304,7 +305,9 @@ public class PluginController(
             return View(model);
         }
 
-        var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
+        var buildParameters = model.ToBuildParameter();
+        buildParameters.BuildImage = metadata.BuildImage;
+        var buildId = await conn.NewBuild(pluginSlug, buildParameters);
         if (buildId == 0)
         {
             var existingSetting = await conn.GetSettings(pluginSlug) ?? new PluginSettings();

--- a/PluginBuilder/PluginBuildParameters.cs
+++ b/PluginBuilder/PluginBuildParameters.cs
@@ -13,4 +13,5 @@ public class PluginBuildParameters
     public string? GitRef { get; set; }
     public string? PluginDirectory { get; set; }
     public string? BuildConfig { get; set; }
+    public string? BuildImage { get; set; }
 }

--- a/PluginBuilder/Services/BuildService.cs
+++ b/PluginBuilder/Services/BuildService.cs
@@ -65,6 +65,12 @@ public class BuildService
             {
                 // Then let's build by running our image plugin-builder (built in DockerStartupHostedService)
                 JObject info = new();
+                var buildImage = "plugin-builder";
+                if (buildParameters.BuildImage != null)
+                {
+                    buildImage = buildParameters.BuildImage;
+                    info["buildImage"] = buildImage;
+                }
 
                 args.Add("run");
                 args.AddRange(new[] { "--env", $"GIT_REPO={buildParameters.GitRepository}" });
@@ -90,7 +96,7 @@ public class BuildService
 
                 args.AddRange(new[] { "-v", $"{volume}:/out" });
                 args.AddRange(new[] { "--rm" });
-                args.Add("plugin-builder");
+                args.Add(buildImage);
                 await UpdateBuild(fullBuildId, BuildStates.Running, info);
             }
             catch (Exception err)
@@ -126,6 +132,8 @@ public class BuildService
 
                     var buildEnvStr = await ReadFileInVolume(volume, "build-env.json");
                     buildEnv = JObject.Parse(buildEnvStr);
+                    if (buildParameters.BuildImage != null)
+                        buildEnv["buildImage"] = buildParameters.BuildImage;
                 }
                 catch (Exception err)
                 {
@@ -275,13 +283,16 @@ public class BuildService
         EventAggregator.Publish(new BuildChanged(fullBuildId, newState) { BuildInfo = buildInfo?.ToString(), ManifestInfo = manifestInfo?.ToString() });
     }
 
-    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    public async Task<PluginProjectMetadata> FetchProjectMetadataFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
     {
         var provider = _providerFactory.GetProvider(repoUrl);
         if (provider == null)
             throw new BuildServiceException("Unsupported git hosting provider. Supported: GitHub, GitLab.");
-        return await provider.FetchIdentifierFromCsprojAsync(repoUrl, gitRef, pluginDir);
+        return await provider.FetchProjectMetadataFromCsprojAsync(repoUrl, gitRef, pluginDir);
     }
+
+    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null) =>
+        (await FetchProjectMetadataFromCsprojAsync(repoUrl, gitRef, pluginDir)).Identifier;
 
 
     public class BuildOutputCapture : IOutputCapture, IDisposable

--- a/PluginBuilder/Services/GitHubHostingProvider.cs
+++ b/PluginBuilder/Services/GitHubHostingProvider.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
@@ -54,7 +53,7 @@ public class GitHubHostingProvider : IGitHostingProvider
         return link;
     }
 
-    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    public async Task<PluginProjectMetadata> FetchProjectMetadataFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
     {
         var client = _httpClientFactory.CreateClient(HttpClientNames.GitHub);
         var (owner, repoName) = ExtractOwnerRepo(repoUrl);
@@ -98,18 +97,7 @@ public class GitHubHostingProvider : IGitHostingProvider
             throw new BuildServiceException(
                 $"GitHub error downloading '{csprojs[0].name}' from {downloadUrl} (HTTP {(int)csprojResp.StatusCode}).\nBody: {csprojBody}");
 
-        XDocument doc;
-        try
-        {
-            doc = XDocument.Parse(csprojBody);
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            throw new BuildServiceException($"Failed to parse '{csprojs[0].name}' as XML: {ex.Message}");
-        }
-        var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].name);
-
-        return assemblyName;
+        return PluginProjectMetadata.Parse(csprojBody, csprojs[0].name);
     }
 
     public async Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir)

--- a/PluginBuilder/Services/GitLabHostingProvider.cs
+++ b/PluginBuilder/Services/GitLabHostingProvider.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.APIModels;
@@ -75,7 +74,7 @@ public class GitLabHostingProvider : IGitHostingProvider
         return link;
     }
 
-    public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+    public async Task<PluginProjectMetadata> FetchProjectMetadataFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
     {
         var client = CreateClientForRepo(repoUrl);
         var projectId = GetProjectId(repoUrl);
@@ -125,18 +124,7 @@ public class GitLabHostingProvider : IGitHostingProvider
             throw new BuildServiceException(
                 $"GitLab error downloading '{csprojs[0].Name}' (HTTP {(int)fileResp.StatusCode}).\nBody: {csprojBody}");
 
-        XDocument doc;
-        try
-        {
-            doc = XDocument.Parse(csprojBody);
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            throw new BuildServiceException($"Failed to parse '{csprojs[0].Name}' as XML: {ex.Message}");
-        }
-        var assemblyName = doc.Descendants("AssemblyName").FirstOrDefault()?.Value ?? Path.GetFileNameWithoutExtension(csprojs[0].Name);
-
-        return assemblyName;
+        return PluginProjectMetadata.Parse(csprojBody, csprojs[0].Name);
     }
 
     public async Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir)

--- a/PluginBuilder/Services/IGitHostingProvider.cs
+++ b/PluginBuilder/Services/IGitHostingProvider.cs
@@ -5,7 +5,7 @@ namespace PluginBuilder.Services;
 public interface IGitHostingProvider
 {
     bool CanHandle(string repoUrl);
-    Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null);
+    Task<PluginProjectMetadata> FetchProjectMetadataFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null);
     Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir);
     string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir);
     (string Owner, string RepoName)? ParseRepository(string repoUrl);

--- a/PluginBuilder/Services/PluginProjectMetadata.cs
+++ b/PluginBuilder/Services/PluginProjectMetadata.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace PluginBuilder.Services;
+
+public record PluginProjectMetadata(string Identifier, string? BuildImage)
+{
+    public static PluginProjectMetadata Parse(string projectXml, string projectFileName)
+    {
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(projectXml);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            throw new BuildServiceException($"Failed to parse '{projectFileName}' as XML: {ex.Message}");
+        }
+
+        var identifier = document.Descendants("AssemblyName").FirstOrDefault()?.Value
+                         ?? Path.GetFileNameWithoutExtension(projectFileName);
+        var buildImage = document.Descendants("PluginBuildImage").FirstOrDefault()?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(buildImage))
+            return new PluginProjectMetadata(identifier, null);
+
+        if (!Regex.IsMatch(buildImage, @"^[^@\s]+@sha256:[a-f0-9]{64}$"))
+            throw new BuildServiceException(
+                $"PluginBuildImage in '{projectFileName}' must be an immutable repository@sha256 digest");
+
+        return new PluginProjectMetadata(identifier, buildImage);
+    }
+}

--- a/PluginBuilder/Util/BuildInfo.cs
+++ b/PluginBuilder/Util/BuildInfo.cs
@@ -16,6 +16,7 @@ public class BuildInfo
     public string Url { get; set; }
     public string Error { get; set; }
     public string BuildConfig { get; set; }
+    public string BuildImage { get; set; }
     public string AssemblyName { get; set; }
     public IDictionary<string, JToken> AdditionalObjects { get; set; }
 

--- a/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
+++ b/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
@@ -366,7 +366,8 @@ public static class NpgsqlConnectionExtensions
             BuildConfig = buildParameters.BuildConfig,
             GitRepository = buildParameters.GitRepository,
             GitRef = buildParameters.GitRef,
-            PluginDir = buildParameters.PluginDirectory
+            PluginDir = buildParameters.PluginDirectory,
+            BuildImage = buildParameters.BuildImage
         };
         var buildId = await connection.ExecuteScalarAsync<long>("" +
                                                                 "WITH cte AS " +


### PR DESCRIPTION
Read the optional PluginBuildImage project property and require a complete repository@sha256 reference.

Persist the digest with immutable build parameters and pass it directly to docker run, while retaining plugin-builder as the default.

Cover valid digests, mutable-reference rejection, and the empty-property fallback with focused tests.
