### PR TITLE
fix: prevent reviewer profile identity collisions

### DIFF
--- a/PluginBuilder.Tests/PlaywrightTester.cs
+++ b/PluginBuilder.Tests/PlaywrightTester.cs
@@ -220,12 +220,12 @@ public class PlaywrightTester : IAsyncDisposable
         await Page.ClickAsync("#LoginButton");
     }
 
-    public async Task VerifyUserAccounts(string email, string npub = "nostrNpub")
+    public async Task VerifyUserAccounts(string email, string npub = "nostrNpub", string? githubHandle = null)
     {
         await using var scope = Server.WebApp.Services.CreateAsyncScope();
         var factory = scope.ServiceProvider.GetRequiredService<DBConnectionFactory>();
         await using var conn = await factory.Open();
-        var githubHandle = $"test-eligibility-{email.Replace("@", "_").Replace(".", "_")}";
+        githubHandle ??= $"test-eligibility-{email.Replace("@", "_").Replace(".", "_")}";
 
         var settings = new AccountSettings { Nostr = new NostrSettings { Npub = npub, Proof = "nostrProof" }, Github = githubHandle };
         await conn.ExecuteAsync(

--- a/PluginBuilder.Tests/PluginTests/PluginReviewerTests.cs
+++ b/PluginBuilder.Tests/PluginTests/PluginReviewerTests.cs
@@ -1,0 +1,45 @@
+using Dapper;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using PluginBuilder.ViewModels.Admin;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests.PluginTests;
+
+public class PluginReviewerTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    [Fact]
+    public async Task UnlinkedReviewerCanStillBeClaimedByProfileUrl()
+    {
+        await using var tester = Create();
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+
+        const string externalProfileUrl = "https://github.com/external-reviewer";
+        var externalReviewerId = await conn.CreateOrUpdatePluginReviewer(new ImportReviewViewModel
+        {
+            ReviewerName = "external-reviewer",
+            ReviewerProfileUrl = externalProfileUrl,
+            Source = ImportReviewViewModel.ImportReviewSourceEnum.Github
+        });
+
+        const string claimUserId = "claim-user";
+        var claimedReviewerId = await conn.CreateOrUpdatePluginReviewer(new ImportReviewViewModel
+        {
+            LinkExistingUser = true,
+            SelectedUserId = claimUserId,
+            ReviewerName = "external-reviewer",
+            ReviewerProfileUrl = externalProfileUrl
+        });
+
+        Assert.Equal(externalReviewerId, claimedReviewerId);
+        Assert.Equal(claimUserId, await conn.QuerySingleAsync<string>(
+            "SELECT user_id FROM plugin_reviewers WHERE id = @ReviewerId",
+            new { ReviewerId = externalReviewerId }));
+        Assert.Equal(1, await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM plugin_reviewers WHERE profile_url = @ProfileUrl",
+            new { ProfileUrl = externalProfileUrl }));
+    }
+}

--- a/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
+++ b/PluginBuilder.Tests/PublicTests/PluginDetailsUITests.cs
@@ -250,8 +250,9 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         await tester.Server.CreateFakeUserAsync("voter@x.com", confirmEmail: true, githubVerified: true);
 
 
-        await tester.VerifyUserAccounts("reviewer@x.com", "reviewernpub1");
-        await tester.VerifyUserAccounts("voter@x.com", "voternpub1");
+        const string reusedGithubHandle = "reused-handle";
+        await tester.VerifyUserAccounts("reviewer@x.com", "reviewernpub1", reusedGithubHandle);
+        await tester.VerifyUserAccounts("voter@x.com", "voternpub1", reusedGithubHandle);
 
         const string url = $"/public/plugins/{slug}";
 
@@ -343,6 +344,7 @@ public class PluginDetailsUITests(ITestOutputHelper output) : PageTest
         await tester.Page.FillAsync("textarea[name='Body']", "scam");
         await tester.Page.Locator("#review-form").GetByRole(AriaRole.Button, new LocatorGetByRoleOptions { Name = "Submit" }).ClickAsync();
         await tester.Page.WaitForURLAsync(new Regex("public/plugins/.+?#reviews"));
+        await Expect(tester.Page.Locator(".test-review-card")).ToHaveCountAsync(2);
 
         //check if filter works
         await tester.Page.ClickAsync("a[href*='RatingFilter=4'][href*='#reviews']");

--- a/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
+++ b/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
@@ -685,6 +685,8 @@ public static class NpgsqlConnectionExtensions
         // 2. When that person registers as a system user, admin can link them (matched by profile_url)
         // 3. The user_id gets populated, claiming ownership of their previously imported reviews
         // This allows users to "claim" their external reviews when they join the platform.
+        // A profile URL must never match a reviewer already linked to another system user.
+        // The outer user_id predicate rechecks that invariant after waiting for a concurrent update lock.
         const string updateSql = """
                                  UPDATE plugin_reviewers p
                                  SET
@@ -699,7 +701,7 @@ public static class NpgsqlConnectionExtensions
                                      FROM plugin_reviewers
                                      WHERE
                                          (@user_id IS NOT NULL AND user_id = @user_id)
-                                         OR (@profile_url IS NOT NULL AND profile_url = @profile_url)
+                                         OR (@profile_url IS NOT NULL AND profile_url = @profile_url AND user_id IS NULL)
                                      ORDER BY
                                          CASE
                                              WHEN @user_id IS NOT NULL AND user_id = @user_id THEN 0
@@ -708,6 +710,10 @@ public static class NpgsqlConnectionExtensions
                                          END
                                      LIMIT 1
                                  )
+                                   AND (
+                                       p.user_id IS NULL
+                                       OR (@user_id IS NOT NULL AND p.user_id = @user_id)
+                                   )
                                  RETURNING id;
                                  """;
 


### PR DESCRIPTION
Prevents users sharing the same GitHub profile URL from reusing the same reviewer identity and overwriting each other’s reviews.

Profile URL matching now only claims unlinked reviewers, while preserving imported-review claiming.