### PR TITLE
Feat : add video file URLs support

### DIFF
--- a/PluginBuilder.Tests/PluginTests/VideoUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/VideoUITests.cs
@@ -140,8 +140,15 @@ public class VideoUITests(ITestOutputHelper output) : PageTest
         Assert.Null(await video.GetAttributeAsync("src"));
         Assert.Equal(0, await t.Page.Locator("video[data-video-file] source").CountAsync());
 
-        await video.ClickAsync();
+        // The cover is what the visitor is meant to click: the native controls alone do not show that
+        // the player still has to fetch anything
+        var cover = t.Page.Locator("[data-video-cover]");
+        await Expect(cover).ToBeVisibleAsync();
+        await Expect(cover).ToContainTextAsync("cdn.example.com");
+
+        await cover.ClickAsync();
         await Expect(video).ToHaveAttributeAsync("src", mp4Url);
+        await Expect(cover).ToHaveCountAsync(0);
 
         // No platform thumbnail exists for a direct file, so the fallback video thumb is used
         await Expect(t.Page.Locator(".plugin-media-video-thumb")).ToBeVisibleAsync();

--- a/PluginBuilder.Tests/PluginTests/VideoUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/VideoUITests.cs
@@ -311,7 +311,7 @@ public class VideoUITests(ITestOutputHelper output) : PageTest
 
         var platformError = t.Page.Locator("span[data-valmsg-for='VideoUrl']");
         await Expect(platformError).ToBeVisibleAsync();
-        await Expect(platformError).ToContainTextAsync(new Regex("youtube|vimeo", RegexOptions.IgnoreCase));
+        await Expect(platformError).ToContainTextAsync("YouTube or Vimeo");
     }
 
     [Fact]

--- a/PluginBuilder.Tests/PluginTests/VideoUITests.cs
+++ b/PluginBuilder.Tests/PluginTests/VideoUITests.cs
@@ -85,6 +85,69 @@ public class VideoUITests(ITestOutputHelper output) : PageTest
     }
 
     [Fact]
