### PR TITLE
fix(listing): limit request text field lengths

### DIFF
--- a/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginRequestListingUITest.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 using Dapper;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,26 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
     public void TelegramVerificationMessageValidation_MatchesServerContract(string value, bool expected)
     {
         Assert.Equal(expected, RequestListingViewModel.IsValidTelegramVerificationMessage(value));
+    }
+
+    [Theory]
+    [InlineData(nameof(RequestListingViewModel.TelegramVerificationMessage), 200)]
+    [InlineData(nameof(RequestListingViewModel.UserReviews), 2000)]
+    public void RequestListingValidation_EnforcesTextFieldMaxLength(string propertyName, int maxLength)
+    {
+        var model = new RequestListingViewModel
+        {
+            ReleaseNote = "Release note",
+            TelegramVerificationMessage = "https://t.me/btcpayserver/1234",
+            UserReviews = "https://example.com/review"
+        };
+
+        SetTextField(model, propertyName, maxLength);
+        Assert.True(Validate(model, out _));
+
+        SetTextField(model, propertyName, maxLength + 1);
+        Assert.False(Validate(model, out var validationResults));
+        Assert.Contains(validationResults, result => result.MemberNames.Contains(propertyName));
     }
 
     [Fact]
@@ -87,6 +108,8 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         await Expect(t.Page.Locator("#ReleaseNote")).ToBeEditableAsync();
         await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToBeEditableAsync();
         await Expect(t.Page.Locator("#UserReviews")).ToBeEditableAsync();
+        await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToHaveAttributeAsync("maxlength", "200");
+        await Expect(t.Page.Locator("#UserReviews")).ToHaveAttributeAsync("maxlength", "2000");
         await Expect(t.Page.Locator("#AnnouncementDate")).ToBeEditableAsync();
         await t.Page!.ClickAsync("#StoreNav-Settings");
 
@@ -246,6 +269,19 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         await Expect(t.Page.Locator("#TelegramVerificationMessage")).ToHaveAttributeAsync("aria-invalid", "false");
         await Expect(telegramFeedback).Not.ToBeVisibleAsync();
         await Expect(t.Page.Locator("#SubmitListing")).ToBeEnabledAsync();
+
+        const string telegramPrefix = "https://t.me/btcpayserver/";
+        var oversizedTelegramResponse = await PostListingRequest(
+            t.Page,
+            telegramVerificationMessage: telegramPrefix + new string('a', 201 - telegramPrefix.Length));
+        Assert.True(oversizedTelegramResponse.Ok);
+        Assert.Null(await conn.GetPendingListingRequestForPlugin(new PluginSlug(pluginSlug)));
+
+        var oversizedUserReviewsResponse = await PostListingRequest(
+            t.Page,
+            userReviews: new string('a', 2001));
+        Assert.True(oversizedUserReviewsResponse.Ok);
+        Assert.Null(await conn.GetPendingListingRequestForPlugin(new PluginSlug(pluginSlug)));
 
         await t.Page.FillAsync("#UserReviews", "");
         await Expect(t.Page.Locator("#request-form-status")).ToContainTextAsync("Incomplete");
@@ -505,7 +541,10 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         Assert.Equal(PluginVisibilityEnum.Unlisted, plugin!.Visibility);
     }
 
-    private static async Task<IAPIResponse> PostListingRequest(IPage page)
+    private static async Task<IAPIResponse> PostListingRequest(
+        IPage page,
+        string telegramVerificationMessage = "https://t.me/btcpayserver/1234",
+        string userReviews = "https://example.com/review")
     {
         var form = page.Locator("#request-listing-form");
         var requestVerificationToken = await form
@@ -517,12 +556,30 @@ public class PluginRequestListingUITest(ITestOutputHelper output) : PageTest
         var formData = page.Context.APIRequest.CreateFormData();
         formData.Set("__RequestVerificationToken", requestVerificationToken);
         formData.Set("ReleaseNote", "Crafted release note");
-        formData.Set("TelegramVerificationMessage", "https://t.me/btcpayserver/1234");
-        formData.Set("UserReviews", "https://example.com/review");
+        formData.Set("TelegramVerificationMessage", telegramVerificationMessage);
+        formData.Set("UserReviews", userReviews);
 
         return await page.Context.APIRequest.PostAsync(
             new Uri(new Uri(page.Url), action).ToString(),
             new APIRequestContextOptions { Form = formData });
+    }
+
+    private static void SetTextField(RequestListingViewModel model, string propertyName, int length)
+    {
+        if (propertyName == nameof(RequestListingViewModel.TelegramVerificationMessage))
+        {
+            const string telegramPrefix = "https://t.me/btcpayserver/";
+            model.TelegramVerificationMessage = telegramPrefix + new string('a', length - telegramPrefix.Length);
+            return;
+        }
+
+        model.UserReviews = new string('a', length);
+    }
+
+    private static bool Validate(RequestListingViewModel model, out List<ValidationResult> validationResults)
+    {
+        validationResults = [];
+        return Validator.TryValidateObject(model, new ValidationContext(model), validationResults, true);
     }
 
 }

--- a/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
+++ b/PluginBuilder/ViewModels/Plugin/RequestListingViewModel.cs
@@ -11,10 +11,12 @@ public class RequestListingViewModel
     public string ReleaseNote { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "Telegram verification message is required.")]
+    [MaxLength(200)]
     [Display(Name = "Telegram Verification Message")]
     public string TelegramVerificationMessage { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "User reviews are required.")]
+    [MaxLength(2000)]
     [Display(Name = "User Reviews")]
     public string UserReviews { get; set; } = string.Empty;
     public bool HasRequests { get; set; }

--- a/PluginBuilder/Views/Plugin/RequestListing.cshtml
+++ b/PluginBuilder/Views/Plugin/RequestListing.cshtml
@@ -231,8 +231,10 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label asp-for="TelegramVerificationMessage" class="form-label" data-required></label>
-                            <input asp-for="TelegramVerificationMessage" type="url" class="form-control" required
+                            <label asp-for="TelegramVerificationMessage" class="form-label" data-required>
+                                Telegram Verification Message <span class="text-muted">(max 200 characters)</span>
+                            </label>
+                            <input asp-for="TelegramVerificationMessage" type="url" maxlength="200" class="form-control" required
                                    readonly="@formSubmitted"
                                    aria-describedby="telegram-verification-message-error" />
                             <span asp-validation-for="TelegramVerificationMessage" id="telegram-verification-message-error"
@@ -243,8 +245,10 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label asp-for="UserReviews" class="form-label" data-required></label>
-                            <textarea asp-for="UserReviews" class="form-control" rows="4" required
+                            <label asp-for="UserReviews" class="form-label" data-required>
+                                User Reviews <span class="text-muted">(max 2,000 characters)</span>
+                            </label>
+                            <textarea asp-for="UserReviews" class="form-control" rows="4" maxlength="2000" required
                                       readonly="@formSubmitted"></textarea>
                             <span asp-validation-for="UserReviews" class="text-danger"></span>
                             <div class="text-muted">Link at least one publicly posted review (Nostr, X, or user websites) from a reputable Bitcoiner who tested


### PR DESCRIPTION
- Limit Telegram verification messages to 200 characters.
- Limit user reviews to 2,000 characters.
- Show the limits in the listing form.
- Reject oversized values server-side before they are persisted.