### PR TITLE
Refactor plugin slug route binding

### DIFF
--- a/PluginBuilder.Tests/PluginSlugModelBinderTests.cs
+++ b/PluginBuilder.Tests/PluginSlugModelBinderTests.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using PluginBuilder.ModelBinders;
+using PluginBuilder.Services;
+using Xunit;
+
+namespace PluginBuilder.Tests;
+
+public class PluginSlugModelBinderTests
+{
+    [Fact]
+    public async Task BindsPluginSlugFromRouteWhenFormContainsDifferentSlug()
+    {
+        const string routeSlug = "owned-plugin";
+        var form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            ["pluginSlug"] = "another-users-plugin"
+        });
+        var actionContext = new ActionContext(
+            new DefaultHttpContext(),
+            new RouteData(new RouteValueDictionary { ["pluginSlug"] = routeSlug }),
+            new ActionDescriptor(),
+            new ModelStateDictionary());
+        var valueProvider = new CompositeValueProvider
+        {
+            new FormValueProvider(BindingSource.Form, form, CultureInfo.InvariantCulture),
+            new RouteValueProvider(BindingSource.Path, actionContext.RouteData.Values)
+        };
+        var metadataProvider = new EmptyModelMetadataProvider();
+        var bindingContext = DefaultModelBindingContext.CreateBindingContext(
+            actionContext,
+            valueProvider,
+            metadataProvider.GetMetadataForType(typeof(PluginSlug)),
+            bindingInfo: null,
+            modelName: "pluginSlug");
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["POSTGRES"] = "Host=localhost;Database=unused;Username=unused"
+            })
+            .Build();
+        var binder = new PluginSlugModelBinder(new DBConnectionFactory(configuration));
+
+        await binder.BindModelAsync(bindingContext);
+
+        var pluginSlug = Assert.IsType<PluginSlug>(bindingContext.Result.Model);
+        Assert.Equal(routeSlug, pluginSlug.ToString());
+    }
+}

--- a/PluginBuilder.Tests/PluginTests/PluginTenantIsolationUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginTenantIsolationUITests.cs
@@ -1,0 +1,78 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.PluginTests;
+
+[Collection("Playwright Tests")]
+public class PluginTenantIsolationUITests(ITestOutputHelper output) : PageTest
+{
+    private readonly XUnitLogger _log = new("PluginTenantIsolationUITests", output);
+
+    [Fact]
+    public async Task FormPluginSlugCannotOverrideAuthorizedRoutePlugin()
+    {
+        await using var tester = new PlaywrightTester(_log) { Server = { ReuseDatabase = false } };
+        await tester.StartAsync();
+        await using var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
+
+        var attackerEmail = $"attacker-{Guid.NewGuid():N}@test.com";
+        var victimEmail = $"victim-{Guid.NewGuid():N}@test.com";
+        var attackerId = await tester.Server.CreateFakeUserAsync(attackerEmail);
+        var victimId = await tester.Server.CreateFakeUserAsync(victimEmail);
+        var attackerSlug = "attacker-" + PlaywrightTester.GetRandomUInt256()[..8];
+        var victimSlug = "victim-" + PlaywrightTester.GetRandomUInt256()[..8];
+        const string attackerRepositoryBefore = "https://github.com/example/attacker-before";
+        const string attackerRepositoryAfter = "https://github.com/example/attacker-after";
+        const string victimRepository = "https://github.com/example/victim";
+
+        await conn.NewPlugin(attackerSlug, attackerId);
+        await conn.NewPlugin(victimSlug, victimId);
+        await conn.SetPluginSettings(attackerSlug, new PluginSettings
+        {
+            PluginTitle = attackerSlug,
+            Description = "Attacker plugin",
+            GitRepository = attackerRepositoryBefore
+        });
+        await conn.SetPluginSettings(victimSlug, new PluginSettings
+        {
+            PluginTitle = victimSlug,
+            Description = "Victim plugin",
+            GitRepository = victimRepository
+        });
+
+        await tester.LogIn(attackerEmail);
+        await tester.GoToUrl($"/plugins/{attackerSlug}/settings");
+        var page = Assert.IsAssignableFrom<IPage>(tester.Page);
+        var form = page.Locator("#plugin-setting-form");
+        await Expect(form.Locator("input[name='__RequestVerificationToken']")).ToHaveCountAsync(1);
+        await page.FillAsync("#PluginTitle", attackerSlug);
+        await page.FillAsync("#Description", "Attacker plugin");
+        await page.FillAsync("#GitRepository", attackerRepositoryAfter);
+        await page.EvaluateAsync(
+            """
+            victimSlug => {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = 'pluginSlug';
+                input.value = victimSlug;
+                document.querySelector('#plugin-setting-form').appendChild(input);
+            }
+            """,
+            victimSlug);
+
+        await Expect(form.Locator("input[name='pluginSlug']")).ToHaveValueAsync(victimSlug);
+        await page.Locator("button[type='submit'][form='plugin-setting-form']").ClickAsync();
+
+        await Expect(page).ToHaveURLAsync(new Regex(
+            $"/plugins/{Regex.Escape(attackerSlug)}/settings$",
+            RegexOptions.IgnoreCase));
+        await tester.AssertNoError();
+        Assert.Equal(attackerRepositoryAfter, (await conn.GetSettings(attackerSlug))?.GitRepository);
+        Assert.Equal(victimRepository, (await conn.GetSettings(victimSlug))?.GitRepository);
+    }
+}