+    public async Task OwnerCanAddDirectMp4VideoUrlAndItRendersWithHtml5Player()
+    {
+        await using var t = new PlaywrightTester(_log);
+        t.Server.ReuseDatabase = false;
+        await t.StartAsync();
+        await using var conn = await t.Server.GetService<DBConnectionFactory>().Open();
+
+        // Create user and plugin with a released version
+        await t.EnableGithubVerificationAsync(conn);
+
+        await t.GoToUrl("/register");
+        var user = await t.RegisterNewUser();
+        await t.VerifyUserAccounts(user);
+
+        var pluginSlug = "video-mp4-" + PlaywrightTester.GetRandomUInt256()[..8];
+        var fullBuildId = await t.Server.CreateAndBuildPluginAsync(
+            await conn.QuerySingleAsync<string>("SELECT \"Id\" FROM \"AspNetUsers\" WHERE \"Email\" = @Email", new { Email = user }),
+            pluginSlug);
+
+        // Release the build so plugin appears on public page
+        var manifestInfoJson = await conn.QuerySingleAsync<string>(
+            "SELECT manifest_info FROM builds WHERE plugin_slug = @PluginSlug AND id = @BuildId",
+            new { PluginSlug = pluginSlug, fullBuildId.BuildId });
+        var manifest = PluginManifest.Parse(manifestInfoJson);
+        await conn.SetVersionBuild(fullBuildId, manifest.Version, manifest.BTCPayMinVersion, manifest.BTCPayMaxVersion, false);
+        await conn.SetPluginSettings(pluginSlug, new PluginSettings { PluginTitle = pluginSlug, Description = "Test plugin", GitRepository = ServerTester.RepoUrl }, PluginVisibilityEnum.Listed);
+
+        // A direct file link, without any video platform involved
+        await t.GoToUrl($"/plugins/{pluginSlug}/settings");
+        const string mp4Url = "https://cdn.example.com/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08.mp4";
+        await t.Page.Locator("input[name='VideoUrl']").FillAsync(mp4Url);
+        await t.Page.Locator("button[type='submit'][form='plugin-setting-form']").ClickAsync();
+        await t.AssertNoError();
+
+        var savedVideoUrl = await conn.QuerySingleOrDefaultAsync<string>(
+            "SELECT settings->>'videoUrl' FROM plugins WHERE slug = @Slug",
+            new { Slug = pluginSlug });
+        Assert.Equal(mp4Url, savedVideoUrl);
+
+        // Verify an HTML5 player is rendered instead of an iframe embed
+        await t.GoToUrl($"/public/plugins/{pluginSlug}");
+        await t.AssertNoError();
+
+        var video = t.Page.Locator("video[data-video-file]");
+        await Expect(video).ToBeVisibleAsync();
+        await Expect(video).ToHaveAttributeAsync("controls", "");
+        await Expect(video).ToHaveAttributeAsync("preload", "none");
+        await Expect(t.Page.Locator("iframe[data-video-embed]")).ToHaveCountAsync(0);
+
+        // The url is parked in data-video-src and only becomes a src once the visitor clicks the player,
+        // so nothing is requested from the host that serves the video before then
+        Assert.Equal(mp4Url, await video.GetAttributeAsync("data-video-src"));
+        Assert.Null(await video.GetAttributeAsync("src"));
+        Assert.Equal(0, await t.Page.Locator("video[data-video-file] source").CountAsync());
+
+        await video.ClickAsync();
+        await Expect(video).ToHaveAttributeAsync("src", mp4Url);
+
+        // No platform thumbnail exists for a direct file, so the fallback video thumb is used
+        await Expect(t.Page.Locator(".plugin-media-video-thumb")).ToBeVisibleAsync();
+    }
+
+    [Fact]
     public async Task OwnerCanUpdateVideoUrlFromYouTubeToVimeo()
     {
         await using var t = new PlaywrightTester(_log);
@@ -234,14 +297,14 @@ public class VideoUITests(ITestOutputHelper output) : PageTest
         await Expect(errorMessage).ToBeVisibleAsync();
         await Expect(errorMessage).ToContainTextAsync("valid HTTPS URL");
 
-        // Test unsupported platform (e.g., Dailymotion)
+        // A link to a platform we embed still has to carry a usable video id
         await t.GoToUrl($"/plugins/{pluginSlug}/settings");
-        await t.Page.Locator("input[name='VideoUrl']").FillAsync("https://www.dailymotion.com/video/x8abc123");
+        await t.Page.Locator("input[name='VideoUrl']").FillAsync("https://www.youtube.com/feed/subscriptions");
         await t.Page.Locator("button[type='submit'][form='plugin-setting-form']").ClickAsync();
 
         var platformError = t.Page.Locator("span[data-valmsg-for='VideoUrl']");
         await Expect(platformError).ToBeVisibleAsync();
-        await Expect(platformError).ToContainTextAsync(new Regex("supported.*platform|youtube|vimeo", RegexOptions.IgnoreCase));
+        await Expect(platformError).ToContainTextAsync(new Regex("youtube|vimeo", RegexOptions.IgnoreCase));
     }
 
     [Fact]

