### PR TITLE
feat(settings): add registration and new build feature flags

### DIFF
--- a/PluginBuilder.Tests/BuildMetadataReadSecurityTests.cs
+++ b/PluginBuilder.Tests/BuildMetadataReadSecurityTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.Logging.Abstractions;
+using PluginBuilder.Controllers.Logic;
 using PluginBuilder.Services;
 using Xunit;
 
@@ -148,7 +149,8 @@ public class BuildMetadataReadSecurityTests
                 null!,
                 null!,
                 null!,
-                null!);
+                null!,
+                new AdminSettingsCache());
 
             var method = typeof(BuildService).GetMethod(
                 "ReadFileInVolume",

--- a/PluginBuilder.Tests/FeatureFlagTests.cs
+++ b/PluginBuilder.Tests/FeatureFlagTests.cs
@@ -1,0 +1,859 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Dapper;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using PluginBuilder.APIModels;
+using PluginBuilder.Controllers.Logic;
+using PluginBuilder.DataModels;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class FeatureFlagTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    [Fact]
+    public async Task FeatureFlags_AreSeededEnabledButFailClosedWhenMissingOrInvalid()
+    {
+        await using var tester = Create("FeatureFlagsDefaults");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        Assert.Equal("true", await conn.SettingsGetAsync(SettingsKeys.RegistrationEnabled));
+        Assert.Equal("true", await conn.SettingsGetAsync(SettingsKeys.NewBuildsEnabled));
+
+        var settings = tester.GetService<AdminSettingsCache>();
+        Assert.True(settings.RegistrationEnabled);
+        Assert.True(settings.NewBuildsEnabled);
+
+        await conn.SettingsDeleteAsync(SettingsKeys.RegistrationEnabled);
+        await conn.SettingsDeleteAsync(SettingsKeys.NewBuildsEnabled);
+        await conn.SettingsInitialize();
+        await settings.RefreshFeatureSettings(conn);
+
+        Assert.Null(await conn.SettingsGetAsync(SettingsKeys.RegistrationEnabled));
+        Assert.Null(await conn.SettingsGetAsync(SettingsKeys.NewBuildsEnabled));
+        Assert.False(settings.RegistrationEnabled);
+        Assert.False(settings.NewBuildsEnabled);
+
+        await conn.SettingsSetAsync(SettingsKeys.RegistrationEnabled, "not-a-boolean");
+        await conn.SettingsSetAsync(SettingsKeys.NewBuildsEnabled, "not-a-boolean");
+        await settings.RefreshFeatureSettings(conn);
+
+        Assert.Equal("not-a-boolean", await conn.SettingsGetAsync(SettingsKeys.RegistrationEnabled));
+        Assert.Equal("not-a-boolean", await conn.SettingsGetAsync(SettingsKeys.NewBuildsEnabled));
+        Assert.False(settings.RegistrationEnabled);
+        Assert.False(settings.NewBuildsEnabled);
+    }
+
+    [Fact]
+    public async Task RegistrationDisabled_BlocksGetAndPostBeforeCreatingUser()
+    {
+        await using var tester = Create("RegistrationFlag");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        using var client = CreateBrowserClient(tester);
+
+        // Fetch a valid antiforgery token while registration is still enabled. This
+        // ensures the POST reaches the action and is rejected by the feature flag.
+        using var registrationPage = await client.GetAsync("/register");
+        registrationPage.EnsureSuccessStatusCode();
+        var antiforgeryToken = ExtractAntiforgeryToken(await registrationPage.Content.ReadAsStringAsync());
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await DisableFeature(tester, conn, SettingsKeys.RegistrationEnabled);
+
+        using var getResponse = await client.GetAsync("/register");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, getResponse.StatusCode);
+
+        using var loginResponse = await client.GetAsync("/login");
+        loginResponse.EnsureSuccessStatusCode();
+        Assert.DoesNotContain("id=\"Register\"", await loginResponse.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+
+        var email = $"registration-disabled-{Guid.NewGuid():N}@example.com";
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Email"] = email,
+            ["Password"] = "123456",
+            ["ConfirmPassword"] = "123456",
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+        using var postResponse = await client.PostAsync("/register", form);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, postResponse.StatusCode);
+
+        Assert.False(await conn.ExecuteScalarAsync<bool>(
+            "SELECT EXISTS(SELECT 1 FROM \"AspNetUsers\" WHERE \"Email\" = @email)",
+            new { email }));
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_BlocksApiBeforeValidationOrBuildCreation()
+    {
+        const string password = "123456";
+
+        await using var tester = Create("BuildsApiFlag");
+        tester.ReuseDatabase = false;
+        var gitProvider = new BlockingGitHostingProvider();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(gitProvider);
+        await tester.Start();
+
+        var email = $"build-disabled-{Guid.NewGuid():N}@example.com";
+        var ownerId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = "build-disabled-" + Guid.NewGuid().ToString("N")[..8];
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(pluginSlug, ownerId);
+        await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+        gitProvider.Release("FeatureFlags.Api");
+
+        using var client = tester.CreateHttpClient().SetBasicAuth(email, password);
+        using var content = CreateBuildJson(gitProvider.RepositoryUrl);
+        using var response = await client.PostAsync($"/api/v1/plugins/{pluginSlug}/builds", content);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(0, gitProvider.FetchCount);
+        var result = JObject.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("builds-disabled", result.Value<string>("error"));
+        Assert.False(await HasBuildRows(conn, pluginSlug));
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_BlocksUiGetAndPostAndHidesCreateActions()
+    {
+        const string password = "123456";
+
+        await using var tester = Create("BuildsUiFlag");
+        tester.ReuseDatabase = false;
+        var gitProvider = new BlockingGitHostingProvider();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(gitProvider);
+        await tester.Start();
+
+        var email = $"build-ui-disabled-{Guid.NewGuid():N}@example.com";
+        var ownerId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = new PluginSlug("build-ui-disabled-" + Guid.NewGuid().ToString("N")[..8]);
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(pluginSlug, ownerId);
+
+        using var client = CreateBrowserClient(tester);
+        await LogIn(client, email, password);
+
+        var createUrl = $"/plugins/{pluginSlug}/create";
+        using var createPage = await client.GetAsync(createUrl);
+        createPage.EnsureSuccessStatusCode();
+        var antiforgeryToken = ExtractAntiforgeryToken(await createPage.Content.ReadAsStringAsync());
+
+        await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+        gitProvider.Release("FeatureFlags.Ui");
+
+        using var getResponse = await client.GetAsync(createUrl);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, getResponse.StatusCode);
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["GitRepository"] = gitProvider.RepositoryUrl,
+            ["GitRef"] = "main",
+            ["BuildConfig"] = ServerTester.BuildCfg,
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+        using var postResponse = await client.PostAsync(createUrl, form);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, postResponse.StatusCode);
+        Assert.Equal(0, gitProvider.FetchCount);
+        Assert.False(await HasBuildRows(conn, pluginSlug));
+
+        var existingBuildId = await conn.NewBuild(
+            pluginSlug,
+            new PluginBuildParameters("https://example.invalid/existing.git"));
+        await conn.UpdateBuild(
+            new FullBuildId(pluginSlug, existingBuildId),
+            BuildStates.Failed,
+            new JObject { ["error"] = "Existing failed build" });
+
+        using var dashboardResponse = await client.GetAsync($"/plugins/{pluginSlug}");
+        dashboardResponse.EnsureSuccessStatusCode();
+        var dashboard = await dashboardResponse.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("id=\"CreateNewBuild\"", dashboard, StringComparison.Ordinal);
+        Assert.DoesNotContain(">Retry</a>", dashboard, StringComparison.Ordinal);
+
+        using var buildResponse = await client.GetAsync($"/plugins/{pluginSlug}/builds/{existingBuildId}");
+        buildResponse.EnsureSuccessStatusCode();
+        Assert.DoesNotContain(">Retry</a>", await buildResponse.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_DuringApiRepositoryLookup_DoesNotCreateBuild()
+    {
+        const string password = "123456";
+        await using var tester = Create("BuildApiRace");
+        tester.ReuseDatabase = false;
+        var gitProvider = new BlockingGitHostingProvider();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(gitProvider);
+        await tester.Start();
+
+        var email = $"build-api-race-{Guid.NewGuid():N}@example.com";
+        var ownerId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = new PluginSlug("api-race-" + Guid.NewGuid().ToString("N")[..8]);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(pluginSlug, ownerId);
+
+        using var client = tester.CreateHttpClient().SetBasicAuth(email, password);
+        using var content = CreateBuildJson(gitProvider.RepositoryUrl);
+        var request = client.PostAsync($"/api/v1/plugins/{pluginSlug}/builds", content);
+        await AssertBuildRejectedWhenDisabledDuringRepositoryLookup(
+            tester, conn, pluginSlug, gitProvider, request);
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_DuringUiRepositoryLookup_DoesNotCreateBuild()
+    {
+        const string password = "123456";
+        await using var tester = Create("BuildUiRace");
+        tester.ReuseDatabase = false;
+        var gitProvider = new BlockingGitHostingProvider();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(gitProvider);
+        await tester.Start();
+
+        var email = $"build-ui-race-{Guid.NewGuid():N}@example.com";
+        var ownerId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = new PluginSlug("ui-race-" + Guid.NewGuid().ToString("N")[..8]);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(pluginSlug, ownerId);
+
+        using var client = CreateBrowserClient(tester);
+        await LogIn(client, email, password);
+
+        var createUrl = $"/plugins/{pluginSlug}/create";
+        using var createPage = await client.GetAsync(createUrl);
+        createPage.EnsureSuccessStatusCode();
+        var antiforgeryToken = ExtractAntiforgeryToken(await createPage.Content.ReadAsStringAsync());
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["GitRepository"] = gitProvider.RepositoryUrl,
+            ["GitRef"] = "main",
+            ["BuildConfig"] = ServerTester.BuildCfg,
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+
+        var request = client.PostAsync(createUrl, form);
+        await AssertBuildRejectedWhenDisabledDuringRepositoryLookup(
+            tester, conn, pluginSlug, gitProvider, request);
+    }
+
+    [Fact]
+    public async Task FeatureFlags_AppearInSettingsEditorAndUpdatesTakeEffectImmediately()
+    {
+        const string password = "123456";
+        await using var tester = Create("FlagSettingsEditor");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var email = $"feature-admin-{Guid.NewGuid():N}@example.com";
+        var adminId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = new PluginSlug("flag-editor-" + Guid.NewGuid().ToString("N")[..8]);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.ExecuteAsync(
+            """
+            INSERT INTO "AspNetUserRoles" ("UserId", "RoleId")
+            SELECT @userId, "Id" FROM "AspNetRoles" WHERE "NormalizedName" = 'SERVERADMIN'
+            """,
+            new { userId = adminId });
+        await conn.NewPlugin(pluginSlug, adminId);
+
+        using var client = CreateBrowserClient(tester);
+        await LogIn(client, email, password);
+
+        using var editorResponse = await client.GetAsync("/admin/SettingsEditor");
+        editorResponse.EnsureSuccessStatusCode();
+        var editor = await editorResponse.Content.ReadAsStringAsync();
+        Assert.Contains($"data-key=\"{SettingsKeys.RegistrationEnabled}\"", editor, StringComparison.Ordinal);
+        Assert.Contains($"data-key=\"{SettingsKeys.NewBuildsEnabled}\"", editor, StringComparison.Ordinal);
+        var antiforgeryToken = ExtractAntiforgeryToken(editor);
+
+        using (var registrationForm = SettingsEditorForm(SettingsKeys.RegistrationEnabled, "false", antiforgeryToken))
+        using (var registrationResponse = await client.PostAsync("/admin/SettingsEditor", registrationForm))
+        {
+            Assert.Equal(HttpStatusCode.Redirect, registrationResponse.StatusCode);
+        }
+
+        var settings = tester.GetService<AdminSettingsCache>();
+        Assert.Equal("false", await conn.SettingsGetAsync(SettingsKeys.RegistrationEnabled));
+        Assert.False(settings.RegistrationEnabled);
+        using (var registrationResponse = await client.GetAsync("/register"))
+        {
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, registrationResponse.StatusCode);
+        }
+
+        using (var buildsForm = SettingsEditorForm(SettingsKeys.NewBuildsEnabled, "false", antiforgeryToken))
+        using (var buildsResponse = await client.PostAsync("/admin/SettingsEditor", buildsForm))
+        {
+            Assert.Equal(HttpStatusCode.Redirect, buildsResponse.StatusCode);
+        }
+
+        Assert.Equal("false", await conn.SettingsGetAsync(SettingsKeys.NewBuildsEnabled));
+        Assert.False(settings.NewBuildsEnabled);
+        using var createResponse = await client.GetAsync($"/plugins/{pluginSlug}/create");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, createResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_KeepsExistingBuildOperationsAvailable()
+    {
+        const string password = "123456";
+        await using var tester = Create("ExistingBuildOps");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+
+        var email = $"existing-build-{Guid.NewGuid():N}@example.com";
+        var ownerId = await tester.CreateFakeUserAsync(email, password);
+        var pluginSlug = new PluginSlug("existing-" + Guid.NewGuid().ToString("N")[..8]);
+        var version = PluginVersion.Parse("1.0.0");
+        var artifactUrl = "https://example.invalid/plugin.zip";
+        var manifest = PluginManifest.Parse($$"""
+            {
+              "Identifier": "FeatureFlags.{{pluginSlug}}",
+              "Name": "Existing build",
+              "Version": "{{version}}",
+              "Description": "Feature flag coverage",
+              "Dependencies": []
+            }
+            """);
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(pluginSlug, ownerId);
+        var buildId = await conn.NewBuild(pluginSlug, new PluginBuildParameters("https://example.invalid/repository.git"));
+        var fullBuildId = new FullBuildId(pluginSlug, buildId);
+        await conn.UpdateBuild(fullBuildId, BuildStates.Uploaded, new JObject
+        {
+            ["url"] = artifactUrl,
+            ["gitCommit"] = "0123456789abcdef"
+        }, manifest);
+        Assert.True(await conn.SetVersionBuild(fullBuildId, version, null, null, true));
+
+        using var browser = CreateBrowserClient(tester);
+        await LogIn(browser, email, password);
+        using var api = tester.CreateHttpClient().SetBasicAuth(email, password);
+        await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+
+        string uiAntiforgeryToken;
+        using (var uiDetails = await browser.GetAsync($"/plugins/{pluginSlug}/builds/{buildId}"))
+        {
+            Assert.Equal(HttpStatusCode.OK, uiDetails.StatusCode);
+            var html = await uiDetails.Content.ReadAsStringAsync();
+            Assert.DoesNotContain(">Retry</a>", html, StringComparison.Ordinal);
+            Assert.Contains($"href=\"{artifactUrl}\"", html, StringComparison.Ordinal);
+            Assert.Contains(">Release</button>", html, StringComparison.Ordinal);
+            uiAntiforgeryToken = ExtractAntiforgeryToken(html);
+        }
+
+        using (var apiDetails = await api.GetAsync($"/api/v1/plugins/{pluginSlug}/builds/{buildId}"))
+        {
+            Assert.Equal(HttpStatusCode.OK, apiDetails.StatusCode);
+        }
+
+        using (var download = await browser.GetAsync($"/api/v1/plugins/{pluginSlug}/versions/{version}/download"))
+        {
+            Assert.Equal(HttpStatusCode.Redirect, download.StatusCode);
+            Assert.Equal(artifactUrl, download.Headers.Location?.AbsoluteUri);
+        }
+
+        using (var releaseForm = VersionCommandForm("release", uiAntiforgeryToken))
+        using (var release = await browser.PostAsync($"/plugins/{pluginSlug}/versions/{version}/release", releaseForm))
+        {
+            Assert.Equal(HttpStatusCode.Redirect, release.StatusCode);
+        }
+        Assert.False(await IsPreRelease(conn, pluginSlug, version));
+
+        using (var unreleaseForm = VersionCommandForm("unrelease", uiAntiforgeryToken))
+        using (var unrelease = await browser.PostAsync($"/plugins/{pluginSlug}/versions/{version}/release", unreleaseForm))
+        {
+            Assert.Equal(HttpStatusCode.Redirect, unrelease.StatusCode);
+        }
+        Assert.True(await IsPreRelease(conn, pluginSlug, version));
+
+        using (var releaseBody = new StringContent("{}", Encoding.UTF8, "application/json"))
+        using (var release = await api.PostAsync($"/api/v1/plugins/{pluginSlug}/versions/{version}/release", releaseBody))
+        {
+            Assert.Equal(HttpStatusCode.OK, release.StatusCode);
+        }
+        Assert.False(await IsPreRelease(conn, pluginSlug, version));
+
+        using (var unrelease = await api.PostAsync($"/api/v1/plugins/{pluginSlug}/versions/{version}/unrelease", null))
+        {
+            Assert.Equal(HttpStatusCode.OK, unrelease.StatusCode);
+        }
+        Assert.True(await IsPreRelease(conn, pluginSlug, version));
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_StopsAlreadyQueuedBuildBeforeDockerWork()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"plugin-builder-queued-flag-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var dockerPath = Path.Combine(tempDirectory, "docker");
+        await File.WriteAllTextAsync(dockerPath, """
+            #!/bin/sh
+            set -eu
+            state="${PB_FAKE_DOCKER_STATE:?}"
+            printf '%s\n' "$*" >> "$state/commands"
+
+            case "$1:$2" in
+                volume:create)
+                    for argument in "$@"; do volume="$argument"; done
+                    while [ ! -f "$state/release-blockers" ]; do sleep 0.01; done
+                    printf '%s\n' "$volume"
+                    ;;
+                container:create)
+                    exit 41
+                    ;;
+                container:rm|volume:rm)
+                    ;;
+                *)
+                    exit 2
+                    ;;
+            esac
+            """);
+        File.SetUnixFileMode(
+            dockerPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalSkipBuild = Environment.GetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD");
+        var originalFakeState = Environment.GetEnvironmentVariable("PB_FAKE_DOCKER_STATE");
+        try
+        {
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", "true");
+            await using var tester = Create("BuildsQueuedFlag");
+            tester.ReuseDatabase = false;
+            await tester.Start();
+
+            Environment.SetEnvironmentVariable("PATH", tempDirectory + Path.PathSeparator + originalPath);
+            Environment.SetEnvironmentVariable("PB_FAKE_DOCKER_STATE", tempDirectory);
+
+            var ownerId = await tester.CreateFakeUserAsync();
+            var pluginSlug = new PluginSlug("queued-disabled-" + Guid.NewGuid().ToString("N")[..8]);
+            await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+            await conn.NewPlugin(pluginSlug, ownerId);
+            List<FullBuildId> fullBuildIds = [];
+            for (var i = 0; i < 6; i++)
+            {
+                var buildId = await conn.NewBuild(pluginSlug, new PluginBuildParameters("https://example.invalid/repository"));
+                fullBuildIds.Add(new FullBuildId(pluginSlug, buildId));
+            }
+
+            var queuedBuild = fullBuildIds[^1];
+            var buildService = tester.GetService<BuildService>();
+            Task[] blockerTasks = [];
+            Task? queuedTask = null;
+            var releaseBlockersPath = Path.Combine(tempDirectory, "release-blockers");
+            try
+            {
+                blockerTasks = fullBuildIds.Take(5).Select(buildService.Build).ToArray();
+                var commandsPath = Path.Combine(tempDirectory, "commands");
+                await WaitForCommandCount(commandsPath, "volume create ", 5);
+
+                queuedTask = buildService.Build(queuedBuild);
+                Assert.False(queuedTask.IsCompleted);
+
+                await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+                await File.WriteAllTextAsync(releaseBlockersPath, string.Empty);
+                await queuedTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+                var build = await conn.QuerySingleAsync<(string state, string error)>(
+                    "SELECT state, build_info->>'error' AS error FROM builds WHERE plugin_slug = @pluginSlug AND id = @buildId",
+                    new { pluginSlug = pluginSlug.ToString(), buildId = queuedBuild.BuildId });
+                Assert.Equal(BuildStates.Failed.ToEventName(), build.state);
+                Assert.Equal("Plugin builds are temporarily disabled.", build.error);
+
+                var commands = await File.ReadAllLinesAsync(commandsPath);
+                Assert.DoesNotContain(
+                    commands,
+                    command => command.Contains(queuedBuild.ToString(), StringComparison.Ordinal));
+            }
+            finally
+            {
+                await File.WriteAllTextAsync(releaseBlockersPath, string.Empty);
+                if (queuedTask is { IsCompleted: false })
+                {
+                    await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+                    try
+                    {
+                        await queuedTask.WaitAsync(TimeSpan.FromSeconds(10));
+                    }
+                    catch
+                    {
+                        // Preserve the original test failure while releasing the queued build.
+                    }
+                }
+
+                foreach (var blockerTask in blockerTasks)
+                {
+                    try
+                    {
+                        await blockerTask.WaitAsync(TimeSpan.FromSeconds(10));
+                    }
+                    catch
+                    {
+                        // The blockers intentionally fail container creation after releasing the queue.
+                    }
+                }
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", originalSkipBuild);
+            Environment.SetEnvironmentVariable("PB_FAKE_DOCKER_STATE", originalFakeState);
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NewBuildsDisabled_DuringContainerCreation_DoesNotStartContainer()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"plugin-builder-feature-flag-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var dockerPath = Path.Combine(tempDirectory, "docker");
+        await File.WriteAllTextAsync(dockerPath, """
+            #!/bin/sh
+            set -eu
+            state="${PB_FAKE_DOCKER_STATE:?}"
+            printf '%s\n' "$*" >> "$state/commands"
+
+            case "$1:$2" in
+                volume:create)
+                    for argument in "$@"; do volume="$argument"; done
+                    printf '%s' "$volume" > "$state/volume"
+                    printf '%s\n' "$volume"
+                    ;;
+                container:create)
+                    previous=""
+                    name=""
+                    for argument in "$@"; do
+                        if [ "$previous" = "--name" ]; then name="$argument"; break; fi
+                        previous="$argument"
+                    done
+                    [ -n "$name" ]
+                    printf '%s' "$name" > "$state/container"
+                    : > "$state/create-entered"
+                    while [ ! -f "$state/release-create" ]; do sleep 0.01; done
+                    printf '%s\n' fake-container-id
+                    ;;
+                container:start|container:run|start:*|run:*)
+                    exit 99
+                    ;;
+                container:rm)
+                    [ -f "$state/container" ]
+                    for argument in "$@"; do target="$argument"; done
+                    [ "$target" = "$(cat "$state/container")" ]
+                    rm -f "$state/container"
+                    ;;
+                volume:rm)
+                    [ -f "$state/volume" ]
+                    for argument in "$@"; do target="$argument"; done
+                    [ "$target" = "$(cat "$state/volume")" ]
+                    rm -f "$state/volume"
+                    ;;
+                *)
+                    ;;
+            esac
+            """);
+        File.SetUnixFileMode(
+            dockerPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var releaseCreatePath = Path.Combine(tempDirectory, "release-create");
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var originalSkipBuild = Environment.GetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD");
+        var originalFakeState = Environment.GetEnvironmentVariable("PB_FAKE_DOCKER_STATE");
+        try
+        {
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", "true");
+
+            await using var tester = Create("BuildFlagDuringCreate");
+            tester.ReuseDatabase = false;
+            await tester.Start();
+
+            Environment.SetEnvironmentVariable("PATH", tempDirectory + Path.PathSeparator + originalPath);
+            Environment.SetEnvironmentVariable("PB_FAKE_DOCKER_STATE", tempDirectory);
+
+            Task? buildTask = null;
+            try
+            {
+                var ownerId = await tester.CreateFakeUserAsync();
+                var pluginSlug = new PluginSlug("mid-create-" + Guid.NewGuid().ToString("N")[..8]);
+                await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+                await conn.NewPlugin(pluginSlug, ownerId);
+                var buildId = await conn.NewBuild(
+                    pluginSlug,
+                    new PluginBuildParameters("https://example.invalid/repository"));
+                var fullBuildId = new FullBuildId(pluginSlug, buildId);
+
+                buildTask = tester.GetService<BuildService>().Build(fullBuildId);
+                await WaitForFile(Path.Combine(tempDirectory, "create-entered"));
+                await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+                await File.WriteAllTextAsync(releaseCreatePath, string.Empty);
+                await buildTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+                var build = await conn.QuerySingleAsync<(string state, string error)>(
+                    "SELECT state, build_info->>'error' AS error FROM builds WHERE plugin_slug = @pluginSlug AND id = @buildId",
+                    new { pluginSlug = pluginSlug.ToString(), buildId });
+                Assert.Equal(BuildStates.Failed.ToEventName(), build.state);
+                Assert.Equal("Plugin builds are temporarily disabled.", build.error);
+                Assert.False(File.Exists(Path.Combine(tempDirectory, "container")));
+                Assert.False(File.Exists(Path.Combine(tempDirectory, "volume")));
+
+                var commands = await File.ReadAllLinesAsync(Path.Combine(tempDirectory, "commands"));
+                Assert.Contains(commands, command => command.StartsWith("volume create ", StringComparison.Ordinal));
+                Assert.Contains(commands, command => command.StartsWith("container create ", StringComparison.Ordinal));
+                Assert.Contains(commands, command => command.StartsWith("container rm ", StringComparison.Ordinal));
+                Assert.Contains(commands, command => command.StartsWith("volume rm ", StringComparison.Ordinal));
+                Assert.DoesNotContain(commands, IsContainerExecutionCommand);
+            }
+            finally
+            {
+                await File.WriteAllTextAsync(releaseCreatePath, string.Empty);
+                if (buildTask is not null)
+                    try
+                    {
+                        await buildTask.WaitAsync(TimeSpan.FromSeconds(10));
+                    }
+                    catch
+                    {
+                        // Preserve the original test failure while ensuring the fake process is released.
+                    }
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", originalSkipBuild);
+            Environment.SetEnvironmentVariable("PB_FAKE_DOCKER_STATE", originalFakeState);
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    private static StringContent CreateBuildJson(string repositoryUrl)
+    {
+        return new StringContent(
+            new JObject
+            {
+                ["gitRepository"] = repositoryUrl,
+                ["gitRef"] = "main",
+                ["buildConfig"] = ServerTester.BuildCfg
+            }.ToString(),
+            Encoding.UTF8,
+            "application/json");
+    }
+
+    private static FormUrlEncodedContent SettingsEditorForm(string key, string value, string antiforgeryToken)
+    {
+        return new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["key"] = key,
+            ["value"] = value,
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+    }
+
+    private static FormUrlEncodedContent VersionCommandForm(string command, string antiforgeryToken)
+    {
+        return new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["command"] = command,
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+    }
+
+    private static HttpClient CreateBrowserClient(ServerTester tester)
+    {
+        return new HttpClient(new HttpClientHandler
+        {
+            AllowAutoRedirect = false,
+            CookieContainer = new CookieContainer()
+        })
+        {
+            BaseAddress = new Uri(tester.WebApp.Urls.First(), UriKind.Absolute)
+        };
+    }
+
+    private static async Task<bool> HasBuildRows(Npgsql.NpgsqlConnection conn, PluginSlug pluginSlug)
+    {
+        return await conn.ExecuteScalarAsync<bool>(
+            """
+            SELECT EXISTS(SELECT 1 FROM builds WHERE plugin_slug = @pluginSlug)
+                OR EXISTS(SELECT 1 FROM builds_ids WHERE plugin_slug = @pluginSlug)
+            """,
+            new { pluginSlug = pluginSlug.ToString() });
+    }
+
+    private static async Task AssertBuildRejectedWhenDisabledDuringRepositoryLookup(
+        ServerTester tester,
+        Npgsql.NpgsqlConnection conn,
+        PluginSlug pluginSlug,
+        BlockingGitHostingProvider gitProvider,
+        Task<HttpResponseMessage> request)
+    {
+        const string identifier = "FeatureFlags.RepositoryRace";
+        try
+        {
+            await gitProvider.Entered.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(1, gitProvider.FetchCount);
+            await DisableFeature(tester, conn, SettingsKeys.NewBuildsEnabled);
+            gitProvider.Release(identifier);
+
+            using var response = await request.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.False(await HasBuildRows(conn, pluginSlug));
+        }
+        finally
+        {
+            gitProvider.Release(identifier);
+            if (!request.IsCompleted)
+                try
+                {
+                    using var response = await request.WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                catch
+                {
+                    // Preserve the original failure while releasing the blocked request.
+                }
+        }
+    }
+
+    private static async Task<bool> IsPreRelease(
+        Npgsql.NpgsqlConnection conn,
+        PluginSlug pluginSlug,
+        PluginVersion version)
+    {
+        return await conn.ExecuteScalarAsync<bool>(
+            "SELECT pre_release FROM versions WHERE plugin_slug = @pluginSlug AND ver = @version",
+            new { pluginSlug = pluginSlug.ToString(), version = version.VersionParts });
+    }
+
+    private static async Task DisableFeature(ServerTester tester, Npgsql.NpgsqlConnection conn, string key)
+    {
+        await conn.SettingsSetAsync(key, "false");
+        await tester.GetService<AdminSettingsCache>().RefreshFeatureSettings(conn);
+    }
+
+    private static async Task LogIn(HttpClient client, string email, string password)
+    {
+        using var loginPage = await client.GetAsync("/login");
+        loginPage.EnsureSuccessStatusCode();
+        var antiforgeryToken = ExtractAntiforgeryToken(await loginPage.Content.ReadAsStringAsync());
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Email"] = email,
+            ["Password"] = password,
+            ["__RequestVerificationToken"] = antiforgeryToken
+        });
+        using var response = await client.PostAsync("/login", form);
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+    }
+
+    private static async Task WaitForFile(string path)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!File.Exists(path))
+            await Task.Delay(10, timeout.Token);
+    }
+
+    private static async Task WaitForCommandCount(string path, string prefix, int expectedCount)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (true)
+        {
+            if (File.Exists(path))
+            {
+                var commands = await File.ReadAllLinesAsync(path, timeout.Token);
+                if (commands.Count(command => command.StartsWith(prefix, StringComparison.Ordinal)) >= expectedCount)
+                    return;
+            }
+
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    private static bool IsContainerExecutionCommand(string command)
+    {
+        return command.StartsWith("container start ", StringComparison.Ordinal) ||
+               command.StartsWith("container run ", StringComparison.Ordinal) ||
+               command.StartsWith("start ", StringComparison.Ordinal) ||
+               command.StartsWith("run ", StringComparison.Ordinal);
+    }
+
+    private static string ExtractAntiforgeryToken(string html)
+    {
+        var input = Regex.Match(
+            html,
+            "<input\\b(?=[^>]*\\bname=\"__RequestVerificationToken\")[^>]*>",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Assert.True(input.Success, "HTML did not contain an antiforgery token input.");
+
+        var value = Regex.Match(
+            input.Value,
+            "\\bvalue=\"([^\"]+)\"",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Assert.True(value.Success, "Antiforgery token input did not contain a value.");
+        return WebUtility.HtmlDecode(value.Groups[1].Value);
+    }
+
+    private sealed class BlockingGitHostingProvider : IGitHostingProvider
+    {
+        private readonly TaskCompletionSource<bool> _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<string> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _fetchCount;
+
+        public string RepositoryUrl { get; } = $"https://feature-flags-{Guid.NewGuid():N}.invalid/repository.git";
+        public int FetchCount => Volatile.Read(ref _fetchCount);
+        public Task Entered => _entered.Task;
+
+        public bool CanHandle(string repoUrl)
+        {
+            return string.Equals(repoUrl, RepositoryUrl, StringComparison.Ordinal);
+        }
+
+        public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+        {
+            Interlocked.Increment(ref _fetchCount);
+            _entered.TrySetResult(true);
+            return await _release.Task;
+        }
+
+        public void Release(string identifier)
+        {
+            _release.TrySetResult(identifier);
+        }
+
+        public Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir)
+        {
+            return Task.FromResult(new List<GitHubContributor>());
+        }
+
+        public string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir)
+        {
+            return null;
+        }
+
+        public (string Owner, string RepoName)? ParseRepository(string repoUrl)
+        {
+            return null;
+        }
+    }
+}

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -28,7 +28,8 @@ public class ApiController(
     UserManager<IdentityUser> userManager,
     UserVerifiedLogic userVerifiedLogic,
     IHttpClientFactory httpClientFactory,
-    ServerEnvironment serverEnvironment)
+    ServerEnvironment serverEnvironment,
+    AdminSettingsCache adminSettingsCache)
     : ControllerBase
 {
     private sealed class BuildRow
@@ -361,6 +362,9 @@ public class ApiController(
         PluginSlug pluginSlug,
         CreateBuildRequest model)
     {
+        if (!adminSettingsCache.NewBuildsEnabled)
+            return BuildsUnavailable();
+
         await using var conn = await connectionFactory.Open();
 
         if (!await userVerifiedLogic.IsUserEmailVerifiedForPublish(User) || !await userVerifiedLogic.IsUserGithubVerified(User, conn))
@@ -403,6 +407,9 @@ public class ApiController(
             return ValidationErrorResult(ModelState);
         }
 
+        if (!adminSettingsCache.NewBuildsEnabled)
+            return BuildsUnavailable();
+
         var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
         var buildUrl = Url.ActionLink(nameof(PluginController.Build), "Plugin",
             new { pluginSlug = pluginSlug.ToString(), buildId });
@@ -414,6 +421,15 @@ public class ApiController(
             ["pluginSlug"] = pluginSlug.ToString(),
             ["buildId"] = buildId,
             ["buildUrl"] = buildUrl
+        });
+    }
+
+    private IActionResult BuildsUnavailable()
+    {
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+        {
+            error = "builds-disabled",
+            message = "Plugin builds are temporarily disabled."
         });
     }
 

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -34,7 +34,8 @@ public class HomeController(
     NostrService nostrService,
     GitHostingProviderFactory gitHostingProviderFactory,
     ILogger<HomeController> logger,
-    HealthCheckService healthCheckService)
+    HealthCheckService healthCheckService,
+    AdminSettingsCache adminSettingsCache)
     : Controller
 {
     [AllowAnonymous]
@@ -159,6 +160,9 @@ public class HomeController(
     [HttpGet("/register")]
     public IActionResult Register(string? returnUrl = null)
     {
+        if (!adminSettingsCache.RegistrationEnabled)
+            return RegistrationUnavailable();
+
         ViewData["ReturnUrl"] = returnUrl;
         return View(new RegisterViewModel());
     }
@@ -168,6 +172,9 @@ public class HomeController(
     [EnableRateLimiting(Policies.PublicApiRateLimit)]
     public async Task<IActionResult> Register(RegisterViewModel model, string? returnUrl = null)
     {
+        if (!adminSettingsCache.RegistrationEnabled)
+            return RegistrationUnavailable();
+
         ViewData["ReturnUrl"] = returnUrl;
         if (!ModelState.IsValid)
             return View(model);
@@ -207,6 +214,12 @@ public class HomeController(
 
         await signInManager.SignInAsync(user, false);
         return RedirectToLocal(returnUrl);
+    }
+
+    private IActionResult RegistrationUnavailable()
+    {
+        HttpContext.Items[UIErrorController.ErrorDetailsKey] = "Registration is temporarily disabled.";
+        return StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 
 

--- a/PluginBuilder/Controllers/Logic/AdminSettingsCache.cs
+++ b/PluginBuilder/Controllers/Logic/AdminSettingsCache.cs
@@ -12,6 +12,8 @@ public class AdminSettingsCache
     public string[] NostrRelays { get; private set; } = Array.Empty<string>();
     public int RateLimitPermitLimit { get; private set; } = 30;
     public int RateLimitWindowSeconds { get; private set; } = 60;
+    public bool RegistrationEnabled { get; private set; }
+    public bool NewBuildsEnabled { get; private set; }
 
     public async Task RefreshIsVerifiedEmailRequiredForPublish(NpgsqlConnection conn)
     {
@@ -31,6 +33,7 @@ public class AdminSettingsCache
 
     public async Task RefreshAllAdminSettings(NpgsqlConnection conn)
     {
+        await RefreshFeatureSettings(conn);
         await RefreshIsVerifiedEmailRequiredForPublish(conn);
         await RefreshIsVerifiedEmailRequiredForLogin(conn);
         await RefreshIsVerifiedGithubRequired(conn);
@@ -58,5 +61,11 @@ public class AdminSettingsCache
     {
         RateLimitPermitLimit = await conn.GetRateLimitPermitLimitSetting();
         RateLimitWindowSeconds = await conn.GetRateLimitWindowSecondsSetting();
+    }
+
+    public async Task RefreshFeatureSettings(NpgsqlConnection conn)
+    {
+        RegistrationEnabled = await conn.GetRegistrationEnabledSetting();
+        NewBuildsEnabled = await conn.GetNewBuildsEnabledSetting();
     }
 }

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -31,6 +31,7 @@ public class PluginController(
     PluginOwnershipService ownershipService,
     VersionLifecycleService versionLifecycleService,
     GitHostingProviderFactory gitHostingProviderFactory,
+    AdminSettingsCache adminSettingsCache,
     ILogger<PluginController> logger)
     : Controller
 {
@@ -240,6 +241,9 @@ public class PluginController(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug, long? copyBuild = null)
     {
+        if (!adminSettingsCache.NewBuildsEnabled)
+            return BuildsUnavailable();
+
         await using var conn = await connectionFactory.Open();
         if (!await userVerifiedLogic.IsUserEmailVerifiedForPublish(User) || !await userVerifiedLogic.IsUserGithubVerified(User, conn))
         {
@@ -279,6 +283,9 @@ public class PluginController(
         PluginSlug pluginSlug,
         CreateBuildViewModel model)
     {
+        if (!adminSettingsCache.NewBuildsEnabled)
+            return BuildsUnavailable();
+
         if (!ModelState.IsValid)
             return View(model);
         await using var conn = await connectionFactory.Open();
@@ -304,6 +311,9 @@ public class PluginController(
             return View(model);
         }
 
+        if (!adminSettingsCache.NewBuildsEnabled)
+            return BuildsUnavailable();
+
         var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
         if (buildId == 0)
         {
@@ -317,6 +327,12 @@ public class PluginController(
 
         _ = buildService.Build(new FullBuildId(pluginSlug, buildId));
         return RedirectToAction(nameof(Build), new { pluginSlug = pluginSlug.ToString(), buildId });
+    }
+
+    private IActionResult BuildsUnavailable()
+    {
+        HttpContext.Items[UIErrorController.ErrorDetailsKey] = "Plugin builds are temporarily disabled.";
+        return StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 
     [HttpGet("listing-history")]

--- a/PluginBuilder/Data/Scripts/24.FeatureFlags.sql
+++ b/PluginBuilder/Data/Scripts/24.FeatureFlags.sql
@@ -1,0 +1,4 @@
+INSERT INTO settings (key, value)
+VALUES ('RegistrationEnabled', 'true'),
+       ('NewBuildsEnabled', 'true')
+ON CONFLICT (key) DO NOTHING

--- a/PluginBuilder/DataModels/SettingsKeys.cs
+++ b/PluginBuilder/DataModels/SettingsKeys.cs
@@ -11,4 +11,6 @@ public static class SettingsKeys
     public const string NostrRelays = nameof(NostrRelays);
     public const string RateLimitPermitLimit = nameof(RateLimitPermitLimit);
     public const string RateLimitWindowSeconds = nameof(RateLimitWindowSeconds);
+    public const string RegistrationEnabled = nameof(RegistrationEnabled);
+    public const string NewBuildsEnabled = nameof(NewBuildsEnabled);
 }

--- a/PluginBuilder/Services/BuildService.cs
+++ b/PluginBuilder/Services/BuildService.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using Dapper;
 using Newtonsoft.Json.Linq;
 using PluginBuilder.Configuration;
+using PluginBuilder.Controllers.Logic;
 using PluginBuilder.Events;
 using PluginBuilder.Util;
 using PluginBuilder.Util.Extensions;
@@ -35,6 +36,7 @@ public class BuildService
     private static readonly SemaphoreSlim _semaphore = new(5);
     private readonly GitHostingProviderFactory _providerFactory;
     private readonly PluginBuilderOptions _options;
+    private readonly AdminSettingsCache _adminSettingsCache;
 
     public BuildService(
         ILogger<BuildService> logger,
@@ -43,7 +45,8 @@ public class BuildService
         DBConnectionFactory connectionFactory,
         EventAggregator eventAggregator,
         AzureStorageClient azureStorageClient,
-        GitHostingProviderFactory providerFactory)
+        GitHostingProviderFactory providerFactory,
+        AdminSettingsCache adminSettingsCache)
     {
         Logger = logger;
         _options = options;
@@ -52,6 +55,7 @@ public class BuildService
         EventAggregator = eventAggregator;
         AzureStorageClient = azureStorageClient;
         _providerFactory = providerFactory;
+        _adminSettingsCache = adminSettingsCache;
     }
 
     public ILogger<BuildService> Logger { get; }
@@ -62,10 +66,17 @@ public class BuildService
 
     public async Task Build(FullBuildId fullBuildId)
     {
+        if (await RejectBuildIfDisabled(fullBuildId))
+            return;
+
         BuildInfo buildParameters;
         await _semaphore.WaitAsync();
         try
         {
+            // A build may have been waiting for an execution slot when the setting changed.
+            if (await RejectBuildIfDisabled(fullBuildId))
+                return;
+
             using BuildOutputCapture buildLogCapture = new(fullBuildId, ConnectionFactory);
             List<string> createArgs = new();
             buildParameters = await GetBuildInfo(fullBuildId);
@@ -130,6 +141,16 @@ public class BuildService
                         throw new BuildServiceException("docker container create failed");
 
                     await UpdateBuild(fullBuildId, BuildStates.Running, info);
+
+                    // The setting may have changed while Docker resources were being created.
+                    // Do not start plugin code after builds have been disabled.
+                    if (await RejectBuildIfDisabled(fullBuildId))
+                    {
+                        if (!await ForceRemoveBuildContainer(containerName))
+                            throw new BuildServiceException(
+                                "Plugin builds were disabled and the build container could not be removed");
+                        return;
+                    }
                 }
                 catch (Exception err)
                 {
@@ -234,6 +255,17 @@ public class BuildService
         }
 
         await SavePluginContributorSnapshot(fullBuildId.PluginSlug, buildParameters);
+    }
+
+    private async Task<bool> RejectBuildIfDisabled(FullBuildId fullBuildId)
+    {
+        if (_adminSettingsCache.NewBuildsEnabled)
+            return false;
+
+        Logger.LogWarning("Skipping build {BuildId} because plugin builds are disabled", fullBuildId);
+        await UpdateBuild(fullBuildId, BuildStates.Failed,
+            new JObject { ["error"] = "Plugin builds are temporarily disabled." });
+        return true;
     }
 
     private async Task<string> CreateBuildVolume(FullBuildId fullBuildId)

--- a/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
+++ b/PluginBuilder/Util/Extensions/NpgsqlConnectionExtensions.cs
@@ -535,6 +535,18 @@ public static class NpgsqlConnectionExtensions
         return int.TryParse(v, out var seconds) && seconds > 0 ? seconds : 60;
     }
 
+    public static async Task<bool> GetRegistrationEnabledSetting(this NpgsqlConnection connection)
+    {
+        var value = await connection.SettingsGetAsync(SettingsKeys.RegistrationEnabled);
+        return bool.TryParse(value, out var enabled) && enabled;
+    }
+
+    public static async Task<bool> GetNewBuildsEnabledSetting(this NpgsqlConnection connection)
+    {
+        var value = await connection.SettingsGetAsync(SettingsKeys.NewBuildsEnabled);
+        return bool.TryParse(value, out var enabled) && enabled;
+    }
+
     #endregion
 
 

--- a/PluginBuilder/Views/Home/Login.cshtml
+++ b/PluginBuilder/Views/Home/Login.cshtml
@@ -1,4 +1,5 @@
 @model LoginViewModel
+@inject PluginBuilder.Controllers.Logic.AdminSettingsCache AdminSettingsCache
 @{
     ViewData["Title"] = "Sign in";
     Layout = "_LayoutHomeModal";
@@ -44,8 +45,11 @@
             </div>
         </fieldset>
     </form>
-    <p class="text-center mt-2 mb-0">
-        <a id="Register" style="font-size:1.15rem" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" tabindex="4">Create your
-            account</a>
-    </p>
+    @if (AdminSettingsCache.RegistrationEnabled)
+    {
+        <p class="text-center mt-2 mb-0">
+            <a id="Register" style="font-size:1.15rem" asp-action="Register" asp-route-returnurl="@ViewData["ReturnUrl"]" tabindex="4">Create your
+                account</a>
+        </p>
+    }
 </div>

--- a/PluginBuilder/Views/Plugin/Build.cshtml
+++ b/PluginBuilder/Views/Plugin/Build.cshtml
@@ -1,5 +1,6 @@
 @using PluginBuilder.ViewModels.Shared
 @model BuildViewModel
+@inject PluginBuilder.Controllers.Logic.AdminSettingsCache AdminSettingsCache
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(PluginNavPages.Dashboard, $"Build {Model.FullBuildId.BuildId}", Model.FullBuildId.ToString());
@@ -36,8 +37,11 @@
                 <span class="badge bg-warning">@Model.State</span>
                 break;
             case "failed":
-                <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
-                   class="btn btn-secondary">Retry</a>
+                if (AdminSettingsCache.NewBuildsEnabled)
+                {
+                    <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
+                       class="btn btn-secondary">Retry</a>
+                }
                 break;
             case "uploaded":
                 if (Model.Version is null || Model.Version?.PreRelease is true)
@@ -56,8 +60,11 @@
                         </form>
                     }
 
-                    <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
-                       class="btn btn-secondary">Retry</a>
+                    if (AdminSettingsCache.NewBuildsEnabled)
+                    {
+                        <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
+                           class="btn btn-secondary">Retry</a>
+                    }
                 }
                 else if (Model.Version?.Published is true)
                 {

--- a/PluginBuilder/Views/Plugin/Dashboard.cshtml
+++ b/PluginBuilder/Views/Plugin/Dashboard.cshtml
@@ -1,4 +1,5 @@
 @model BuildListViewModel
+@inject PluginBuilder.Controllers.Logic.AdminSettingsCache AdminSettingsCache
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(PluginNavPages.Dashboard, "Builds");
@@ -44,8 +45,11 @@
                     Public Page
                 </a>
             }
-            <a id="CreateNewBuild" asp-action="CreateBuild" asp-route-pluginSlug="@pluginSlug" class="btn btn-primary"><span class="fa fa-plus"></span> Create a
-                new build</a>
+            @if (AdminSettingsCache.NewBuildsEnabled)
+            {
+                <a id="CreateNewBuild" asp-action="CreateBuild" asp-route-pluginSlug="@pluginSlug" class="btn btn-primary"><span class="fa fa-plus"></span> Create a
+                    new build</a>
+            }
         </div>
     }
 </div>
@@ -104,9 +108,12 @@
                             <a href="@item.DownloadLink" rel="noreferrer noopener">Download</a>
                             <span> - </span>
                         }
-                        <a asp-action="CreateBuild" asp-controller="Plugin" asp-route-pluginSlug="@(pluginSlug ?? item.PluginSlug)"
-                           asp-route-copyBuild="@item.BuildId">Retry</a>
-                        <span> - </span>
+                        @if (AdminSettingsCache.NewBuildsEnabled)
+                        {
+                            <a asp-action="CreateBuild" asp-controller="Plugin" asp-route-pluginSlug="@(pluginSlug ?? item.PluginSlug)"
+                               asp-route-copyBuild="@item.BuildId">Retry</a>
+                            <span> - </span>
+                        }
                         <a asp-action="Build" asp-controller="Plugin" asp-route-pluginSlug="@(pluginSlug ?? item.PluginSlug)" asp-route-buildId="@item.BuildId">Details</a>
                     </td>
                 </tr>


### PR DESCRIPTION
- Add `RegistrationEnabled` and `BuildsEnabled` to the Settings Editor.
- Seed both flags as `true` through a one-time migration for backward compatibility.
- Treat missing or invalid values as disabled.
- Return HTTP 503 when registration or new builds are disabled.
- Recheck `BuildsEnabled` before inserting a build and before starting the Docker container.
- Hide registration, build creation, and retry links when disabled.
- Keep details, downloads, release, and unrelease available for existing builds.

The flags are seeded by a migration instead of startup initialization so that a deleted setting remains fail-closed after restart.