--- a/PluginBuilder/Authentication/PluginBuilderAuthorizationHandler.cs
+++ b/PluginBuilder/Authentication/PluginBuilderAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using PluginBuilder.ModelBinders;
 using PluginBuilder.Services;
 using PluginBuilder.Util.Extensions;
 
@@ -25,7 +26,7 @@ public class PluginBuilderAuthorizationHandler : AuthorizationHandler<OwnPluginR
         var slug = context.Resource as PluginSlug;
         if (slug is null)
         {
-            if (httpContext?.GetRouteData().Values.TryGetValue("pluginSlug", out v) is not true)
+            if (httpContext?.GetRouteData().Values.TryGetValue(PluginSlugModelBinder.PluginSlugRouteKey, out v) is not true)
                 return;
             if (v is not string v2 || !PluginSelectorBySlug.TryParse(v2, out var slugSelector))
             {

--- a/PluginBuilder/ModelBinders/PluginSlugModelBinder.cs
+++ b/PluginBuilder/ModelBinders/PluginSlugModelBinder.cs
@@ -6,6 +6,9 @@ namespace PluginBuilder.ModelBinders;
 
 public class PluginSlugModelBinder : IModelBinder
 {
+    // Route key carrying the tenant key; must stay in sync with OwnPlugin authorization.
+    public const string PluginSlugRouteKey = "pluginSlug";
+
     private readonly DBConnectionFactory _connectionFactory;
 
     public PluginSlugModelBinder(DBConnectionFactory connectionFactory)
@@ -16,7 +19,7 @@ public class PluginSlugModelBinder : IModelBinder
     public async Task BindModelAsync(ModelBindingContext bindingContext)
     {
         // Keep the bound tenant key aligned with the route value checked by OwnPlugin authorization.
-        if (!bindingContext.ActionContext.RouteData.Values.TryGetValue(bindingContext.ModelName, out var value) ||
+        if (!bindingContext.ActionContext.RouteData.Values.TryGetValue(PluginSlugRouteKey, out var value) ||
             value is not string v)
             return;
 

--- a/PluginBuilder/ModelBinders/PluginSlugModelBinder.cs
+++ b/PluginBuilder/ModelBinders/PluginSlugModelBinder.cs
@@ -15,10 +15,11 @@ public class PluginSlugModelBinder : IModelBinder
 
     public async Task BindModelAsync(ModelBindingContext bindingContext)
     {
-        var val = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
-        var v = val.FirstValue;
-        if (v is null)
+        // Keep the bound tenant key aligned with the route value checked by OwnPlugin authorization.
+        if (!bindingContext.ActionContext.RouteData.Values.TryGetValue(bindingContext.ModelName, out var value) ||
+            value is not string v)
             return;
+
         if (PluginSelector.TryParse(v, out var s))
         {
             var pluginSlug = await _connectionFactory.ResolvePluginSlug(s);


### PR DESCRIPTION
Ensures plugin slug model binding consistently uses route data.

Adds regression coverage for conflicting route and form values.