### PR TITLE
feat(api): add exact directory plugin lookup by slug

### DIFF
--- a/PluginBuilder.Tests/ApiTests/PluginBySlugApiTests.cs
+++ b/PluginBuilder.Tests/ApiTests/PluginBySlugApiTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using Dapper;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PluginBuilder.APIModels;
+using PluginBuilder.DataModels;
+using PluginBuilder.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.ApiTests;
+
+public class PluginBySlugApiTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    [Fact]
+    public async Task ReturnsListedAndUnlistedPluginsAsSingleObjectButHidesHiddenPlugins()
+    {
+        await using var tester = Create();
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var pluginSlug = UniqueSlug("slug-visibility");
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await InsertPlugin(conn, pluginSlug, PluginVisibilityEnum.Listed, new VersionFixture("1.0.0.0"));
+
+        var client = tester.CreateHttpClient();
+        using (var listedResponse = await client.GetAsync(DirectoryUrl(pluginSlug)))
+            await AssertPublishedVersion(listedResponse, pluginSlug, "1.0.0.0");
+
+        await SetVisibility(conn, pluginSlug, PluginVisibilityEnum.Unlisted);
+        using (var unlistedResponse = await client.GetAsync(DirectoryUrl(pluginSlug)))
+            await AssertPublishedVersion(unlistedResponse, pluginSlug, "1.0.0.0");
+
+        await SetVisibility(conn, pluginSlug, PluginVisibilityEnum.Hidden);
+        using var hiddenResponse = await client.GetAsync(DirectoryUrl(pluginSlug));
+        Assert.Equal(HttpStatusCode.NotFound, hiddenResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task RequiresAnExactValidSlug()
+    {
+        await using var tester = Create();
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var pluginSlug = UniqueSlug("slug-exact");
+        var unpublishedSlug = UniqueSlug("slug-unpublished");
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await InsertPlugin(conn, pluginSlug, PluginVisibilityEnum.Listed, new VersionFixture("1.0.0.0"));
+        await InsertPlugin(conn, unpublishedSlug, PluginVisibilityEnum.Listed);
+
+        var client = tester.CreateHttpClient();
+
+        using var partialResponse = await client.GetAsync(DirectoryUrl(pluginSlug[..^1]));
+        Assert.Equal(HttpStatusCode.NotFound, partialResponse.StatusCode);
+
+        using var unknownResponse = await client.GetAsync(DirectoryUrl("missing-plugin"));
+        Assert.Equal(HttpStatusCode.NotFound, unknownResponse.StatusCode);
+
+        using var unpublishedResponse = await client.GetAsync(DirectoryUrl(unpublishedSlug));
+        Assert.Equal(HttpStatusCode.NotFound, unpublishedResponse.StatusCode);
+
+        using var malformedResponse = await client.GetAsync(DirectoryUrl("bad-"));
+        Assert.Equal(HttpStatusCode.BadRequest, malformedResponse.StatusCode);
+
+        using var identifierResponse = await client.GetAsync(DirectoryUrl("[BTCPayServer.Plugins.Test]"));
+        Assert.Equal(HttpStatusCode.BadRequest, identifierResponse.StatusCode);
+
+        using var invalidBooleanResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?includePreRelease=invalid"));
+        Assert.Equal(HttpStatusCode.BadRequest, invalidBooleanResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SelectsPrereleasesAndFiltersCompatibleVersions()
+    {
+        await using var tester = Create();
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var pluginSlug = UniqueSlug("slug-versions");
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await InsertPlugin(
+            conn,
+            pluginSlug,
+            PluginVisibilityEnum.Listed,
+            new VersionFixture("1.0.0.0", BtcpayMinVersion: "2.3.0.0", BtcpayMaxVersion: "2.3.7.0"),
+            new VersionFixture("2.0.0.0", PreRelease: true, BtcpayMinVersion: "2.4.0.0", BtcpayMaxVersion: "2.4.5.0"));
+        var client = tester.CreateHttpClient();
+
+        using var stableResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.3.7"));
+        var stablePlugin = await AssertPublishedVersion(stableResponse, pluginSlug, "1.0.0.0");
+        Assert.Equal("2.3.0.0", stablePlugin.BTCPayMinVersion);
+        Assert.Equal("2.3.7.0", stablePlugin.BTCPayMaxVersion);
+
+        using var prereleaseHostResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.3.7-rc2&includePreRelease=true"));
+        var prereleaseHostPlugin = await AssertPublishedVersion(prereleaseHostResponse, pluginSlug, "1.0.0.0");
+        Assert.Equal("2.3.0.0", prereleaseHostPlugin.BTCPayMinVersion);
+        Assert.Equal("2.3.7.0", prereleaseHostPlugin.BTCPayMaxVersion);
+
+        using var excludedCompatiblePrereleaseResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.4.0"));
+        Assert.Equal(HttpStatusCode.NotFound, excludedCompatiblePrereleaseResponse.StatusCode);
+
+        using var includedCompatiblePrereleaseResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.4.0&includePreRelease=true"));
+        var compatiblePrereleasePlugin = await AssertPublishedVersion(includedCompatiblePrereleaseResponse, pluginSlug, "2.0.0.0");
+        Assert.Equal("2.4.0.0", compatiblePrereleasePlugin.BTCPayMinVersion);
+        Assert.Equal("2.4.5.0", compatiblePrereleasePlugin.BTCPayMaxVersion);
+
+        using var incompatibleResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.4.5.1&includePreRelease=true"));
+        Assert.Equal(HttpStatusCode.NotFound, incompatibleResponse.StatusCode);
+
+        using var invalidHostResponse = await client.GetAsync(DirectoryUrl(pluginSlug, "?btcpayVersion=2.3.x-rc1"));
+        Assert.Equal(HttpStatusCode.BadRequest, invalidHostResponse.StatusCode);
+    }
+
+    private static async Task InsertPlugin(
+        System.Data.IDbConnection conn,
+        string pluginSlug,
+        PluginVisibilityEnum visibility,
+        params VersionFixture[] versions)
+    {
+        var identifier = IdentifierFor(pluginSlug);
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO plugins (slug, identifier, settings, visibility)
+            VALUES (@pluginSlug, @identifier, @settings::JSONB, @visibility::plugin_visibility_enum)
+            """,
+            new
+            {
+                pluginSlug,
+                identifier,
+                settings = "{\"pluginTitle\":\"Test plugin\",\"description\":\"Test plugin description\"}",
+                visibility = visibility.ToString().ToLowerInvariant()
+            });
+
+        for (var i = 0; i < versions.Length; i++)
+        {
+            var fixture = versions[i];
+            var buildId = i + 1L;
+            var manifestInfo = new JObject
+            {
+                ["Identifier"] = identifier,
+                ["Name"] = "Test plugin",
+                ["Version"] = fixture.Version,
+                ["Description"] = "Test plugin description",
+                ["Dependencies"] = new JArray()
+            };
+
+            await conn.ExecuteAsync(
+                """
+                INSERT INTO builds (plugin_slug, id, state, manifest_info, build_info)
+                VALUES (@pluginSlug, @buildId, 'uploaded', @manifestInfo::JSONB, '{}'::JSONB);
+
+                INSERT INTO versions (plugin_slug, ver, build_id, btcpay_min_ver, btcpay_max_ver, pre_release)
+                VALUES (@pluginSlug, @version, @buildId, @btcpayMinVersion, @btcpayMaxVersion, @preRelease);
+                """,
+                new
+                {
+                    pluginSlug,
+                    buildId,
+                    manifestInfo = manifestInfo.ToString(Formatting.None),
+                    version = PluginVersion.Parse(fixture.Version).VersionParts,
+                    btcpayMinVersion = PluginVersion.Parse(fixture.BtcpayMinVersion).VersionParts,
+                    btcpayMaxVersion = fixture.BtcpayMaxVersion is null
+                        ? null
+                        : PluginVersion.Parse(fixture.BtcpayMaxVersion).VersionParts,
+                    preRelease = fixture.PreRelease
+                });
+        }
+    }
+
+    private static Task SetVisibility(System.Data.IDbConnection conn, string pluginSlug, PluginVisibilityEnum visibility)
+    {
+        return conn.ExecuteAsync(
+            "UPDATE plugins SET visibility = @visibility::plugin_visibility_enum WHERE slug = @pluginSlug",
+            new { pluginSlug, visibility = visibility.ToString().ToLowerInvariant() });
+    }
+
+    private static string DirectoryUrl(string pluginSlug, string query = "")
+    {
+        return $"/api/v1/plugins/directory/{Uri.EscapeDataString(pluginSlug)}{query}";
+    }
+
+    private static async Task<PublishedVersion> AssertPublishedVersion(
+        HttpResponseMessage response,
+        string expectedSlug,
+        string expectedVersion)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = JToken.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(JTokenType.Object, json.Type);
+        var publishedVersion = json.ToObject<PublishedVersion>() ?? throw new InvalidOperationException("Expected a published plugin version.");
+        Assert.Equal(expectedSlug, publishedVersion.ProjectSlug);
+        Assert.Equal(expectedVersion, publishedVersion.Version);
+        Assert.Equal(IdentifierFor(expectedSlug), publishedVersion.ManifestInfo?["Identifier"]?.ToString());
+        Assert.NotNull(publishedVersion.BuildInfo);
+        return publishedVersion;
+    }
+
+    private static string IdentifierFor(string pluginSlug) => $"BTCPayServer.Plugins.{pluginSlug.Replace('-', '.')}";
+
+    private static string UniqueSlug(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}"[..Math.Min(prefix.Length + 9, 30)];
+    }
+
+    private sealed record VersionFixture(
+        string Version,
+        bool PreRelease = false,
+        string BtcpayMinVersion = "0.0.0.0",
+        string? BtcpayMaxVersion = null);
+}

--- a/PluginBuilder.Tests/PublicTests/RateLimitTests.cs
+++ b/PluginBuilder.Tests/PublicTests/RateLimitTests.cs
@@ -16,6 +16,7 @@ public class RateLimitTests(ITestOutputHelper logs) : UnitTestBase(logs)
     [Theory]
     [InlineData("/public/plugins", "GET")]
     [InlineData("/api/v1/plugins", "GET")]
+    [InlineData("/api/v1/plugins/directory/test-slug", "GET")]
     [InlineData("/public/plugins/any-slug", "GET")]
     [InlineData("/api/v1/plugins/test-identifier", "GET")]
     [InlineData("/api/v1/plugins/test-slug/versions/1.0.0", "GET")]

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -144,6 +144,62 @@ public class ApiController(
     }
 
     [AllowAnonymous]
+    [HttpGet("plugins/directory/{pluginSlug}")]
+    [EnableRateLimiting(Policies.PublicApiRateLimit)]
+    public async Task<IActionResult> GetDirectoryPluginBySlug(
+        string pluginSlug,
+        [ModelBinder(typeof(BtcPayHostVersionModelBinder))]
+        PluginVersion? btcpayVersion = null,
+        bool? includePreRelease = null)
+    {
+        if (!PluginSlug.TryParse(pluginSlug, out var parsedPluginSlug))
+        {
+            ModelState.AddModelError(nameof(pluginSlug), "Invalid plugin slug");
+            return ValidationProblem(ModelState);
+        }
+
+        includePreRelease ??= false;
+        await using var conn = await connectionFactory.Open();
+
+        var query = """
+                    SELECT lv.plugin_slug, lv.ver, p.settings, b.id, b.manifest_info, b.build_info,
+                           v.btcpay_min_ver,
+                           v.btcpay_max_ver,
+                           v.signatureproof->>'fingerprint' AS fingerprint,
+                           v.changelog
+                    FROM get_latest_versions(@btcpayVersion, @includePreRelease) lv
+                    JOIN versions v ON v.plugin_slug = lv.plugin_slug AND v.ver = lv.ver
+                    JOIN builds b ON b.plugin_slug = lv.plugin_slug AND b.id = lv.build_id
+                    JOIN plugins p ON b.plugin_slug = p.slug
+                    WHERE p.slug = @pluginSlug
+                      AND p.visibility IN ('listed', 'unlisted')
+                      AND b.build_info IS NOT NULL
+                      AND b.manifest_info IS NOT NULL
+                    LIMIT 1
+                    """;
+
+        var row =
+            await conn.QueryFirstOrDefaultAsync<(string plugin_slug, int[] ver, string settings, long id, string manifest_info, string build_info,
+                int[] btcpay_min_ver, int[]? btcpay_max_ver, string? fingerprint, string? changelog)?>(
+                query,
+                new
+                {
+                    btcpayVersion = btcpayVersion?.VersionParts,
+                    includePreRelease = includePreRelease.Value,
+                    pluginSlug = parsedPluginSlug.ToString()
+                });
+
+        if (row is null)
+            return NotFound();
+
+        var r = row.Value;
+        var manifestInfo = JObject.Parse(r.manifest_info);
+        var settings = SafeJson.Deserialize<PluginSettings>((string?)r.settings);
+        return Ok(CreatePublishedVersion(r.plugin_slug, r.ver, r.btcpay_min_ver, r.btcpay_max_ver, r.id, settings, manifestInfo,
+            JObject.Parse(r.build_info), r.fingerprint, r.changelog));
+    }
+
+    [AllowAnonymous]
     [HttpGet("plugins/{identifier}")]
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> GetPluginVersionsForDownload(

--- a/PluginBuilder/wwwroot/swagger/v1/swagger.json
+++ b/PluginBuilder/wwwroot/swagger/v1/swagger.json
@@ -135,6 +135,67 @@
         }
       }
     },
+    "/plugins/directory/{pluginSlug}": {
+      "get": {
+        "tags": ["Plugins"],
+        "summary": "Get a Directory plugin by slug",
+        "description": "Returns the latest published version compatible with the requested BTCPay Server version for an exact Plugin Directory slug. Listed and unlisted plugins are available; hidden plugins are not returned.",
+        "operationId": "getDirectoryPluginBySlug",
+        "parameters": [
+          {
+            "name": "pluginSlug",
+            "in": "path",
+            "description": "The exact plugin slug (e.g. `lnbank`).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "lnbank"
+            }
+          },
+          {
+            "name": "btcpayVersion",
+            "in": "query",
+            "description": "Filter by BTCPay Server version compatibility.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "2.2.1"
+            }
+          },
+          {
+            "name": "includePreRelease",
+            "in": "query",
+            "description": "Include pre-release versions.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest compatible published version for the plugin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublishedVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid plugin slug or query parameter"
+          },
+          "404": {
+            "description": "Plugin not found or no compatible published version is available"
+          },
+          "429": {
+            "description": "Too many requests"
+          }
+        }
+      }
+    },
     "/plugins/{identifier}": {
       "get": {
         "tags": ["Plugins"],


### PR DESCRIPTION
Unlisted plugins can be found through the Plugin Directory search, but BTCPay currently has no reliable way to load the exact plugin after it is selected. This can leave the plugin details panel empty and prevent installation.

This PR adds an exact Directory lookup by slug, allowing BTCPay to display the correct details for both listed and unlisted plugins.

Hidden plugins remain unavailable through the Plugin Directory, while the existing identifier-based installation and autoinstall flows remain unchanged.