--- a/PluginBuilder.Tests/VideoUrlExtensionsTests.cs
+++ b/PluginBuilder.Tests/VideoUrlExtensionsTests.cs
@@ -1,0 +1,56 @@
+using PluginBuilder.Util.Extensions;
+using Xunit;
+
+namespace PluginBuilder.Tests;
+
+public class VideoUrlExtensionsTests
+{
+    [Theory]
+    [InlineData("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/embed/dQw4w9WgXcQ")]
+    [InlineData("https://youtu.be/dQw4w9WgXcQ", "https://www.youtube.com/embed/dQw4w9WgXcQ")]
+    [InlineData("https://www.youtube.com/watch?v=9bZkp7q19f0&t=30s", "https://www.youtube.com/embed/9bZkp7q19f0")]
+    [InlineData("https://vimeo.com/123456789", "https://player.vimeo.com/video/123456789")]
+    public void PlatformUrlsAreEmbedded(string videoUrl, string expectedUrl)
+    {
+        var source = videoUrl.GetVideoSource();
+        Assert.NotNull(source);
+        Assert.Equal(VideoPlayerKind.Embed, source.Kind);
+        Assert.Equal(expectedUrl, source.Url);
+        Assert.NotNull(videoUrl.GetVideoThumbnailUrl());
+    }
+
+    // The URL is passed through untouched whatever it looks like: only the Content-Type the host returns
+    // decides whether the browser plays it, so the extension is never used to claim a type.
+    [Theory]
+    [InlineData("https://cdn.example.com/9f86d081884c7d659a2feaa0c55ad015.mp4")]
+    [InlineData("https://example.com/media/demo.MP4")]
+    [InlineData("https://example.com/media/demo.mp4?token=abc")]
+    [InlineData("https://cdn.example.com/9f86d081884c7d659a2feaa0c55ad015")]
+    [InlineData("https://example.com/media/demo.webm")]
+    [InlineData("https://www.dailymotion.com/video/x8abc123")]
+    public void EverythingElseIsPlayedAsAFile(string videoUrl)
+    {
+        var source = videoUrl.GetVideoSource();
+        Assert.NotNull(source);
+        Assert.Equal(VideoPlayerKind.File, source.Kind);
+        Assert.Equal(videoUrl, source.Url);
+        Assert.Null(videoUrl.GetVideoThumbnailUrl());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-valid-url")]
+    [InlineData("http://example.com/demo.mp4")] // https only
+    [InlineData("javascript:alert(1)")]
+    // Platform links still need a usable video id, an iframe pointing at nothing helps nobody
+    [InlineData("https://www.youtube.com/watch?v=tooshort")]
+    [InlineData("https://www.youtube.com/feed/subscriptions")]
+    [InlineData("https://youtu.be/")]
+    [InlineData("https://vimeo.com/channels/staffpicks")]
+    public void UnsupportedUrlsAreRejected(string? videoUrl)
+    {
+        Assert.Null(videoUrl.GetVideoSource());
+        Assert.False(videoUrl.IsSupportedVideoUrl());
+    }
+}

--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -187,7 +187,7 @@ public class AdminController(
             if (!Uri.TryCreate(model.PluginSettings.VideoUrl, UriKind.Absolute, out var videoUri) || videoUri.Scheme != Uri.UriSchemeHttps)
             {
                 ModelState.AddModelError($"{nameof(PluginEditViewModel.PluginSettings)}.{nameof(PluginSettings.VideoUrl)}",
-                    "Video URL must be a valid HTTPS URL.");
+                    "Video URL must be a valid HTTPS URL");
                 await PopulatePluginEditViewModel(conn, pluginSlug, model);
                 return View(model);
             }
@@ -195,7 +195,7 @@ public class AdminController(
             if (!model.PluginSettings.VideoUrl.IsSupportedVideoUrl())
             {
                 ModelState.AddModelError($"{nameof(PluginEditViewModel.PluginSettings)}.{nameof(PluginSettings.VideoUrl)}",
-                    "Video URL must be a direct link to a video.");
+                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct HTTPS link that serves a browser-playable video file");
                 await PopulatePluginEditViewModel(conn, pluginSlug, model);
                 return View(model);
             }

--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -195,7 +195,7 @@ public class AdminController(
             if (!model.PluginSettings.VideoUrl.IsSupportedVideoUrl())
             {
                 ModelState.AddModelError($"{nameof(PluginEditViewModel.PluginSettings)}.{nameof(PluginSettings.VideoUrl)}",
-                    "Video URL must be from a supported platform (YouTube, Vimeo).");
+                    "Video URL must be a direct link to a video.");
                 await PopulatePluginEditViewModel(conn, pluginSlug, model);
                 return View(model);
             }

--- a/PluginBuilder/Controllers/DashboardController.cs
+++ b/PluginBuilder/Controllers/DashboardController.cs
@@ -60,7 +60,7 @@ public class DashboardController(
             if (!model.VideoUrl.IsSupportedVideoUrl())
             {
                 ModelState.AddModelError(nameof(model.VideoUrl),
-                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct link to a video file");
+                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct HTTPS link that serves a browser-playable video file");
                 return View(model);
             }
         }

--- a/PluginBuilder/Controllers/DashboardController.cs
+++ b/PluginBuilder/Controllers/DashboardController.cs
@@ -59,7 +59,8 @@ public class DashboardController(
             }
             if (!model.VideoUrl.IsSupportedVideoUrl())
             {
-                ModelState.AddModelError(nameof(model.VideoUrl), "Video URL must be from a supported platform (YouTube, Vimeo)");
+                ModelState.AddModelError(nameof(model.VideoUrl),
+                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct link to a video file");
                 return View(model);
             }
         }

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -94,7 +94,8 @@ public class PluginController(
 
             if (!settingViewModel.VideoUrl.IsSupportedVideoUrl())
             {
-                ModelState.AddModelError(nameof(settingViewModel.VideoUrl), "Video URL must be from a supported platform (YouTube, Vimeo)");
+                ModelState.AddModelError(nameof(settingViewModel.VideoUrl),
+                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct link to a video file");
                 return View(settingViewModel);
             }
         }

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -95,7 +95,7 @@ public class PluginController(
             if (!settingViewModel.VideoUrl.IsSupportedVideoUrl())
             {
                 ModelState.AddModelError(nameof(settingViewModel.VideoUrl),
-                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct link to a video file");
+                    "Video URL must be a YouTube or Vimeo link pointing at a video, or a direct HTTPS link that serves a browser-playable video file");
                 return View(settingViewModel);
             }
         }

--- a/PluginBuilder/Util/Extensions/VideoUrlExtensions.cs
+++ b/PluginBuilder/Util/Extensions/VideoUrlExtensions.cs
@@ -2,6 +2,19 @@ using System.Text.RegularExpressions;
 
 namespace PluginBuilder.Util.Extensions;
 
+public enum VideoPlayerKind
+{
+    /// <summary>Third party player rendered in an iframe (YouTube, Vimeo).</summary>
+    Embed,
+
+    /// <summary>Direct video file played by the browser through a &lt;video&gt; element.</summary>
+    File
+}
+
+/// <summary>How a plugin video should be rendered: <paramref name="Url" /> is the iframe source for
+/// <see cref="VideoPlayerKind.Embed" />, or the file to play for <see cref="VideoPlayerKind.File" />.</summary>
+public record VideoSource(VideoPlayerKind Kind, string Url);
+
 public static partial class VideoUrlExtensions
 {
     [GeneratedRegex(@"^[A-Za-z0-9_-]{11}$")]
@@ -12,30 +25,42 @@ public static partial class VideoUrlExtensions
 
     public static bool IsSupportedVideoUrl(this string? videoUrl)
     {
-        return videoUrl.GetVideoEmbedUrl() != null;
+        return videoUrl.GetVideoSource() != null;
     }
 
-    public static string? GetVideoEmbedUrl(this string? videoUrl)
+    public static VideoSource? GetVideoSource(this string? videoUrl)
     {
         if (!TryParseVideoUri(videoUrl, out var uri)) return null;
 
-        var youtubeId = TryGetYoutubeVideoId(uri!);
-        if (!string.IsNullOrEmpty(youtubeId))
-            return $"https://www.youtube.com/embed/{youtubeId}";
+        // A link to a platform we embed has to carry a usable video id, otherwise the iframe would be broken
+        // and falling back to a media player would not help either.
+        if (IsHost(uri!, "youtube.com") || IsHost(uri!, "youtu.be"))
+        {
+            var youtubeId = TryGetYoutubeVideoId(uri!);
+            return youtubeId is null ? null : new VideoSource(VideoPlayerKind.Embed, $"https://www.youtube.com/embed/{youtubeId}");
+        }
 
-        var vimeoId = TryGetVimeoVideoId(uri!);
-        return !string.IsNullOrEmpty(vimeoId) ? $"https://player.vimeo.com/video/{vimeoId}" : null;
+        if (IsHost(uri!, "vimeo.com"))
+        {
+            var vimeoId = TryGetVimeoVideoId(uri!);
+            return vimeoId is null ? null : new VideoSource(VideoPlayerKind.Embed, $"https://player.vimeo.com/video/{vimeoId}");
+        }
+
+        // Anything else is handed to the browser as a media file. Whether it plays is decided by the
+        // Content-Type the host returns, which is why no extension is required and why we advertise no type
+        // of our own: the URL an author types is not evidence of what the host actually serves.
+        return new VideoSource(VideoPlayerKind.File, uri!.AbsoluteUri);
     }
 
     public static string? GetVideoThumbnailUrl(this string? videoUrl)
     {
         if (!TryParseVideoUri(videoUrl, out var uri)) return null;
 
-        var youtubeId = TryGetYoutubeVideoId(uri);
+        var youtubeId = TryGetYoutubeVideoId(uri!);
         if (!string.IsNullOrEmpty(youtubeId))
             return $"https://i.ytimg.com/vi/{youtubeId}/hqdefault.jpg";
 
-        var vimeoId = TryGetVimeoVideoId(uri);
+        var vimeoId = TryGetVimeoVideoId(uri!);
         if (!string.IsNullOrEmpty(vimeoId))
             return $"https://vumbnail.com/{vimeoId}.jpg";
 
@@ -89,4 +114,3 @@ public static partial class VideoUrlExtensions
                uri.Host.EndsWith("." + host, StringComparison.OrdinalIgnoreCase);
     }
 }
-

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -113,7 +113,7 @@
                     <div class="form-group">
                         <label asp-for="PluginSettings.VideoUrl" class="form-label"></label>
                         <input asp-for="PluginSettings.VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
-                        <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
+                        <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
                         <span asp-validation-for="PluginSettings.VideoUrl" class="text-danger"></span>
                     </div>
                     <div class="form-group">

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -113,6 +113,7 @@
                     <div class="form-group">
                         <label asp-for="PluginSettings.VideoUrl" class="form-label"></label>
                         <input asp-for="PluginSettings.VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
+                        <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
                         <span asp-validation-for="PluginSettings.VideoUrl" class="text-danger"></span>
                     </div>
                     <div class="form-group">

--- a/PluginBuilder/Views/Admin/PluginEdit.cshtml
+++ b/PluginBuilder/Views/Admin/PluginEdit.cshtml
@@ -113,7 +113,7 @@
                     <div class="form-group">
                         <label asp-for="PluginSettings.VideoUrl" class="form-label"></label>
                         <input asp-for="PluginSettings.VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
-                        <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
+                        <div class="form-text">YouTube, Vimeo, or a direct HTTPS link that serves a browser-playable video file.</div>
                         <span asp-validation-for="PluginSettings.VideoUrl" class="text-danger"></span>
                     </div>
                     <div class="form-group">

--- a/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
+++ b/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
@@ -33,7 +33,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" type="url" class="form-control" />
-                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group mt-4">

--- a/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
+++ b/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
@@ -33,6 +33,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" type="url" class="form-control" />
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group mt-4">

--- a/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
+++ b/PluginBuilder/Views/Dashboard/CreatePlugin.cshtml
@@ -33,7 +33,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" type="url" class="form-control" />
-                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link that serves a browser-playable video file.</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group mt-4">

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -153,13 +153,21 @@
                                         }
                                         else if (m.Video is { Kind: VideoPlayerKind.File })
                                         {
+                                            var videoHost = new Uri(m.MediaUrl).Host;
                                             @* No src is rendered: it is assigned from data-video-src on an explicit click, so the
-                                               request to the third party host is always user triggered rather than left to preload heuristics. *@
+                                               request to the third party host is always user triggered rather than left to preload heuristics.
+                                               The cover tells the visitor that the player needs a click and which host it will reach. *@
                                             <video data-video-file data-video-src="@m.MediaUrl" class="plugin-media-video" title="Plugin video"
                                                    controls playsinline preload="none">
                                                 Your browser does not support embedded videos.
                                                 <a href="@m.MediaUrl" rel="noreferrer noopener" target="_blank">Download the video</a>.
                                             </video>
+                                            <button type="button" class="plugin-media-video-cover" data-video-cover
+                                                    aria-label="Play video, loaded from @videoHost">
+                                                <span class="plugin-media-video-cover-icon"><i class="fa fa-play" aria-hidden="true"></i></span>
+                                                <span class="plugin-media-video-cover-text">Play video</span>
+                                                <span class="plugin-media-video-cover-host">Loads from @videoHost</span>
+                                            </button>
                                         }
                                         else
                                         {
@@ -601,11 +609,14 @@
         slides.forEach(s => {
             const video = s.querySelector('video[data-video-file]');
             if (!video || !video.dataset.videoSrc) return;
+            const cover = s.querySelector('[data-video-cover]');
             const load = play => {
+                cover?.remove();
                 if (video.src) return;
                 video.src = video.dataset.videoSrc;
                 if (play) video.play?.().catch(() => { });
             };
+            cover?.addEventListener('click', () => load(true));
             video.addEventListener('click', () => load(true));
             video.addEventListener('keydown', () => load(false));
         });

--- a/PluginBuilder/Views/Home/GetPluginDetails.cshtml
+++ b/PluginBuilder/Views/Home/GetPluginDetails.cshtml
@@ -26,16 +26,16 @@
     var currentVersion = Model.PluginVersions.FirstOrDefault(v => v.Version == Model.Plugin.Version);
     var currentShortVersion = string.Join(".", Model.Plugin.Version.Split('.').Take(3));
 
-    var videoEmbedUrl = Model.Plugin.VideoUrl.GetVideoEmbedUrl();
+    var videoSource = Model.Plugin.VideoUrl.GetVideoSource();
     var videoThumbUrl = Model.Plugin.VideoUrl.GetVideoThumbnailUrl();
     var screenshots = Model.Plugin.Images?.Where(s => !string.IsNullOrWhiteSpace(s)).ToList() ?? new List<string>();
-    var mediaItems = new List<(bool IsVideo, string MediaUrl, string? ThumbUrl, string Alt, string ThumbLabel)>();
+    var mediaItems = new List<(VideoSource? Video, string MediaUrl, string? ThumbUrl, string Alt, string ThumbLabel)>();
 
-    if (!string.IsNullOrWhiteSpace(videoEmbedUrl))
-        mediaItems.Add((true, videoEmbedUrl, videoThumbUrl, "Plugin video", "Show video"));
+    if (videoSource != null)
+        mediaItems.Add((videoSource, videoSource.Url, videoThumbUrl, "Plugin video", "Show video"));
 
     for (var i = 0; i < screenshots.Count; i++)
-        mediaItems.Add((false, screenshots[i], screenshots[i], $"{Model.Plugin.PluginTitle} screenshot {i + 1}", $"Show screenshot {i + 1}"));
+        mediaItems.Add((null, screenshots[i], screenshots[i], $"{Model.Plugin.PluginTitle} screenshot {i + 1}", $"Show screenshot {i + 1}"));
 }
 
 @section Meta {
@@ -143,13 +143,23 @@
                                 {
                                     var m = mediaItems[i];
                                     <div class="plugin-media-slide @(i == 0 ? "is-active" : "d-none")" data-media-slide aria-hidden="@(i == 0 ? "false" : "true")">
-                                        @if (m.IsVideo)
+                                        @if (m.Video is { Kind: VideoPlayerKind.Embed })
                                         {
                                             <iframe data-video-embed data-video-src="@m.MediaUrl"
                                                     title="Plugin video"
                                                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                                     allowfullscreen loading="lazy" style="border: none;">
                                             </iframe>
+                                        }
+                                        else if (m.Video is { Kind: VideoPlayerKind.File })
+                                        {
+                                            @* No src is rendered: it is assigned from data-video-src on an explicit click, so the
+                                               request to the third party host is always user triggered rather than left to preload heuristics. *@
+                                            <video data-video-file data-video-src="@m.MediaUrl" class="plugin-media-video" title="Plugin video"
+                                                   controls playsinline preload="none">
+                                                Your browser does not support embedded videos.
+                                                <a href="@m.MediaUrl" rel="noreferrer noopener" target="_blank">Download the video</a>.
+                                            </video>
                                         }
                                         else
                                         {
@@ -164,7 +174,7 @@
                                 {
                                     var m = mediaItems[i];
                                     <button type="button" class="plugin-media-thumb @(i == 0 ? "is-active" : "")" data-media-thumb aria-label="@m.ThumbLabel" aria-current="@(i == 0 ? "true" : "false")">
-                                        @if (m.IsVideo)
+                                        @if (m.Video != null)
                                         {
                                             @if (!string.IsNullOrWhiteSpace(m.ThumbUrl))
                                             {
@@ -586,6 +596,20 @@
 
         let activeIndex = Math.max(0, slides.findIndex(s => s.classList.contains('is-active')));
 
+        // The file player stays sourceless until the visitor acts on it, so no request reaches the
+        // host that serves the video until they ask for it.
+        slides.forEach(s => {
+            const video = s.querySelector('video[data-video-file]');
+            if (!video || !video.dataset.videoSrc) return;
+            const load = play => {
+                if (video.src) return;
+                video.src = video.dataset.videoSrc;
+                if (play) video.play?.().catch(() => { });
+            };
+            video.addEventListener('click', () => load(true));
+            video.addEventListener('keydown', () => load(false));
+        });
+
         const setActive = (index, scroll = false) => {
             activeIndex = (index + slides.length) % slides.length;
             slides.forEach((s, i) => {
@@ -595,6 +619,8 @@
                 s.setAttribute('aria-hidden', on ? 'false' : 'true');
                 const iframe = s.querySelector('iframe[data-video-embed]');
                 if (iframe) on ? (iframe.src || (iframe.src = iframe.dataset.videoSrc)) : iframe.removeAttribute('src');
+                const video = s.querySelector('video[data-video-file]');
+                if (video && !on) video.pause();
             });
             thumbs.forEach((t, i) => {
                 const on = i === activeIndex;

--- a/PluginBuilder/Views/Plugin/Settings.cshtml
+++ b/PluginBuilder/Views/Plugin/Settings.cshtml
@@ -58,7 +58,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
-                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/PluginBuilder/Views/Plugin/Settings.cshtml
+++ b/PluginBuilder/Views/Plugin/Settings.cshtml
@@ -58,7 +58,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
-                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file.</div>
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link that serves a browser-playable video file.</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/PluginBuilder/Views/Plugin/Settings.cshtml
+++ b/PluginBuilder/Views/Plugin/Settings.cshtml
@@ -58,6 +58,7 @@
             <div class="form-group">
                 <label asp-for="VideoUrl" class="form-label"></label>
                 <input asp-for="VideoUrl" class="form-control" placeholder="https://www.youtube.com/watch?v=..." />
+                <div class="form-text">YouTube, Vimeo, or a direct HTTPS link to a video file hosted anywhere (MP4 with H.264/AAC plays everywhere).</div>
                 <span asp-validation-for="VideoUrl" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/PluginBuilder/wwwroot/main/bootstrap/bootstrap.css
+++ b/PluginBuilder/wwwroot/main/bootstrap/bootstrap.css
@@ -5398,6 +5398,15 @@ fieldset:disabled .btn {
     display: block;
 }
 
+.plugin-media-carousel .plugin-media-video {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    object-fit: contain;
+    background: #000;
+    display: block;
+}
+
 .plugin-media-carousel .plugin-media-nav {
     position: absolute;
     top: 50%;

--- a/PluginBuilder/wwwroot/main/bootstrap/bootstrap.css
+++ b/PluginBuilder/wwwroot/main/bootstrap/bootstrap.css
@@ -5407,6 +5407,53 @@ fieldset:disabled .btn {
     display: block;
 }
 
+.plugin-media-carousel .plugin-media-video-cover {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    border: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    text-align: center;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.55);
+}
+
+.plugin-media-carousel .plugin-media-video-cover:hover,
+.plugin-media-carousel .plugin-media-video-cover:focus-visible {
+    background: rgba(0, 0, 0, 0.7);
+}
+
+.plugin-media-carousel .plugin-media-video-cover-icon {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    /* the triangle reads off centre without a nudge */
+    padding-left: 0.25rem;
+    background: rgba(255, 255, 255, 0.15);
+    border: 2px solid rgba(255, 255, 255, 0.85);
+}
+
+.plugin-media-carousel .plugin-media-video-cover-text {
+    font-weight: 600;
+}
+
+.plugin-media-carousel .plugin-media-video-cover-host {
+    font-size: 0.8125rem;
+    opacity: 0.75;
+    word-break: break-all;
+}
+
 .plugin-media-carousel .plugin-media-nav {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Summary

Closes #235 

Allow plugin video URLs to be direct HTTPS media files as well as YouTube/Vimeo embeds. This adds source detection for direct file URLs, renders them with HTML5 video players instead of iframes, and rejects invalid platform links without usable IDs. It also updates validation messages and form hints, and adds tests covering direct MP4 playback and unsupported URL cases.

## Description

https://github.com/user-attachments/assets/9d9867b0-913f-4996-8a7e-ee2bdcf76c3d