### PR TITLE
feat(build): allow trusted accounts while new builds are disabled

### DIFF
--- a/PluginBuilder.Tests/AdminTests/AdminBuildWhitelistUITests.cs
+++ b/PluginBuilder.Tests/AdminTests/AdminBuildWhitelistUITests.cs
@@ -1,0 +1,86 @@
+using Dapper;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Playwright;
+using PluginBuilder.HostedServices;
+using PluginBuilder.Services;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.Playwright.Assertions;
+
+namespace PluginBuilder.Tests.AdminTests;
+
+[Collection("Playwright Tests")]
+public class AdminBuildWhitelistUITests(ITestOutputHelper output) : UnitTestBase(output)
+{
+    [Fact]
+    public async Task SettingsEditor_DeleteSendsVersionAndReloadsWhileStaleDeleteShowsConflict()
+    {
+        await using var tester = new PlaywrightTester(Log, Create("BuildWhitelistEditorUi"));
+        tester.Server.ReuseDatabase = false;
+        tester.Server.ConfigureServices = services =>
+        {
+            foreach (var descriptor in services.Where(descriptor =>
+                         descriptor.ServiceType == typeof(IHostedService) &&
+                         (descriptor.ImplementationType == typeof(DockerStartupHostedService) ||
+                          descriptor.ImplementationType == typeof(AzureStartupHostedService))).ToArray())
+                services.Remove(descriptor);
+        };
+        await tester.StartAsync();
+        await tester.LogIn(await tester.CreateServerAdminAsync());
+        var email = $"trusted-{Guid.NewGuid():N}@example.test";
+        var userId = await tester.CreateConfirmedUser(email);
+        await using var conn = await tester.Server.GetService<DBConnectionFactory>().Open();
+
+        var page = tester.Page!;
+        await page.GotoAsync(new Uri(tester.ServerUri!, "/admin/SettingsEditor").ToString(),
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        var row = page.Locator("tr[data-key='NewBuildsWhitelist']");
+        await Expect(row).ToHaveCountAsync(1);
+        await Expect(row.Locator(".value")).ToHaveTextAsync("");
+
+        // Keep a second tab's original version while saving a grant through the real editor.
+        var stalePage = await page.Context.NewPageAsync();
+        stalePage.SetDefaultTimeout(10_000);
+        try
+        {
+            await stalePage.GotoAsync(page.Url, new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+            await row.GetByRole(AriaRole.Button, new() { Name = "Edit", Exact = true }).ClickAsync();
+            await row.Locator("textarea").FillAsync(email);
+            await row.GetByRole(AriaRole.Button, new() { Name = "Save", Exact = true }).ClickAsync();
+            await Expect(row.Locator(".value")).ToHaveTextAsync(email);
+            Assert.Equal(new[] { userId }, (await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist")).ToArray());
+
+            var dialogReceived = new TaskCompletionSource<IDialog>(TaskCreationOptions.RunContinuationsAsynchronously);
+            stalePage.Dialog += (_, dialog) => dialogReceived.TrySetResult(dialog);
+            var staleDelete = stalePage.RunAndWaitForResponseAsync(
+                () => stalePage.Locator("tr[data-key='NewBuildsWhitelist']")
+                    .GetByRole(AriaRole.Button, new() { Name = "Delete", Exact = true }).ClickAsync(),
+                response => IsEditorResponse(response, "DELETE"));
+            var dialog = await dialogReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var message = dialog.Message;
+            await dialog.DismissAsync();
+            Assert.Equal(409, (await staleDelete).Status);
+            Assert.Contains("Reload the page", message, StringComparison.Ordinal);
+            Assert.Equal(new[] { userId }, (await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist")).ToArray());
+
+            // Observe the actual DELETE and the navigation triggered by its success handler.
+            // A manual navigation here would hide a missing version or missing reload in the UI.
+            var deleted = page.WaitForResponseAsync(response => IsEditorResponse(response, "DELETE"));
+            var reload = await page.RunAndWaitForResponseAsync(
+                () => row.GetByRole(AriaRole.Button, new() { Name = "Delete", Exact = true }).ClickAsync(),
+                response => response.Request.IsNavigationRequest && IsEditorResponse(response, "GET"));
+            Assert.Equal(200, (await deleted).Status);
+            Assert.Equal(200, reload.Status);
+            await Expect(row).ToHaveCountAsync(1);
+            await Expect(row.Locator(".value")).ToHaveTextAsync("");
+            Assert.Empty(await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist"));
+        }
+        finally
+        {
+            await stalePage.CloseAsync();
+        }
+    }
+
+    private static bool IsEditorResponse(IResponse response, string method) =>
+        response.Request.Method == method && new Uri(response.Url).AbsolutePath == "/admin/SettingsEditor";
+}

--- a/PluginBuilder.Tests/BuildWhitelistEmailTests.cs
+++ b/PluginBuilder.Tests/BuildWhitelistEmailTests.cs
@@ -1,0 +1,378 @@
+using Dapper;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PluginBuilder.Controllers;
+using PluginBuilder.Controllers.Logic;
+using PluginBuilder.DataModels;
+using PluginBuilder.HostedServices;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using PluginBuilder.Util;
+using PluginBuilder.ViewModels.Admin;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class BuildWhitelistEmailTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    [Fact]
+    public async Task ConfirmedEmailChangePreservesAccountAuthorizationAndShowsCurrentEmail()
+    {
+        await using var tester = CreateEmailTester();
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+        using var adminScope = tester.WebApp.Services.CreateScope();
+        var adminUserManager = adminScope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        // Cookie validation may track the administrator before a concurrent email confirmation completes.
+        var trackedUser = await adminUserManager.FindByIdAsync(change.UserId);
+        Assert.NotNull(trackedUser);
+        Assert.Equal(change.OldEmail, trackedUser.Email);
+        var admin = CreateAdminController(adminScope.ServiceProvider, change.UserId);
+        var before = Assert.IsType<SettingsEditorViewModel>(Assert.IsType<ViewResult>(await admin.SettingsEditor()).Model);
+
+        await AssertConfirmation(tester, change, change.Token, success: true);
+        Assert.Equal(change.OldEmail, trackedUser.Email);
+
+        var current = Assert.IsType<SettingsEditorViewModel>(Assert.IsType<ViewResult>(await admin.SettingsEditor()).Model);
+        var currentValue = Assert.Single(current.Settings, setting => setting.key == SettingsKeys.NewBuildsWhitelist).value;
+        Assert.Equal(new[] { change.NewEmail, change.OtherEmail }.Order(), currentValue.Split(',').Order());
+        Assert.NotEqual(before.WhitelistVersion, current.WhitelistVersion);
+        Assert.IsType<RedirectToActionResult>(await admin.SettingsEditor(
+            SettingsKeys.NewBuildsWhitelist, currentValue, current.WhitelistVersion));
+        Assert.False(admin.TempData.ContainsKey(TempDataConstant.WarningMessage));
+
+        using var scope = tester.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByIdAsync(change.UserId);
+        Assert.NotNull(user);
+        Assert.Equal(change.NewEmail, user.Email);
+        Assert.Equal(change.NewEmail, user.UserName);
+        Assert.Equal(userManager.NormalizeEmail(change.NewEmail), user.NormalizedEmail);
+        Assert.Equal(userManager.NormalizeName(change.NewEmail), user.NormalizedUserName);
+        Assert.True(user.EmailConfirmed);
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        var details = await conn.GetAccountDetailSettings(change.UserId);
+        Assert.NotNull(details);
+        Assert.True(string.IsNullOrEmpty(details.PendingNewEmail));
+        Assert.Equal("preserved-profile", details.Github);
+        Assert.Equal(new[] { change.UserId, change.OtherUserId }.Order(),
+            (await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist")).Order());
+        Assert.True(await scope.ServiceProvider.GetRequiredService<BuildAccessLogic>().IsWhitelisted(Principal(change.UserId)));
+
+        var replacementId = await tester.CreateFakeUserAsync(change.OldEmail);
+        Assert.NotEqual(change.UserId, replacementId);
+        Assert.False(await scope.ServiceProvider.GetRequiredService<BuildAccessLogic>().IsWhitelisted(Principal(replacementId)));
+
+        // An editor opened before the email change must not grant the newly registered account.
+        Assert.IsType<RedirectToActionResult>(await admin.SettingsEditor(
+            SettingsKeys.NewBuildsWhitelist, $"{change.OldEmail},{change.OtherEmail}", before.WhitelistVersion));
+        Assert.Contains("reload", Assert.IsType<string>(admin.TempData[TempDataConstant.WarningMessage]), StringComparison.OrdinalIgnoreCase);
+        await AssertWhitelist(tester, change.NewEmail, change.OtherEmail);
+    }
+
+    [Fact]
+    public async Task EmailConfirmationWaitsForWhitelistSnapshotBeforeEmailsAreResolved()
+    {
+        var normalizer = new PausingEmailNormalizer();
+        await using var tester = CreateEmailTester(normalizer);
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+        using var adminScope = tester.WebApp.Services.CreateScope();
+        var admin = CreateAdminController(adminScope.ServiceProvider, change.UserId);
+        var before = Assert.IsType<SettingsEditorViewModel>(Assert.IsType<ViewResult>(await admin.SettingsEditor()).Model);
+        await using var observer = await tester.GetService<DBConnectionFactory>().Open();
+
+        // Pause after the version was checked but before the later account-resolution query can take its own locks.
+        normalizer.Arm(change.OldEmail);
+        var save = Task.Run(() => admin.SettingsEditor(
+            SettingsKeys.NewBuildsWhitelist, $"{change.OldEmail},{change.OtherEmail}", before.WhitelistVersion));
+        Task? confirmation = null;
+        try
+        {
+            await normalizer.Paused.WaitAsync(TimeSpan.FromSeconds(10));
+            var savePid = await observer.QuerySingleAsync<int>(
+                """
+                SELECT DISTINCT l.pid
+                FROM pg_locks l
+                JOIN pg_stat_activity a ON a.pid = l.pid
+                WHERE a.datname = current_database()
+                    AND l.relation = 'build_whitelist'::regclass
+                    AND l.mode = 'ShareRowExclusiveLock' AND l.granted
+                """);
+            confirmation = AssertConfirmation(tester, change, change.Token, success: true);
+            using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            while (!await observer.ExecuteScalarAsync<bool>(new CommandDefinition(
+                       """
+                       SELECT EXISTS (
+                           SELECT 1 FROM pg_stat_activity
+                           WHERE datname = current_database()
+                               AND @savePid = ANY(pg_blocking_pids(pid))
+                               AND query LIKE '%UPDATE "AspNetUsers"%'
+                       )
+                       """, new { savePid }, cancellationToken: waitTimeout.Token)))
+            {
+                Assert.False(confirmation.IsCompleted,
+                    "The email confirmation must wait for the whitelist snapshot, before email resolution starts.");
+                await Task.Delay(10, waitTimeout.Token);
+            }
+
+            normalizer.Release();
+            Assert.IsType<RedirectToActionResult>(await save.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.False(admin.TempData.ContainsKey(TempDataConstant.WarningMessage));
+            await confirmation.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using var scope = tester.WebApp.Services.CreateScope();
+            var user = await scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>().FindByIdAsync(change.UserId);
+            Assert.NotNull(user);
+            Assert.Equal(change.NewEmail, user.Email);
+            Assert.Equal(change.NewEmail, user.UserName);
+            var details = await observer.GetAccountDetailSettings(change.UserId);
+            Assert.NotNull(details);
+            Assert.True(string.IsNullOrEmpty(details.PendingNewEmail));
+            await AssertWhitelist(tester, change.NewEmail, change.OtherEmail);
+            Assert.Equal(new[] { change.UserId, change.OtherUserId }.Order(),
+                (await observer.QueryAsync<string>("SELECT user_id FROM build_whitelist")).Order());
+
+            var replacementId = await tester.CreateFakeUserAsync(change.OldEmail);
+            var access = scope.ServiceProvider.GetRequiredService<BuildAccessLogic>();
+            Assert.True(await access.IsWhitelisted(Principal(change.UserId)));
+            Assert.False(await access.IsWhitelisted(Principal(replacementId)));
+        }
+        finally
+        {
+            normalizer.Release();
+            foreach (var pending in new Task?[] { save, confirmation })
+                if (pending is not null)
+                    try
+                    {
+                        await pending.WaitAsync(TimeSpan.FromSeconds(10));
+                    }
+                    catch
+                    {
+                        // Preserve the original failure while releasing both operations before disposing the server.
+                    }
+        }
+    }
+
+    [Fact]
+    public async Task InvalidTokenPreservesAccountPendingEmailAndWhitelist()
+    {
+        await using var tester = CreateEmailTester();
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+        var before = await ReadAccount(tester, change.UserId);
+
+        await AssertConfirmation(tester, change, "not-a-valid-token", success: false);
+
+        Assert.Equal(before, await ReadAccount(tester, change.UserId));
+        await AssertWhitelist(tester, change.OldEmail, change.OtherEmail);
+    }
+
+    [Fact]
+    public async Task RevocationWhileEmailChangeIsPendingDoesNotRestoreWhitelistAccess()
+    {
+        await using var tester = CreateEmailTester();
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+        await using (var conn = await tester.GetService<DBConnectionFactory>().Open())
+            await conn.ExecuteAsync("DELETE FROM build_whitelist WHERE user_id = @UserId", new { change.UserId });
+
+        await AssertConfirmation(tester, change, change.Token, success: true);
+
+        using var scope = tester.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByIdAsync(change.UserId);
+        Assert.NotNull(user);
+        Assert.Equal(change.NewEmail, user.Email);
+        Assert.Equal(change.NewEmail, user.UserName);
+        await using var connAfter = await tester.GetService<DBConnectionFactory>().Open();
+        var details = await connAfter.GetAccountDetailSettings(change.UserId);
+        Assert.NotNull(details);
+        Assert.True(string.IsNullOrEmpty(details.PendingNewEmail));
+        await AssertWhitelist(tester, change.OtherEmail);
+        Assert.False(await scope.ServiceProvider.GetRequiredService<BuildAccessLogic>().IsWhitelisted(Principal(change.UserId)));
+    }
+
+    [Fact]
+    public async Task UsernameConflictRollsBackEmailChangePendingEmailAndWhitelist()
+    {
+        await using var tester = CreateEmailTester();
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+
+        using (var scope = tester.WebApp.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+            var conflict = new IdentityUser
+            {
+                UserName = change.NewEmail,
+                Email = $"username-conflict-{Guid.NewGuid():N}@example.com",
+                EmailConfirmed = true
+            };
+            var created = await userManager.CreateAsync(conflict, "123456");
+            Assert.True(created.Succeeded, string.Join(", ", created.Errors.Select(error => error.Description)));
+            Assert.Null(await userManager.FindByEmailAsync(change.NewEmail));
+        }
+        var before = await ReadAccount(tester, change.UserId);
+
+        await AssertConfirmation(tester, change, change.Token, success: false);
+
+        Assert.Equal(before, await ReadAccount(tester, change.UserId));
+        await AssertWhitelist(tester, change.OldEmail, change.OtherEmail);
+    }
+
+    [Fact]
+    public async Task ExistingEmailWithDifferentUsernameDoesNotTransferAccountOrWhitelist()
+    {
+        await using var tester = CreateEmailTester();
+        await tester.Start();
+        var change = await PrepareEmailChange(tester);
+
+        using (var scope = tester.WebApp.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+            var conflict = new IdentityUser
+            {
+                UserName = $"email-conflict-{Guid.NewGuid():N}",
+                Email = change.NewEmail,
+                EmailConfirmed = true
+            };
+            var created = await userManager.CreateAsync(conflict, "123456");
+            Assert.True(created.Succeeded, string.Join(", ", created.Errors.Select(error => error.Description)));
+            Assert.Null(await userManager.FindByNameAsync(change.NewEmail));
+        }
+        var before = await ReadAccount(tester, change.UserId);
+
+        await AssertConfirmation(tester, change, change.Token, success: false);
+
+        Assert.Equal(before, await ReadAccount(tester, change.UserId));
+        await AssertWhitelist(tester, change.OldEmail, change.OtherEmail);
+    }
+
+    private ServerTester CreateEmailTester(ILookupNormalizer? normalizer = null)
+    {
+        var tester = Create("BuildWhitelistEmail");
+        tester.ReuseDatabase = false;
+        tester.ConfigureServices = services =>
+        {
+            foreach (var descriptor in services.Where(descriptor =>
+                         descriptor.ServiceType == typeof(IHostedService) &&
+                         (descriptor.ImplementationType == typeof(DockerStartupHostedService) ||
+                          descriptor.ImplementationType == typeof(AzureStartupHostedService))).ToArray())
+                services.Remove(descriptor);
+            if (normalizer is not null)
+                services.AddSingleton(normalizer);
+        };
+        return tester;
+    }
+
+    private sealed class PausingEmailNormalizer : ILookupNormalizer
+    {
+        private readonly UpperInvariantLookupNormalizer _inner = new();
+        private readonly TaskCompletionSource _paused = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private string? _email;
+        private int _pauseTaken;
+
+        public Task Paused => _paused.Task;
+        public void Arm(string email) => _email = email;
+        public void Release() => _released.TrySetResult();
+        public string? NormalizeName(string? name) => _inner.NormalizeName(name);
+
+        public string? NormalizeEmail(string? email)
+        {
+            if (email is not null && email == _email && Interlocked.CompareExchange(ref _pauseTaken, 1, 0) == 0)
+            {
+                _paused.TrySetResult();
+                _released.Task.WaitAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+            }
+            return _inner.NormalizeEmail(email);
+        }
+    }
+
+    private static async Task<PendingEmailChange> PrepareEmailChange(ServerTester tester)
+    {
+        var oldEmail = $"old-{Guid.NewGuid():N}@example.com";
+        var newEmail = $"new-{Guid.NewGuid():N}@example.com";
+        var otherEmail = $"other-{Guid.NewGuid():N}@example.com";
+        var userId = await tester.CreateFakeUserAsync(oldEmail);
+        var otherUserId = await tester.CreateFakeUserAsync(otherEmail);
+
+        using var scope = tester.WebApp.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByIdAsync(userId);
+        Assert.NotNull(user);
+        var token = await userManager.GenerateChangeEmailTokenAsync(user, newEmail);
+
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.SetAccountDetailSettings(new AccountSettings
+        {
+            Github = "preserved-profile",
+            PendingNewEmail = newEmail
+        }, userId);
+        await conn.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES (@userId), (@otherUserId)",
+            new { userId, otherUserId });
+        return new PendingEmailChange(userId, oldEmail, newEmail, otherUserId, otherEmail, token);
+    }
+
+    private static async Task AssertConfirmation(
+        ServerTester tester, PendingEmailChange change, string token, bool success)
+    {
+        using var client = tester.CreateHttpClient();
+        using var response = await client.GetAsync(
+            $"/UpdateEmail?uid={Uri.EscapeDataString(change.UserId)}&token={Uri.EscapeDataString(token)}");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains(success ? "has been verified!" : "We couldn't verify your email", html, StringComparison.Ordinal);
+    }
+
+    private static async Task<string> ReadAccount(ServerTester tester, string userId)
+    {
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        return await conn.QuerySingleAsync<string>(
+            """
+            SELECT row_to_json(account)::text FROM "AspNetUsers" account WHERE "Id" = @userId
+            """,
+            new { userId });
+    }
+
+    private static async Task AssertWhitelist(ServerTester tester, params string[] expectedEmails)
+    {
+        using var scope = tester.WebApp.Services.CreateScope();
+        var controller = CreateAdminController(scope.ServiceProvider, "test-administrator");
+        var view = Assert.IsType<SettingsEditorViewModel>(Assert.IsType<ViewResult>(await controller.SettingsEditor()).Model);
+        var value = Assert.Single(view.Settings, setting => setting.key == SettingsKeys.NewBuildsWhitelist).value;
+        var actual = value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .OrderBy(email => email, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(expectedEmails.OrderBy(email => email, StringComparer.OrdinalIgnoreCase), actual,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static ClaimsPrincipal Principal(string userId) =>
+        new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Role, Roles.ServerAdmin)], "test"));
+
+    private static AdminController CreateAdminController(IServiceProvider services, string userId)
+    {
+        var controller = ActivatorUtilities.CreateInstance<AdminController>(services);
+        controller.ControllerContext = new ControllerContext
+        {
+            RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+            ActionDescriptor = new Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor(),
+            HttpContext = new DefaultHttpContext { RequestServices = services, User = Principal(userId) }
+        };
+        return controller;
+    }
+
+    private sealed record PendingEmailChange(
+        string UserId, string OldEmail, string NewEmail, string OtherUserId, string OtherEmail, string Token);
+}

--- a/PluginBuilder.Tests/BuildWhitelistMigrationTests.cs
+++ b/PluginBuilder.Tests/BuildWhitelistMigrationTests.cs
@@ -1,0 +1,62 @@
+using Dapper;
+using Npgsql;
+using PluginBuilder.DataModels;
+using PluginBuilder.Util.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests;
+
+public class BuildWhitelistMigrationTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    [Fact]
+    public async Task MigrationStartsEmptyWithoutGrantingExistingAccounts()
+    {
+        await using var tester = CreateMigrationTester("BuildWhitelistEmptyMigration");
+        await tester.RunScriptsUntil("25.BuildWhitelist");
+        await using var conn = await tester.Open();
+        await InsertUser(conn, "confirmed", confirmed: true);
+        await InsertUser(conn, "unconfirmed", confirmed: false);
+        await conn.SettingsSetAsync(SettingsKeys.NewBuildsEnabled, "false");
+
+        await tester.RunRemainingScripts();
+
+        Assert.Empty(await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist"));
+        Assert.Null(await conn.SettingsGetAsync(SettingsKeys.NewBuildsWhitelist));
+        Assert.Equal("false", await conn.SettingsGetAsync(SettingsKeys.NewBuildsEnabled));
+        Assert.Equal(2, await conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM \"AspNetUsers\""));
+    }
+
+    [Fact]
+    public async Task WhitelistRequiresAnExistingUniqueAccountAndCascadesItsDeletion()
+    {
+        await using var tester = CreateMigrationTester("BuildWhitelistConstraints");
+        await tester.RunScriptsUntil("25.BuildWhitelist");
+        await tester.RunRemainingScripts();
+        await using var conn = await tester.Open();
+        await InsertUser(conn, "authorized", confirmed: true);
+        await conn.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES ('authorized')");
+
+        var duplicate = await Assert.ThrowsAsync<PostgresException>(() =>
+            conn.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES ('authorized')"));
+        Assert.Equal(PostgresErrorCodes.UniqueViolation, duplicate.SqlState);
+        var nonexistent = await Assert.ThrowsAsync<PostgresException>(() =>
+            conn.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES ('nonexistent')"));
+        Assert.Equal(PostgresErrorCodes.ForeignKeyViolation, nonexistent.SqlState);
+        Assert.Equal("authorized", await conn.QuerySingleAsync<string>("SELECT user_id FROM build_whitelist"));
+
+        await conn.ExecuteAsync("DELETE FROM \"AspNetUsers\" WHERE \"Id\" = 'authorized'");
+
+        Assert.Empty(await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist"));
+    }
+
+    private static Task InsertUser(NpgsqlConnection conn, string userId, bool confirmed) =>
+        conn.ExecuteAsync(
+            """
+            INSERT INTO "AspNetUsers"
+                ("Id", "UserName", "NormalizedUserName", "Email", "NormalizedEmail", "EmailConfirmed",
+                 "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled", "AccessFailedCount")
+            VALUES
+                (@userId, @userId, UPPER(@userId), @email, UPPER(@email), @confirmed, FALSE, FALSE, FALSE, 0)
+            """, new { userId, email = $"{userId}@example.test", confirmed });
+}

--- a/PluginBuilder.Tests/BuildWhitelistTests.cs
+++ b/PluginBuilder.Tests/BuildWhitelistTests.cs
@@ -1,0 +1,827 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Dapper;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Npgsql;
+using PluginBuilder.APIModels;
+using PluginBuilder.Controllers.Logic;
+using PluginBuilder.DataModels;
+using PluginBuilder.Services;
+using PluginBuilder.Util.Extensions;
+using PluginBuilder.ViewModels.Admin;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PluginBuilder.Tests;
+
+[Collection(nameof(NonParallelizableCollectionDefinition))]
+public class BuildWhitelistTests(ITestOutputHelper logs) : UnitTestBase(logs)
+{
+    private const string Password = "123456";
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    public async Task CreationAndRetry_RespectFlagAndWhitelist(bool enabled, bool whitelisted, bool api)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var docker = new FakeDocker();
+        await using var tester = Create("WhitelistMatrix");
+        tester.ReuseDatabase = false;
+        var git = new TestGitProvider();
+        git.Release();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(git);
+        await tester.Start();
+        docker.Activate();
+
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email);
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(slug, userId);
+        var previousBuild = await conn.NewBuild(slug, new PluginBuildParameters(git.RepositoryUrl));
+        await conn.UpdateBuild(new FullBuildId(slug, previousBuild), BuildStates.Failed, new JObject
+        {
+            ["error"] = "Previous build failed",
+            ["gitRepository"] = git.RepositoryUrl,
+            ["gitRef"] = "main"
+        });
+
+        using var browser = CreateBrowser(tester);
+        await LogIn(browser, email);
+        // Keep the same login session and form token while changing the setting.
+        using var initialPage = await browser.GetAsync($"/plugins/{slug}/create");
+        initialPage.EnsureSuccessStatusCode();
+        var token = AntiforgeryToken(await initialPage.Content.ReadAsStringAsync());
+        await SetAccess(tester, conn, enabled, whitelisted ? email : "");
+
+        var allowed = enabled || whitelisted;
+        foreach (var path in new[] { $"/plugins/{slug}/create", $"/plugins/{slug}/create?copyBuild={previousBuild}" })
+        {
+            using var get = await browser.GetAsync(path);
+            Assert.Equal(allowed ? HttpStatusCode.OK : HttpStatusCode.ServiceUnavailable, get.StatusCode);
+        }
+
+        using var dashboard = await browser.GetAsync($"/plugins/{slug}");
+        dashboard.EnsureSuccessStatusCode();
+        var dashboardHtml = await dashboard.Content.ReadAsStringAsync();
+        Assert.Equal(allowed, dashboardHtml.Contains("id=\"CreateNewBuild\"", StringComparison.Ordinal));
+        Assert.Equal(allowed, dashboardHtml.Contains(">Retry</a>", StringComparison.Ordinal));
+        using var details = await browser.GetAsync($"/plugins/{slug}/builds/{previousBuild}");
+        details.EnsureSuccessStatusCode();
+        Assert.Equal(allowed, (await details.Content.ReadAsStringAsync()).Contains(">Retry</a>", StringComparison.Ordinal));
+
+        using var client = api ? CreateBrowser(tester).SetBasicAuth(email, Password) : null;
+        using var content = api ? BuildJson(git.RepositoryUrl) : BuildForm(git.RepositoryUrl, token);
+        using var response = await (client ?? browser).PostAsync(
+            api ? $"/api/v1/plugins/{slug}/builds" : $"/plugins/{slug}/create?copyBuild={previousBuild}", content);
+
+        Assert.Equal(allowed ? api ? HttpStatusCode.Created : HttpStatusCode.Redirect : HttpStatusCode.ServiceUnavailable,
+            response.StatusCode);
+        Assert.Equal(allowed ? 1 : 0, git.FetchCount);
+        Assert.Equal(allowed ? 2 : 1, await BuildCount(conn, slug));
+        if (allowed)
+        {
+            // The approved exception must pass every guard before container execution.
+            await docker.WaitForCommand("container start ");
+            await WaitForFailedBuild(conn, slug, previousBuild + 1);
+            await docker.WaitForCommand("volume rm ");
+        }
+        else if (api)
+        {
+            Assert.Equal("builds-disabled", JObject.Parse(await response.Content.ReadAsStringAsync()).Value<string>("error"));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SettingsEditor_ValidatesAccountsAndAppliesChangesToExistingSession(bool requireConfirmedEmail)
+    {
+        await using var tester = Create("WhitelistSettings");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        var adminEmail = NewEmail();
+        var adminId = await tester.CreateFakeUserAsync(adminEmail);
+        var ownerEmail = NewEmail();
+        var ownerId = await tester.CreateFakeUserAsync(ownerEmail);
+        var unconfirmedEmail = NewEmail();
+        var unconfirmedId = await tester.CreateFakeUserAsync(unconfirmedEmail, confirmEmail: false);
+        var ambiguousEmail = NewEmail();
+        await tester.CreateFakeUserAsync(ambiguousEmail);
+        var duplicateId = await tester.CreateFakeUserAsync();
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.ExecuteAsync(
+            """
+            UPDATE "AspNetUsers" SET "Email" = @ambiguousEmail, "NormalizedEmail" = @normalizedEmail
+            WHERE "Id" = @duplicateId
+            """, new { ambiguousEmail, normalizedEmail = ambiguousEmail.ToUpperInvariant(), duplicateId });
+        await MakeAdmin(conn, adminId);
+        await conn.NewPlugin(slug, ownerId);
+        var adminSlug = NewSlug();
+        await conn.NewPlugin(adminSlug, adminId);
+        await SetAccess(tester, conn, false, "");
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForLogin, requireConfirmedEmail ? "true" : "false");
+        await tester.GetService<AdminSettingsCache>().RefreshIsVerifiedEmailRequiredForLogin(conn);
+
+        using var admin = CreateBrowser(tester);
+        using var owner = CreateBrowser(tester);
+        await LogIn(admin, adminEmail);
+        await LogIn(owner, ownerEmail);
+        using var editor = await admin.GetAsync("/admin/SettingsEditor");
+        editor.EnsureSuccessStatusCode();
+        var editorHtml = await editor.Content.ReadAsStringAsync();
+        Assert.Contains($"data-key=\"{SettingsKeys.NewBuildsWhitelist}\"", editorHtml, StringComparison.Ordinal);
+        var token = AntiforgeryToken(editorHtml);
+        var version = InputValue(editorHtml, "whitelistVersion");
+        using (var blockedAdmin = await admin.GetAsync($"/plugins/{adminSlug}/create"))
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, blockedAdmin.StatusCode);
+        using (var blockedOwner = await owner.GetAsync($"/plugins/{slug}/create"))
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, blockedOwner.StatusCode);
+
+        using (var add = SettingForm($"  {ownerEmail.ToUpperInvariant()}, {ownerEmail}  ", token, version))
+        using (var added = await admin.PostAsync("/admin/SettingsEditor", add))
+            Assert.Equal(HttpStatusCode.Redirect, added.StatusCode);
+        Assert.Equal(new[] { ownerId }, await WhitelistedIds(conn));
+        using (var allowedOwner = await owner.GetAsync($"/plugins/{slug}/create"))
+            Assert.Equal(HttpStatusCode.OK, allowedOwner.StatusCode);
+        using (var stillBlockedAdmin = await admin.GetAsync($"/plugins/{adminSlug}/create"))
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, stillBlockedAdmin.StatusCode);
+
+        // Ordinary settings can still be saved without a whitelist version and preserve grants.
+        using (var ordinaryForm = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["key"] = SettingsKeys.RegistrationEnabled,
+            ["value"] = "false",
+            ["__RequestVerificationToken"] = token
+        }))
+        using (var saved = await admin.PostAsync("/admin/SettingsEditor", ordinaryForm))
+            Assert.Equal(HttpStatusCode.Redirect, saved.StatusCode);
+        Assert.Equal("false", await conn.SettingsGetAsync(SettingsKeys.RegistrationEnabled));
+        Assert.Equal(new[] { ownerId }, await WhitelistedIds(conn));
+
+        version = (await GetEditor(admin)).Version;
+        foreach (var invalid in new[] { NewEmail(), $"{ownerEmail}, {NewEmail()}", "not-an-email", ambiguousEmail })
+        {
+            using var invalidForm = SettingForm(invalid, token, version);
+            using var rejected = await admin.PostAsync("/admin/SettingsEditor", invalidForm);
+            Assert.Equal(HttpStatusCode.Redirect, rejected.StatusCode);
+            using var rejectionPage = await admin.GetAsync("/admin/SettingsEditor");
+            rejectionPage.EnsureSuccessStatusCode();
+            Assert.Contains("Whitelist not saved", await rejectionPage.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+            Assert.Equal(new[] { ownerId }, await WhitelistedIds(conn));
+            using var stillAllowed = await owner.GetAsync($"/plugins/{slug}/create");
+            Assert.Equal(HttpStatusCode.OK, stillAllowed.StatusCode);
+        }
+
+        using (var addUnconfirmed = SettingForm($"{ownerEmail}, {unconfirmedEmail}", token, version))
+        using (var result = await admin.PostAsync("/admin/SettingsEditor", addUnconfirmed))
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
+        using (var resultPage = await admin.GetAsync("/admin/SettingsEditor"))
+        {
+            resultPage.EnsureSuccessStatusCode();
+            Assert.Equal(requireConfirmedEmail,
+                (await resultPage.Content.ReadAsStringAsync()).Contains("Whitelist not saved", StringComparison.Ordinal));
+        }
+        Assert.Equal((requireConfirmedEmail ? new[] { ownerId } : new[] { ownerId, unconfirmedId }).Order(),
+            await WhitelistedIds(conn));
+
+        version = (await GetEditor(admin)).Version;
+        using (var remove = SettingForm("", token, version))
+        using (var removed = await admin.PostAsync("/admin/SettingsEditor", remove))
+            Assert.Equal(HttpStatusCode.Redirect, removed.StatusCode);
+        using var revoked = await owner.GetAsync($"/plugins/{slug}/create");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, revoked.StatusCode);
+        Assert.Empty(await WhitelistedIds(conn));
+        Assert.Null(await conn.SettingsGetAsync(SettingsKeys.NewBuildsWhitelist));
+    }
+
+    [Fact]
+    public async Task SettingsEditor_RejectsStaleOrMissingSaveVersionAndMissingDeleteVersion()
+    {
+        await using var tester = Create("WhitelistStaleSettings");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        var firstAdminEmail = NewEmail();
+        var firstAdminId = await tester.CreateFakeUserAsync(firstAdminEmail);
+        var secondAdminEmail = NewEmail();
+        var secondAdminId = await tester.CreateFakeUserAsync(secondAdminEmail);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await MakeAdmin(conn, firstAdminId);
+        await MakeAdmin(conn, secondAdminId);
+        using var firstAdmin = CreateBrowser(tester);
+        using var secondAdmin = CreateBrowser(tester);
+        await LogIn(firstAdmin, firstAdminEmail);
+        await LogIn(secondAdmin, secondAdminEmail);
+
+        var firstPage = await GetEditor(firstAdmin);
+        var secondPage = await GetEditor(secondAdmin);
+        Assert.Equal(firstPage.Version, secondPage.Version);
+        using (var form = SettingForm(firstAdminEmail, firstPage.Token, firstPage.Version))
+        using (var saved = await firstAdmin.PostAsync("/admin/SettingsEditor", form))
+            Assert.Equal(HttpStatusCode.Redirect, saved.StatusCode);
+
+        const string conflict = "The build whitelist has changed. Reload the page before saving or deleting it.";
+        foreach (var invalidVersion in new[] { secondPage.Version, null })
+        {
+            using var staleForm = SettingForm(secondAdminEmail, secondPage.Token, invalidVersion);
+            using var rejected = await secondAdmin.PostAsync("/admin/SettingsEditor", staleForm);
+            Assert.Equal(HttpStatusCode.Redirect, rejected.StatusCode);
+            Assert.Contains(conflict, (await GetEditor(secondAdmin)).Html, StringComparison.Ordinal);
+            Assert.Equal(new[] { firstAdminId }, await WhitelistedIds(conn));
+        }
+
+        using var delete = await DeleteWhitelist(secondAdmin, secondPage.Token, version: null);
+        Assert.Equal(HttpStatusCode.Conflict, delete.StatusCode);
+        Assert.Equal(conflict, await delete.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { firstAdminId }, await WhitelistedIds(conn));
+    }
+
+    [Fact]
+    public async Task SettingsEditor_ConcurrentSavesCompareVersionAfterAcquiringLock()
+    {
+        await using var tester = Create("WhitelistConcurrentSettings");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        var firstEmail = NewEmail();
+        var firstId = await tester.CreateFakeUserAsync(firstEmail);
+        var secondEmail = NewEmail();
+        var secondId = await tester.CreateFakeUserAsync(secondEmail);
+        await using var blocking = await tester.GetService<DBConnectionFactory>().Open();
+        await using var observer = await tester.GetService<DBConnectionFactory>().Open();
+        await MakeAdmin(blocking, firstId);
+        await MakeAdmin(blocking, secondId);
+        using var firstAdmin = CreateBrowser(tester);
+        using var secondAdmin = CreateBrowser(tester);
+        await LogIn(firstAdmin, firstEmail);
+        await LogIn(secondAdmin, secondEmail);
+        var firstPage = await GetEditor(firstAdmin);
+        var secondPage = await GetEditor(secondAdmin);
+        Assert.Equal(firstPage.Version, secondPage.Version);
+        Assert.Empty(await WhitelistedIds(observer));
+
+        await using var blocker = await blocking.BeginTransactionAsync();
+        await blocking.ExecuteAsync("LOCK TABLE build_whitelist IN SHARE ROW EXCLUSIVE MODE");
+        using var firstForm = SettingForm(firstEmail, firstPage.Token, firstPage.Version);
+        using var secondForm = SettingForm(secondEmail, secondPage.Token, secondPage.Version);
+        using var requestsTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var pending = new[]
+        {
+            firstAdmin.PostAsync("/admin/SettingsEditor", firstForm, requestsTimeout.Token),
+            secondAdmin.PostAsync("/admin/SettingsEditor", secondForm, requestsTimeout.Token)
+        };
+        try
+        {
+            using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            // Establish that both real requests reached the contested lock before either can save.
+            while (await observer.ExecuteScalarAsync<int>(new CommandDefinition(
+                       """
+                       SELECT COUNT(*) FROM pg_stat_activity
+                       WHERE datname = current_database()
+                           AND @blockingPid = ANY(pg_blocking_pids(pid))
+                       """, new { blockingPid = blocking.ProcessID }, cancellationToken: waitTimeout.Token)) < 2)
+            {
+                Assert.All(pending, request => Assert.False(request.IsCompleted,
+                    "Both saves must wait for the transaction holding the whitelist lock."));
+                await Task.Delay(10, waitTimeout.Token);
+            }
+            await blocker.CommitAsync();
+
+            foreach (var request in pending)
+                Assert.Equal(HttpStatusCode.Redirect, (await request.WaitAsync(TimeSpan.FromSeconds(10))).StatusCode);
+            const string conflict = "The build whitelist has changed. Reload the page before saving or deleting it.";
+            var firstConflict = (await GetEditor(firstAdmin)).Html.Contains(conflict, StringComparison.Ordinal);
+            var secondConflict = (await GetEditor(secondAdmin)).Html.Contains(conflict, StringComparison.Ordinal);
+            Assert.NotEqual(firstConflict, secondConflict);
+            Assert.Equal(new[] { firstConflict ? secondId : firstId }, await WhitelistedIds(observer));
+        }
+        finally
+        {
+            await blocker.DisposeAsync();
+            foreach (var request in pending)
+                try
+                {
+                    (await request.WaitAsync(TimeSpan.FromSeconds(10))).Dispose();
+                }
+                catch
+                {
+                    // Preserve the original failure while releasing both blocked HTTP requests.
+                }
+        }
+    }
+
+    [Fact]
+    public async Task SettingsEditor_VersionDetectsDifferentAccountWithTheSameEmail()
+    {
+        await using var tester = Create("WhitelistIdSnapshot");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        var adminEmail = NewEmail();
+        var adminId = await tester.CreateFakeUserAsync(adminEmail);
+        var email = NewEmail();
+        var originalId = await tester.CreateFakeUserAsync(email);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await MakeAdmin(conn, adminId);
+        await SetAccess(tester, conn, false, email);
+        using var admin = CreateBrowser(tester);
+        await LogIn(admin, adminEmail);
+        var before = await GetEditor(admin);
+
+        await conn.ExecuteAsync("""DELETE FROM "AspNetUsers" WHERE "Id" = @originalId""", new { originalId });
+        var replacementId = await tester.CreateFakeUserAsync(email);
+        Assert.NotEqual(originalId, replacementId);
+        Assert.Empty(await WhitelistedIds(conn));
+        await SetAccess(tester, conn, false, email);
+        var after = await GetEditor(admin);
+        Assert.Equal(WhitelistValue(before.Html), WhitelistValue(after.Html));
+        Assert.NotEqual(before.Version, after.Version);
+
+        using var deleted = await DeleteWhitelist(admin, before.Token, before.Version);
+        Assert.Equal(HttpStatusCode.Conflict, deleted.StatusCode);
+        Assert.Equal(new[] { replacementId }, await WhitelistedIds(conn));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UnconfirmedWhitelistedAccount_TracksLoginVerificationFlagInExistingSession(bool api)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var docker = new FakeDocker();
+        await using var tester = Create("WhitelistEmailFlag");
+        tester.ReuseDatabase = false;
+        var git = new TestGitProvider();
+        git.Release();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(git);
+        await tester.Start();
+        docker.Activate();
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email, confirmEmail: false);
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(slug, userId);
+        // Configured SMTP ensures publishing checks cannot silently skip verification.
+        await tester.GetService<EmailService>().SaveEmailSettingsToDatabase(new EmailSettingsViewModel
+        {
+            Server = "127.0.0.1",
+            Port = 1,
+            Username = "whitelist-test",
+            Password = "whitelist-test",
+            From = "Whitelist Test <whitelist@example.test>"
+        });
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForLogin, "false");
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForPluginPublish, "false");
+        await tester.GetService<AdminSettingsCache>().RefreshAllVerifiedEmailSettings(conn);
+        await SetAccess(tester, conn, false, email);
+
+        using var browser = CreateBrowser(tester);
+        await LogIn(browser, email);
+        using var initialPage = await browser.GetAsync($"/plugins/{slug}/create");
+        initialPage.EnsureSuccessStatusCode();
+        var token = AntiforgeryToken(await initialPage.Content.ReadAsStringAsync());
+        using var client = api ? CreateBrowser(tester).SetBasicAuth(email, Password) : null;
+        var accepted = 0;
+        foreach (var requireConfirmedEmail in new[] { false, true, false })
+        {
+            await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForLogin, requireConfirmedEmail ? "true" : "false");
+            await tester.GetService<AdminSettingsCache>().RefreshIsVerifiedEmailRequiredForLogin(conn);
+            using (var page = await browser.GetAsync($"/plugins/{slug}/create"))
+                Assert.Equal(requireConfirmedEmail ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK, page.StatusCode);
+            using (var dashboard = await browser.GetAsync($"/plugins/{slug}"))
+            {
+                dashboard.EnsureSuccessStatusCode();
+                Assert.Equal(!requireConfirmedEmail,
+                    (await dashboard.Content.ReadAsStringAsync()).Contains("id=\"CreateNewBuild\"", StringComparison.Ordinal));
+            }
+            using var content = api ? BuildJson(git.RepositoryUrl) : BuildForm(git.RepositoryUrl, token);
+            using var response = await (client ?? browser).PostAsync(
+                api ? $"/api/v1/plugins/{slug}/builds" : $"/plugins/{slug}/create", content);
+            Assert.Equal(requireConfirmedEmail ? HttpStatusCode.ServiceUnavailable :
+                api ? HttpStatusCode.Created : HttpStatusCode.Redirect, response.StatusCode);
+            if (!requireConfirmedEmail)
+            {
+                await docker.WaitForCommand("container start ", ++accepted);
+                await WaitForFailedBuild(conn, slug, accepted - 1);
+                await docker.WaitForCommand("volume rm ", accepted);
+            }
+            Assert.Equal(accepted, await BuildCount(conn, slug));
+            Assert.Equal(accepted, git.FetchCount);
+        }
+
+        // The separate publishing requirement still applies when login verification is disabled.
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForPluginPublish, "true");
+        await tester.GetService<AdminSettingsCache>().RefreshIsVerifiedEmailRequiredForPublish(conn);
+        using var blockedContent = api ? BuildJson(git.RepositoryUrl) : BuildForm(git.RepositoryUrl, token);
+        using var blocked = await (client ?? browser).PostAsync(
+            api ? $"/api/v1/plugins/{slug}/builds" : $"/plugins/{slug}/create", blockedContent);
+        Assert.Equal(api ? HttpStatusCode.Forbidden : HttpStatusCode.Redirect, blocked.StatusCode);
+        if (!api)
+            Assert.Contains("account", blocked.Headers.Location?.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(accepted, await BuildCount(conn, slug));
+        Assert.Equal(accepted, git.FetchCount);
+    }
+
+    [Fact]
+    public async Task OrdinaryUser_CannotManageWhitelistOrBuildAnotherOwnersPlugin()
+    {
+        await using var tester = Create("WhitelistPermissions");
+        tester.ReuseDatabase = false;
+        var git = new TestGitProvider();
+        git.Release();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(git);
+        await tester.Start();
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email);
+        var otherId = await tester.CreateFakeUserAsync();
+        var ownSlug = NewSlug();
+        var otherSlug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(ownSlug, userId);
+        await conn.NewPlugin(otherSlug, otherId);
+        await SetAccess(tester, conn, false, email);
+        using var browser = CreateBrowser(tester);
+        await LogIn(browser, email);
+        using var ownPage = await browser.GetAsync($"/plugins/{ownSlug}/create");
+        ownPage.EnsureSuccessStatusCode();
+        var token = AntiforgeryToken(await ownPage.Content.ReadAsStringAsync());
+
+        using (var unauthorizedEditor = await browser.GetAsync("/admin/SettingsEditor"))
+            AssertDenied(unauthorizedEditor);
+        using (var unauthorizedForm = SettingForm("", token))
+        using (var unauthorizedPost = await browser.PostAsync("/admin/SettingsEditor", unauthorizedForm))
+            AssertDenied(unauthorizedPost);
+        using (var unauthorizedDelete = new HttpRequestMessage(HttpMethod.Delete, "/admin/SettingsEditor"))
+        {
+            unauthorizedDelete.Content = SettingForm("", token);
+            using var deleted = await browser.SendAsync(unauthorizedDelete);
+            AssertDenied(deleted);
+        }
+        Assert.Equal(new[] { userId }, await WhitelistedIds(conn));
+
+        using (var otherPage = await browser.GetAsync($"/plugins/{otherSlug}/create"))
+            AssertDenied(otherPage);
+        using (var otherForm = BuildForm(git.RepositoryUrl, token))
+        using (var otherPost = await browser.PostAsync($"/plugins/{otherSlug}/create", otherForm))
+            AssertDenied(otherPost);
+        using var api = CreateBrowser(tester).SetBasicAuth(email, Password);
+        using var content = BuildJson(git.RepositoryUrl);
+        using var deniedApi = await api.PostAsync($"/api/v1/plugins/{otherSlug}/builds", content);
+        Assert.Equal(HttpStatusCode.Forbidden, deniedApi.StatusCode);
+        Assert.Equal(0, git.FetchCount);
+        Assert.Equal(0, await BuildCount(conn, otherSlug));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RemovalDuringRepositoryLookup_RejectsBeforeAcceptingBuild(bool api)
+    {
+        await using var tester = Create("WhitelistLookupRace");
+        tester.ReuseDatabase = false;
+        var git = new TestGitProvider();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(git);
+        await tester.Start();
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email);
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(slug, userId);
+        await SetAccess(tester, conn, false, email);
+        using var client = CreateBrowser(tester);
+        string token = "";
+        if (api)
+            client.SetBasicAuth(email, Password);
+        else
+        {
+            await LogIn(client, email);
+            using var page = await client.GetAsync($"/plugins/{slug}/create");
+            page.EnsureSuccessStatusCode();
+            token = AntiforgeryToken(await page.Content.ReadAsStringAsync());
+        }
+        using var content = api ? BuildJson(git.RepositoryUrl) : BuildForm(git.RepositoryUrl, token);
+        var request = client.PostAsync(api ? $"/api/v1/plugins/{slug}/builds" : $"/plugins/{slug}/create", content);
+        try
+        {
+            await git.Entered.WaitAsync(TimeSpan.FromSeconds(10));
+            await SetAccess(tester, conn, false, "");
+        }
+        finally
+        {
+            git.Release();
+        }
+        using var response = await request.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(1, git.FetchCount);
+        Assert.Equal(0, await BuildCount(conn, slug));
+        Assert.False(await conn.ExecuteScalarAsync<bool>(
+            "SELECT EXISTS(SELECT 1 FROM builds_ids WHERE plugin_slug = @slug)", new { slug = slug.ToString() }));
+    }
+
+    [Fact]
+    public async Task Whitelist_DoesNotBypassGithubVerification()
+    {
+        await using var tester = Create("WhitelistVerification");
+        tester.ReuseDatabase = false;
+        var git = new TestGitProvider();
+        git.Release();
+        tester.ConfigureServices = services => services.AddSingleton<IGitHostingProvider>(git);
+        await tester.Start();
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email, githubVerified: false);
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(slug, userId);
+        await SetAccess(tester, conn, false, email);
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedGithub, "true");
+        await tester.GetService<AdminSettingsCache>().RefreshAllAdminSettings(conn);
+
+        using var browser = CreateBrowser(tester);
+        await LogIn(browser, email);
+        using var get = await browser.GetAsync($"/plugins/{slug}/create");
+        Assert.Equal(HttpStatusCode.Redirect, get.StatusCode);
+        Assert.Contains("account", get.Headers.Location?.ToString(), StringComparison.OrdinalIgnoreCase);
+        using var api = CreateBrowser(tester).SetBasicAuth(email, Password);
+        using var body = BuildJson(git.RepositoryUrl);
+        using var response = await api.PostAsync($"/api/v1/plugins/{slug}/builds", body);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(0, git.FetchCount);
+        Assert.Equal(0, await BuildCount(conn, slug));
+    }
+
+    [Fact]
+    public async Task RemovingUser_DoesNotCancelPreviouslyAcceptedQueuedBuild()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var docker = new FakeDocker();
+        docker.BlockVolumes();
+        await using var tester = Create("WhitelistAcceptedQueue");
+        tester.ReuseDatabase = false;
+        await tester.Start();
+        docker.Activate();
+        var email = NewEmail();
+        var userId = await tester.CreateFakeUserAsync(email);
+        var slug = NewSlug();
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.NewPlugin(slug, userId);
+        await SetAccess(tester, conn, false, email);
+        List<FullBuildId> builds = [];
+        for (var i = 0; i < 6; i++)
+            builds.Add(new FullBuildId(slug, await conn.NewBuild(slug, new PluginBuildParameters("https://example.invalid/repository.git"))));
+        var service = tester.GetService<BuildService>();
+        List<Task> pending = [];
+        try
+        {
+            pending.AddRange(builds.Take(5).Select(id => service.Build(id, true)));
+            await docker.WaitForCommand("volume create ", 5);
+            var queued = service.Build(builds[^1], true);
+            pending.Add(queued);
+            Assert.False(queued.IsCompleted);
+
+            await SetAccess(tester, conn, false, "");
+            docker.ReleaseVolumes();
+            foreach (var task in pending)
+                await Assert.ThrowsAsync<BuildServiceException>(() => task.WaitAsync(TimeSpan.FromSeconds(10)));
+            var last = builds[^1];
+            var error = await conn.ExecuteScalarAsync<string>(
+                "SELECT build_info->>'error' FROM builds WHERE plugin_slug = @slug AND id = @id",
+                new { slug = slug.ToString(), id = last.BuildId });
+            Assert.Equal("docker build failed", error);
+            Assert.Equal(builds.Count, (await docker.Commands()).Count(command =>
+                command.StartsWith("container start ", StringComparison.Ordinal)));
+        }
+        finally
+        {
+            docker.ReleaseVolumes();
+            foreach (var task in pending)
+                try
+                {
+                    await task.WaitAsync(TimeSpan.FromSeconds(10));
+                }
+                catch
+                {
+                    // Fake container execution intentionally fails; release every execution slot.
+                }
+        }
+    }
+
+    private static string NewEmail() => $"whitelist-{Guid.NewGuid():N}@example.com";
+    private static PluginSlug NewSlug() => new("whitelist-" + Guid.NewGuid().ToString("N")[..8]);
+
+    private static async Task SetAccess(ServerTester tester, NpgsqlConnection conn, bool enabled, string emails)
+    {
+        using var scope = tester.WebApp.Services.CreateScope();
+        var normalizer = scope.ServiceProvider.GetRequiredService<ILookupNormalizer>();
+        await conn.SettingsSetAsync(SettingsKeys.NewBuildsEnabled, enabled ? "true" : "false");
+        await conn.ExecuteAsync("DELETE FROM build_whitelist");
+        foreach (var email in emails.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            await conn.ExecuteAsync(
+                """
+                INSERT INTO build_whitelist (user_id)
+                SELECT "Id" FROM "AspNetUsers" WHERE "NormalizedEmail" = @normalizedEmail
+                """, new { normalizedEmail = normalizer.NormalizeEmail(email) });
+        await tester.GetService<AdminSettingsCache>().RefreshFeatureSettings(conn);
+    }
+
+    private static Task MakeAdmin(NpgsqlConnection conn, string userId) => conn.ExecuteAsync(
+        """
+        INSERT INTO "AspNetUserRoles" ("UserId", "RoleId")
+        SELECT @userId, "Id" FROM "AspNetRoles" WHERE "NormalizedName" = 'SERVERADMIN'
+        """, new { userId });
+
+    private static Task<int> BuildCount(NpgsqlConnection conn, PluginSlug slug) => conn.ExecuteScalarAsync<int>(
+        "SELECT COUNT(*) FROM builds WHERE plugin_slug = @slug", new { slug = slug.ToString() });
+
+    private static async Task WaitForFailedBuild(NpgsqlConnection conn, PluginSlug slug, long buildId)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (await conn.ExecuteScalarAsync<string>(
+                   "SELECT state FROM builds WHERE plugin_slug = @slug AND id = @buildId", new { slug = slug.ToString(), buildId })
+               != BuildStates.Failed.ToEventName())
+            await Task.Delay(10, timeout.Token);
+    }
+
+    private static HttpClient CreateBrowser(ServerTester tester) => new(new HttpClientHandler
+    {
+        AllowAutoRedirect = false,
+        CookieContainer = new CookieContainer()
+    }) { BaseAddress = new Uri(tester.WebApp.Urls.First()) };
+
+    private static async Task LogIn(HttpClient client, string email)
+    {
+        using var page = await client.GetAsync("/login");
+        page.EnsureSuccessStatusCode();
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["Email"] = email,
+            ["Password"] = Password,
+            ["__RequestVerificationToken"] = AntiforgeryToken(await page.Content.ReadAsStringAsync())
+        });
+        using var response = await client.PostAsync("/login", form);
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+    }
+
+    private static string AntiforgeryToken(string html) => InputValue(html, "__RequestVerificationToken");
+
+    private static string InputValue(string html, string name)
+    {
+        var input = Regex.Match(html, $"<input\\b(?=[^>]*\\bname=\"{Regex.Escape(name)}\")[^>]*>",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Assert.True(input.Success, $"Page must contain the {name} input.");
+        var value = Regex.Match(input.Value, "\\bvalue=\"([^\"]+)\"");
+        Assert.True(value.Success);
+        return WebUtility.HtmlDecode(value.Groups[1].Value);
+    }
+
+    private static HttpContent BuildJson(string repository) => new StringContent(new JObject
+    {
+        ["gitRepository"] = repository,
+        ["gitRef"] = "main",
+        ["buildConfig"] = ServerTester.BuildCfg
+    }.ToString(), Encoding.UTF8, "application/json");
+
+    private static HttpContent BuildForm(string repository, string token) => new FormUrlEncodedContent(new Dictionary<string, string>
+    {
+        ["GitRepository"] = repository,
+        ["GitRef"] = "main",
+        ["BuildConfig"] = ServerTester.BuildCfg,
+        ["__RequestVerificationToken"] = token
+    });
+
+    private static HttpContent SettingForm(string value, string token, string? version = null)
+    {
+        var values = new Dictionary<string, string>
+        {
+            ["key"] = SettingsKeys.NewBuildsWhitelist,
+            ["value"] = value,
+            ["__RequestVerificationToken"] = token
+        };
+        if (version is not null)
+            values["whitelistVersion"] = version;
+        return new FormUrlEncodedContent(values);
+    }
+
+    private static async Task<(string Token, string Version, string Html)> GetEditor(HttpClient browser)
+    {
+        using var response = await browser.GetAsync("/admin/SettingsEditor");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+        return (AntiforgeryToken(html), InputValue(html, "whitelistVersion"), html);
+    }
+
+    private static async Task<string[]> WhitelistedIds(NpgsqlConnection conn) =>
+        (await conn.QueryAsync<string>("SELECT user_id FROM build_whitelist ORDER BY user_id")).ToArray();
+
+    private static string WhitelistValue(string html)
+    {
+        var row = Regex.Match(html, $"<tr data-key=\"{SettingsKeys.NewBuildsWhitelist}\">(.*?)</tr>", RegexOptions.Singleline);
+        Assert.True(row.Success, "The virtual whitelist row must always be visible.");
+        var value = Regex.Match(row.Value, "<td class=\"value\">(.*?)</td>", RegexOptions.Singleline);
+        Assert.True(value.Success);
+        return WebUtility.HtmlDecode(value.Groups[1].Value).Trim();
+    }
+
+    private static async Task<HttpResponseMessage> DeleteWhitelist(HttpClient browser, string token, string? version)
+    {
+        var url = $"/admin/SettingsEditor?key={SettingsKeys.NewBuildsWhitelist}";
+        if (version is not null)
+            url += "&whitelistVersion=" + Uri.EscapeDataString(version);
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Add("RequestVerificationToken", token);
+        return await browser.SendAsync(request);
+    }
+
+    private static void AssertDenied(HttpResponseMessage response)
+    {
+        // Cookie authentication redirects access-denied requests; Basic authentication returns 403.
+        Assert.True(response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Redirect);
+        if (response.StatusCode == HttpStatusCode.Redirect)
+            Assert.Contains("/errors/403", response.Headers.Location?.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class TestGitProvider : IGitHostingProvider
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<string> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _fetchCount;
+        public string RepositoryUrl { get; } = $"https://whitelist-{Guid.NewGuid():N}.invalid/repository.git";
+        public int FetchCount => Volatile.Read(ref _fetchCount);
+        public Task Entered => _entered.Task;
+        public bool CanHandle(string repoUrl) => repoUrl == RepositoryUrl;
+        public async Task<string> FetchIdentifierFromCsprojAsync(string repoUrl, string gitRef, string? pluginDir = null)
+        {
+            Interlocked.Increment(ref _fetchCount);
+            _entered.TrySetResult();
+            return await _release.Task;
+        }
+        public void Release() => _release.TrySetResult("Whitelist.TestPlugin");
+        public Task<List<GitHubContributor>> GetContributorsAsync(string repoUrl, string pluginDir) => Task.FromResult(new List<GitHubContributor>());
+        public string? GetSourceUrl(string repoUrl, string? commit, string? pluginDir) => null;
+        public (string Owner, string RepoName)? ParseRepository(string repoUrl) => null;
+    }
+
+    private sealed class FakeDocker : IDisposable
+    {
+        private readonly string _directory = Path.Combine(Path.GetTempPath(), $"plugin-builder-whitelist-{Guid.NewGuid():N}");
+        private readonly string? _originalPath = Environment.GetEnvironmentVariable("PATH");
+        private readonly string? _originalSkipBuild = Environment.GetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD");
+        public FakeDocker()
+        {
+            if (OperatingSystem.IsWindows())
+                throw new PlatformNotSupportedException("The fake Docker executable uses a POSIX shell.");
+            Directory.CreateDirectory(_directory);
+            var executable = Path.Combine(_directory, "docker");
+            File.WriteAllText(executable, """
+                #!/bin/sh
+                set -eu
+                state="$(dirname "$0")"
+                printf '%s\n' "$*" >> "$state/commands"
+                case "$1:$2" in
+                    volume:create)
+                        for argument in "$@"; do volume="$argument"; done
+                        while [ -f "$state/block-volumes" ] && [ ! -f "$state/release-volumes" ]; do sleep 0.01; done
+                        printf '%s\n' "$volume"
+                        ;;
+                    container:create) printf '%s\n' fake-container-id ;;
+                    container:start) exit 41 ;;
+                    volume:rm|container:rm) ;;
+                    *) exit 2 ;;
+                esac
+                """);
+            File.SetUnixFileMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", "true");
+        }
+        public void Activate() => Environment.SetEnvironmentVariable("PATH", _directory + Path.PathSeparator + _originalPath);
+        public void BlockVolumes() => File.WriteAllText(Path.Combine(_directory, "block-volumes"), "");
+        public void ReleaseVolumes() => File.WriteAllText(Path.Combine(_directory, "release-volumes"), "");
+        public Task<string[]> Commands() => File.ReadAllLinesAsync(Path.Combine(_directory, "commands"));
+        public async Task WaitForCommand(string prefix, int count = 1)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var path = Path.Combine(_directory, "commands");
+            while (!File.Exists(path) || (await File.ReadAllLinesAsync(path, timeout.Token)).Count(line => line.StartsWith(prefix, StringComparison.Ordinal)) < count)
+                await Task.Delay(10, timeout.Token);
+        }
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("PATH", _originalPath);
+            Environment.SetEnvironmentVariable("DOCKER_STARTUP_SKIP_BUILD", _originalSkipBuild);
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+}

--- a/PluginBuilder.Tests/PluginTests/UserCleanupTests.cs
+++ b/PluginBuilder.Tests/PluginTests/UserCleanupTests.cs
@@ -1,9 +1,20 @@
 using System;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Dapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
+using PluginBuilder.Controllers;
+using PluginBuilder.Controllers.Logic;
+using PluginBuilder.DataModels;
+using PluginBuilder.HostedServices;
 using PluginBuilder.Services;
 using PluginBuilder.Util.Extensions;
+using PluginBuilder.Util;
+using PluginBuilder.ViewModels.Admin;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,8 +25,7 @@ public class UserCleanupTests(ITestOutputHelper logs) : UnitTestBase(logs)
     [Fact]
     public async Task CleanupDeletesOnlyStaleUnconfirmedUsersWithoutLinks()
     {
-        await using var tester = Create();
-        tester.ReuseDatabase = false;
+        await using var tester = CreateCleanupTester();
         await tester.Start();
 
         await using var conn = await tester.GetService<DBConnectionFactory>().Open();
@@ -107,6 +117,191 @@ public class UserCleanupTests(ITestOutputHelper logs) : UnitTestBase(logs)
         Assert.True(voteOnlyExists);
         Assert.True(listingReviewerExists);
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CleanupPreservesWhitelistedAccountUntilRevocation(bool requireConfirmedEmail)
+    {
+        await using var tester = CreateCleanupTester("WhitelistUserCleanup");
+        await tester.Start();
+        const string email = "kelvin-cleanup@example.test";
+        var userId = await tester.CreateFakeUserAsync(email, confirmEmail: false, githubVerified: false);
+        await using var conn = await tester.GetService<DBConnectionFactory>().Open();
+        await conn.ExecuteAsync(
+            "UPDATE \"AspNetUsers\" SET \"CreatedAt\" = @CreatedAt WHERE \"Id\" = @userId",
+            new { CreatedAt = DateTimeOffset.UtcNow.AddDays(-60), userId });
+        await conn.SettingsSetAsync(SettingsKeys.NewBuildsEnabled, "false");
+        await conn.SettingsSetAsync(SettingsKeys.VerifiedEmailForLogin, requireConfirmedEmail ? "true" : "false");
+        await conn.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES (@userId)", new { userId });
+        await tester.GetService<AdminSettingsCache>().RefreshAllAdminSettings(conn);
+
+        using var scope = tester.WebApp.Services.CreateScope();
+        var access = scope.ServiceProvider.GetRequiredService<BuildAccessLogic>();
+        var runner = scope.ServiceProvider.GetRequiredService<UserCleanupRunner>();
+        var principal = Principal(userId);
+        Assert.Equal(!requireConfirmedEmail, await access.CanCreateBuild(principal));
+
+        Assert.Equal(0, await runner.RunOnceAsync());
+        Assert.True(await UserExists(conn, userId));
+
+        await conn.ExecuteAsync("DELETE FROM build_whitelist WHERE user_id = @userId", new { userId });
+        Assert.False(await access.CanCreateBuild(principal));
+        Assert.Equal(1, await runner.RunOnceAsync());
+        Assert.False(await UserExists(conn, userId));
+
+        // Reusing a revoked account's email must not inherit the earlier authorization.
+        var replacementId = await tester.CreateFakeUserAsync(email, confirmEmail: false, githubVerified: false);
+        Assert.NotEqual(userId, replacementId);
+        Assert.False(await access.IsWhitelisted(Principal(replacementId)));
+        Assert.False(await access.CanCreateBuild(Principal(replacementId)));
+    }
+
+    [Fact]
+    public async Task CleanupWaitsForConcurrentWhitelistGrantBeforeDeletingUsers()
+    {
+        await using var tester = CreateCleanupTester("WhitelistCleanupGrant");
+        await tester.Start();
+        const string email = "concurrent-cleanup@example.test";
+        var userId = await tester.CreateFakeUserAsync(email, confirmEmail: false, githubVerified: false);
+        await using var granting = await tester.GetService<DBConnectionFactory>().Open();
+        await using var observer = await tester.GetService<DBConnectionFactory>().Open();
+        await granting.ExecuteAsync(
+            "UPDATE \"AspNetUsers\" SET \"CreatedAt\" = @CreatedAt WHERE \"Id\" = @userId",
+            new { CreatedAt = DateTimeOffset.UtcNow.AddDays(-60), userId });
+        await using var grant = await granting.BeginTransactionAsync();
+        await granting.ExecuteAsync("LOCK TABLE build_whitelist IN SHARE ROW EXCLUSIVE MODE");
+        using var scope = tester.WebApp.Services.CreateScope();
+        var pending = scope.ServiceProvider.GetRequiredService<UserCleanupRunner>().RunOnceAsync();
+        try
+        {
+            await WaitForBlockedConnection(observer, granting.ProcessID, pending);
+            await granting.ExecuteAsync("INSERT INTO build_whitelist (user_id) VALUES (@userId)", new { userId });
+            await grant.CommitAsync();
+
+            Assert.Equal(0, await pending.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.True(await UserExists(observer, userId));
+            Assert.Equal(userId, await observer.QuerySingleAsync<string>("SELECT user_id FROM build_whitelist"));
+        }
+        finally
+        {
+            await grant.DisposeAsync();
+            try
+            {
+                await pending.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch
+            {
+                // Preserve the original assertion failure while releasing the blocked connection.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task WhitelistGrantWaitsForCleanupAndRejectsTheDeletedAccount()
+    {
+        await using var tester = CreateCleanupTester("WhitelistGrantAfterCleanup");
+        await tester.Start();
+        var userId = await tester.CreateFakeUserAsync("cleanup-before-grant@example.test", confirmEmail: false, githubVerified: false);
+        var adminId = await tester.CreateFakeUserAsync();
+        await using var blocking = await tester.GetService<DBConnectionFactory>().Open();
+        await using var observer = await tester.GetService<DBConnectionFactory>().Open();
+        await blocking.ExecuteAsync(
+            "UPDATE \"AspNetUsers\" SET \"CreatedAt\" = @CreatedAt WHERE \"Id\" = @userId",
+            new { CreatedAt = DateTimeOffset.UtcNow.AddDays(-60), userId });
+        await blocking.SettingsSetAsync(SettingsKeys.VerifiedEmailForLogin, "false");
+        await tester.GetService<AdminSettingsCache>().RefreshAllAdminSettings(blocking);
+
+        using var adminScope = tester.WebApp.Services.CreateScope();
+        var admin = ActivatorUtilities.CreateInstance<AdminController>(adminScope.ServiceProvider);
+        admin.ControllerContext = new ControllerContext
+        {
+            RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+            ActionDescriptor = new Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor(),
+            HttpContext = new DefaultHttpContext
+            {
+                RequestServices = adminScope.ServiceProvider,
+                User = new ClaimsPrincipal(new ClaimsIdentity([
+                    new Claim(ClaimTypes.NameIdentifier, adminId),
+                    new Claim(ClaimTypes.Role, Roles.ServerAdmin)
+                ], "test"))
+            }
+        };
+        var editor = Assert.IsType<SettingsEditorViewModel>(Assert.IsType<ViewResult>(await admin.SettingsEditor()).Model);
+
+        // Pause the real cleanup at DELETE, after it has acquired the whitelist table lock.
+        await using var rowLock = await blocking.BeginTransactionAsync();
+        await blocking.QuerySingleAsync<string>("SELECT \"Id\" FROM \"AspNetUsers\" WHERE \"Id\" = @userId FOR UPDATE", new { userId });
+        using var cleanupScope = tester.WebApp.Services.CreateScope();
+        var cleanup = cleanupScope.ServiceProvider.GetRequiredService<UserCleanupRunner>().RunOnceAsync();
+        Task<IActionResult>? grant = null;
+        try
+        {
+            var cleanupPid = await WaitForBlockedConnection(observer, blocking.ProcessID, cleanup);
+            Assert.True(await observer.ExecuteScalarAsync<bool>(
+                "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE pid = @cleanupPid AND relation = 'build_whitelist'::regclass AND mode = 'ShareRowExclusiveLock' AND granted)",
+                new { cleanupPid }), "Cleanup must retain its whitelist lock while deleting accounts.");
+
+            grant = admin.SettingsEditor(SettingsKeys.NewBuildsWhitelist, "cleanup-before-grant@example.test", editor.WhitelistVersion);
+            await WaitForBlockedConnection(observer, cleanupPid, grant);
+            await rowLock.CommitAsync();
+
+            Assert.Equal(1, await cleanup.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.IsType<RedirectToActionResult>(await grant.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.Contains("must identify one existing account", Assert.IsType<string>(admin.TempData[TempDataConstant.WarningMessage]), StringComparison.Ordinal);
+            Assert.False(await UserExists(observer, userId));
+            Assert.Empty(await observer.QueryAsync<string>("SELECT user_id FROM build_whitelist"));
+        }
+        finally
+        {
+            await rowLock.DisposeAsync();
+            try
+            {
+                await cleanup.WaitAsync(TimeSpan.FromSeconds(10));
+                if (grant is not null)
+                    await grant.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch
+            {
+                // Preserve the original assertion failure while releasing blocked connections.
+            }
+        }
+    }
+
+    private ServerTester CreateCleanupTester(string name = "UserCleanup")
+    {
+        var tester = Create(name);
+        tester.ReuseDatabase = false;
+        tester.ConfigureServices = services =>
+        {
+            // These tests control each cleanup run and must not race the startup run.
+            foreach (var descriptor in services.Where(descriptor =>
+                         descriptor.ServiceType == typeof(IHostedService) &&
+                         (descriptor.ImplementationType == typeof(UserCleanupHostedService) ||
+                          descriptor.ImplementationType == typeof(DockerStartupHostedService) ||
+                          descriptor.ImplementationType == typeof(AzureStartupHostedService))).ToArray())
+                services.Remove(descriptor);
+        };
+        return tester;
+    }
+
+    private static async Task<int> WaitForBlockedConnection(NpgsqlConnection observer, int blockingPid, Task pending)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (true)
+        {
+            var waitingPid = await observer.ExecuteScalarAsync<int?>(new CommandDefinition(
+                "SELECT pid FROM pg_stat_activity WHERE datname = current_database() AND @blockingPid = ANY(pg_blocking_pids(pid)) LIMIT 1",
+                new { blockingPid }, cancellationToken: timeout.Token));
+            if (waitingPid is not null)
+                return waitingPid.Value;
+            Assert.False(pending.IsCompleted, "The operation must wait for the competing transaction.");
+            await Task.Delay(10, timeout.Token);
+        }
+    }
+
+    private static ClaimsPrincipal Principal(string userId) =>
+        new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId)], "test"));
 
     private static async Task<bool> UserExists(System.Data.IDbConnection conn, string userId)
     {

--- a/PluginBuilder/Controllers/AdminController.cs
+++ b/PluginBuilder/Controllers/AdminController.cs
@@ -1,10 +1,12 @@
 using System.Security.Claims;
+using System.Security.Cryptography;
 using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Npgsql;
 using PluginBuilder.Configuration;
@@ -36,11 +38,13 @@ public class AdminController(
     PluginBuilderOptions pbOptions,
     IOutputCacheStore outputCacheStore,
     PluginOwnershipService ownershipService,
-    ServerEnvironment serverEnvironment)
+    ServerEnvironment serverEnvironment,
+    ILogger<AdminController> logger)
     : Controller
 {
     // settings editor
     private const string ProtectedKeys = SettingsKeys.EmailSettings;
+    private const string WhitelistChangedMessage = "The build whitelist has changed. Reload the page before saving or deleting it.";
 
     private sealed class PluginVersionAdminRow
     {
@@ -1057,32 +1061,140 @@ public class AdminController(
         await using var conn = await connectionFactory.Open();
         var result = await conn.SettingsGetAllAsync();
         var list = result.ToList();
-        list.RemoveAll(setting => setting.key == ProtectedKeys);
-        return View(list);
+        list.RemoveAll(setting => setting.key is ProtectedKeys or SettingsKeys.NewBuildsWhitelist);
+        var accounts = await ReadBuildWhitelist(conn);
+        list.Add((SettingsKeys.NewBuildsWhitelist, string.Join(",", accounts.Select(account => account.Email))));
+        return View(new SettingsEditorViewModel
+        {
+            Settings = list,
+            WhitelistVersion = GetWhitelistVersion(accounts)
+        });
     }
 
     [HttpPost("SettingsEditor")]
-    public async Task<IActionResult> SettingsEditor(string key, string value)
+    public async Task<IActionResult> SettingsEditor(string key, string value, string? whitelistVersion = null)
     {
         if (key == ProtectedKeys)
             return BadRequest();
 
         await using var conn = await connectionFactory.Open();
-        var result = await conn.SettingsSetAsync(key, value);
+        if (key == SettingsKeys.NewBuildsWhitelist)
+            return await SaveBuildWhitelist(conn, value, whitelistVersion);
+
+        await conn.SettingsSetAsync(key, value);
         await adminSettingsCache.RefreshAllAdminSettings(conn);
         return RedirectToAction(nameof(SettingsEditor));
     }
 
     [HttpDelete("SettingsEditor")]
-    public async Task<IActionResult> SettingsEditorDelete(string key)
+    public async Task<IActionResult> SettingsEditorDelete(string key, string? whitelistVersion = null)
     {
         if (key == ProtectedKeys)
             return BadRequest();
 
         await using var conn = await connectionFactory.Open();
+        if (key == SettingsKeys.NewBuildsWhitelist)
+        {
+            await using var transaction = await conn.BeginTransactionAsync(System.Data.IsolationLevel.ReadCommitted);
+            await conn.ExecuteAsync("LOCK TABLE build_whitelist IN SHARE ROW EXCLUSIVE MODE");
+            var previous = await ReadBuildWhitelist(conn, lockAccounts: true);
+            if (whitelistVersion != GetWhitelistVersion(previous))
+                return Conflict(WhitelistChangedMessage);
+
+            await conn.ExecuteAsync("DELETE FROM build_whitelist");
+            await transaction.CommitAsync();
+            LogWhitelistChange(previous, []);
+            return Ok();
+        }
+
         var result = await conn.SettingsDeleteAsync(key);
         await adminSettingsCache.RefreshAllAdminSettings(conn);
         return Ok();
+    }
+
+    private async Task<IActionResult> SaveBuildWhitelist(NpgsqlConnection conn, string value, string? whitelistVersion)
+    {
+        await using var transaction = await conn.BeginTransactionAsync(System.Data.IsolationLevel.ReadCommitted);
+        await conn.ExecuteAsync("LOCK TABLE build_whitelist IN SHARE ROW EXCLUSIVE MODE");
+        var previous = await ReadBuildWhitelist(conn, lockAccounts: true);
+        if (whitelistVersion != GetWhitelistVersion(previous))
+        {
+            TempData[TempDataConstant.WarningMessage] = WhitelistChangedMessage;
+            return RedirectToAction(nameof(SettingsEditor));
+        }
+
+        var requireConfirmedEmail = adminSettingsCache.IsEmailVerificationRequiredForLogin;
+        var emails = ParseWhitelistEmails(value);
+        var normalizedEmails = emails.Select(userManager.NormalizeEmail).Distinct(StringComparer.Ordinal).ToArray();
+        var users = (await conn.QueryAsync<(string UserId, string Email, string NormalizedEmail, bool EmailConfirmed)>(
+            """
+            SELECT "Id", "Email", "NormalizedEmail", "EmailConfirmed"
+            FROM "AspNetUsers"
+            WHERE "NormalizedEmail" = ANY(@NormalizedEmails)
+            ORDER BY "Id"
+            FOR SHARE
+            """, new { NormalizedEmails = normalizedEmails })).ToList();
+        var accounts = new List<(string UserId, string Email)>();
+        foreach (var email in emails)
+        {
+            var normalizedEmail = userManager.NormalizeEmail(email);
+            var matches = users.Where(user => user.NormalizedEmail == normalizedEmail).ToList();
+            if (!MailboxAddressValidator.IsMailboxAddress(email) || matches.Count != 1 ||
+                (requireConfirmedEmail && !matches[0].EmailConfirmed))
+            {
+                var confirmationRequirement = requireConfirmedEmail ? " with a confirmed email" : "";
+                TempData[TempDataConstant.WarningMessage] = $"Whitelist not saved: '{email}' must identify one existing account{confirmationRequirement}.";
+                return RedirectToAction(nameof(SettingsEditor));
+            }
+            accounts.Add((matches[0].UserId, matches[0].Email));
+        }
+
+        var userIds = accounts.Select(account => account.UserId).Distinct(StringComparer.Ordinal).ToArray();
+        await conn.ExecuteAsync("DELETE FROM build_whitelist WHERE user_id <> ALL(@UserIds)", new { UserIds = userIds });
+        await conn.ExecuteAsync(
+            "INSERT INTO build_whitelist (user_id) SELECT unnest(@UserIds::text[]) ON CONFLICT DO NOTHING",
+            new { UserIds = userIds });
+        await transaction.CommitAsync();
+        LogWhitelistChange(previous, accounts);
+        return RedirectToAction(nameof(SettingsEditor));
+    }
+
+    private static async Task<List<(string UserId, string Email)>> ReadBuildWhitelist(NpgsqlConnection conn, bool lockAccounts = false)
+    {
+        var query = """
+                    SELECT u."Id", u."Email"
+                    FROM build_whitelist w
+                    JOIN "AspNetUsers" u ON u."Id" = w.user_id
+                    ORDER BY u."Id"
+                    """;
+        if (lockAccounts)
+            query += " FOR SHARE OF u";
+        return (await conn.QueryAsync<(string UserId, string Email)>(query)).ToList();
+    }
+
+    private static string GetWhitelistVersion(IEnumerable<(string UserId, string Email)> accounts)
+    {
+        var snapshot = accounts.OrderBy(account => account.UserId, StringComparer.Ordinal)
+            .Select(account => new { account.UserId, account.Email });
+        return Convert.ToHexString(SHA256.HashData(System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(snapshot)));
+    }
+
+    private static string[] ParseWhitelistEmails(string? value) =>
+        (value ?? string.Empty).Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+        .Select(email => email.Normalize())
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    private void LogWhitelistChange(IEnumerable<(string UserId, string Email)> previous, IEnumerable<(string UserId, string Email)> current)
+    {
+        var previousAccounts = previous.ToArray();
+        var currentAccounts = current.ToArray();
+        var added = currentAccounts.ExceptBy(previousAccounts.Select(account => account.UserId), account => account.UserId).ToArray();
+        var removed = previousAccounts.ExceptBy(currentAccounts.Select(account => account.UserId), account => account.UserId).ToArray();
+        if (added.Length != 0 || removed.Length != 0)
+            logger.LogInformation("Build whitelist changed by administrator {AdministratorId}: added {AddedUsers}; removed {RemovedUsers}",
+                userManager.GetUserId(User), string.Join(",", added.Select(account => account.UserId)),
+                string.Join(",", removed.Select(account => account.UserId)));
     }
 
     [HttpGet("server/logs/{file?}")]

--- a/PluginBuilder/Controllers/ApiController.cs
+++ b/PluginBuilder/Controllers/ApiController.cs
@@ -27,6 +27,7 @@ public class ApiController(
     VersionLifecycleService versionLifecycleService,
     UserManager<IdentityUser> userManager,
     UserVerifiedLogic userVerifiedLogic,
+    BuildAccessLogic buildAccessLogic,
     IHttpClientFactory httpClientFactory,
     ServerEnvironment serverEnvironment,
     AdminSettingsCache adminSettingsCache)
@@ -362,7 +363,7 @@ public class ApiController(
         PluginSlug pluginSlug,
         CreateBuildRequest model)
     {
-        if (!adminSettingsCache.NewBuildsEnabled)
+        if (!await buildAccessLogic.CanCreateBuild(User))
             return BuildsUnavailable();
 
         await using var conn = await connectionFactory.Open();
@@ -407,14 +408,15 @@ public class ApiController(
             return ValidationErrorResult(ModelState);
         }
 
-        if (!adminSettingsCache.NewBuildsEnabled)
+        var isWhitelisted = await buildAccessLogic.IsWhitelisted(User);
+        if (!adminSettingsCache.NewBuildsEnabled && !isWhitelisted)
             return BuildsUnavailable();
 
         var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
         var buildUrl = Url.ActionLink(nameof(PluginController.Build), "Plugin",
             new { pluginSlug = pluginSlug.ToString(), buildId });
 
-        _ = buildService.Build(new FullBuildId(pluginSlug, buildId));
+        _ = buildService.Build(new FullBuildId(pluginSlug, buildId), isWhitelisted);
 
         return CreatedAtAction(nameof(Build), new { pluginSlug = pluginSlug.ToString(), buildId }, new JObject
         {

--- a/PluginBuilder/Controllers/HomeController.cs
+++ b/PluginBuilder/Controllers/HomeController.cs
@@ -1,10 +1,13 @@
 using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
+using Npgsql;
 using PluginBuilder.APIModels;
 using PluginBuilder.Components.PluginVersion;
 using PluginBuilder.Configuration;
@@ -35,7 +38,8 @@ public class HomeController(
     GitHostingProviderFactory gitHostingProviderFactory,
     ILogger<HomeController> logger,
     HealthCheckService healthCheckService,
-    AdminSettingsCache adminSettingsCache)
+    AdminSettingsCache adminSettingsCache,
+    IdentityDbContext<IdentityUser> identityDbContext)
     : Controller
 {
     [AllowAnonymous]
@@ -764,13 +768,20 @@ public class HomeController(
     public async Task<IActionResult> VerifyEmailUpdate(string uid, string token)
     {
         ConfirmEmailViewModel model = new();
-        await using var conn = await connectionFactory.Open();
+        // Commit the email, username, and pending email together.
+        await using var transaction = await identityDbContext.Database.BeginTransactionAsync();
+        var conn = (NpgsqlConnection)identityDbContext.Database.GetDbConnection();
         var user = await userManager.FindByIdAsync(uid);
         if (user is null)
             return View("ConfirmEmail", model);
 
         var settings = await conn.GetAccountDetailSettings(user.Id);
         if (string.IsNullOrEmpty(settings?.PendingNewEmail))
+            return View("ConfirmEmail", model);
+
+        var newEmail = settings.PendingNewEmail;
+        var normalizedEmail = userManager.NormalizeEmail(newEmail);
+        if (await userManager.Users.AnyAsync(u => u.Id != user.Id && u.NormalizedEmail == normalizedEmail))
             return View("ConfirmEmail", model);
 
         var result = await userManager.ChangeEmailAsync(user, settings.PendingNewEmail, token);
@@ -784,6 +795,7 @@ public class HomeController(
         {
             settings.PendingNewEmail = string.Empty;
             await conn.SetAccountDetailSettings(settings, user.Id);
+            await transaction.CommitAsync();
         }
 
         return View("ConfirmEmail", model);

--- a/PluginBuilder/Controllers/Logic/BuildAccessLogic.cs
+++ b/PluginBuilder/Controllers/Logic/BuildAccessLogic.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using Dapper;
+using Microsoft.AspNetCore.Identity;
+using PluginBuilder.Services;
+
+namespace PluginBuilder.Controllers.Logic;
+
+public class BuildAccessLogic(
+    DBConnectionFactory connectionFactory,
+    UserManager<IdentityUser> userManager,
+    AdminSettingsCache adminSettingsCache)
+{
+    public async Task<bool> CanCreateBuild(ClaimsPrincipal principal) =>
+        adminSettingsCache.NewBuildsEnabled || await IsWhitelisted(principal);
+
+    public async Task<bool> IsWhitelisted(ClaimsPrincipal principal)
+    {
+        var userId = userManager.GetUserId(principal);
+        if (userId is null)
+            return false;
+
+        await using var conn = await connectionFactory.Open();
+        return await conn.ExecuteScalarAsync<bool>(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM build_whitelist w
+                JOIN "AspNetUsers" u ON u."Id" = w.user_id
+                WHERE w.user_id = @UserId AND (NOT @RequireConfirmedEmail OR u."EmailConfirmed" = TRUE)
+            )
+            """, new
+            {
+                UserId = userId,
+                RequireConfirmedEmail = adminSettingsCache.IsEmailVerificationRequiredForLogin
+            });
+    }
+}

--- a/PluginBuilder/Controllers/PluginController.cs
+++ b/PluginBuilder/Controllers/PluginController.cs
@@ -27,6 +27,7 @@ public class PluginController(
     BuildService buildService,
     AzureStorageClient azureStorageClient,
     UserVerifiedLogic userVerifiedLogic,
+    BuildAccessLogic buildAccessLogic,
     IOutputCacheStore outputCacheStore,
     PluginOwnershipService ownershipService,
     VersionLifecycleService versionLifecycleService,
@@ -241,7 +242,7 @@ public class PluginController(
         [ModelBinder(typeof(PluginSlugModelBinder))]
         PluginSlug pluginSlug, long? copyBuild = null)
     {
-        if (!adminSettingsCache.NewBuildsEnabled)
+        if (!await buildAccessLogic.CanCreateBuild(User))
             return BuildsUnavailable();
 
         await using var conn = await connectionFactory.Open();
@@ -283,7 +284,7 @@ public class PluginController(
         PluginSlug pluginSlug,
         CreateBuildViewModel model)
     {
-        if (!adminSettingsCache.NewBuildsEnabled)
+        if (!await buildAccessLogic.CanCreateBuild(User))
             return BuildsUnavailable();
 
         if (!ModelState.IsValid)
@@ -311,7 +312,8 @@ public class PluginController(
             return View(model);
         }
 
-        if (!adminSettingsCache.NewBuildsEnabled)
+        var isWhitelisted = await buildAccessLogic.IsWhitelisted(User);
+        if (!adminSettingsCache.NewBuildsEnabled && !isWhitelisted)
             return BuildsUnavailable();
 
         var buildId = await conn.NewBuild(pluginSlug, model.ToBuildParameter());
@@ -325,7 +327,7 @@ public class PluginController(
             await conn.SetPluginSettings(pluginSlug, existingSetting);
         }
 
-        _ = buildService.Build(new FullBuildId(pluginSlug, buildId));
+        _ = buildService.Build(new FullBuildId(pluginSlug, buildId), isWhitelisted);
         return RedirectToAction(nameof(Build), new { pluginSlug = pluginSlug.ToString(), buildId });
     }
 

--- a/PluginBuilder/Data/Scripts/25.BuildWhitelist.sql
+++ b/PluginBuilder/Data/Scripts/25.BuildWhitelist.sql
@@ -1,0 +1,4 @@
+CREATE TABLE build_whitelist
+(
+    user_id text PRIMARY KEY REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
+);

--- a/PluginBuilder/DataModels/SettingsKeys.cs
+++ b/PluginBuilder/DataModels/SettingsKeys.cs
@@ -13,4 +13,5 @@ public static class SettingsKeys
     public const string RateLimitWindowSeconds = nameof(RateLimitWindowSeconds);
     public const string RegistrationEnabled = nameof(RegistrationEnabled);
     public const string NewBuildsEnabled = nameof(NewBuildsEnabled);
+    public const string NewBuildsWhitelist = nameof(NewBuildsWhitelist);
 }

--- a/PluginBuilder/Program.cs
+++ b/PluginBuilder/Program.cs
@@ -262,6 +262,7 @@ public class Program
         // shared controller logic
         services.AddSingleton<AdminSettingsCache>();
         services.AddTransient<UserVerifiedLogic>();
+        services.AddScoped<BuildAccessLogic>();
         services.AddScoped<ReferrerNavigationService>();
         services.AddHttpContextAccessor();
         services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();

--- a/PluginBuilder/Services/BuildService.cs
+++ b/PluginBuilder/Services/BuildService.cs
@@ -64,9 +64,12 @@ public class BuildService
     public EventAggregator EventAggregator { get; }
     public AzureStorageClient AzureStorageClient { get; }
 
-    public async Task Build(FullBuildId fullBuildId)
+    public Task Build(FullBuildId fullBuildId) => Build(fullBuildId, false);
+
+    public async Task Build(FullBuildId fullBuildId, bool isWhitelisted)
     {
-        if (await RejectBuildIfDisabled(fullBuildId))
+        // Keep the whitelist exception approved when this build was accepted, even if it is later revoked.
+        if (await RejectBuildIfDisabled(fullBuildId, isWhitelisted))
             return;
 
         BuildInfo buildParameters;
@@ -74,7 +77,7 @@ public class BuildService
         try
         {
             // A build may have been waiting for an execution slot when the setting changed.
-            if (await RejectBuildIfDisabled(fullBuildId))
+            if (await RejectBuildIfDisabled(fullBuildId, isWhitelisted))
                 return;
 
             using BuildOutputCapture buildLogCapture = new(fullBuildId, ConnectionFactory);
@@ -143,8 +146,8 @@ public class BuildService
                     await UpdateBuild(fullBuildId, BuildStates.Running, info);
 
                     // The setting may have changed while Docker resources were being created.
-                    // Do not start plugin code after builds have been disabled.
-                    if (await RejectBuildIfDisabled(fullBuildId))
+                    // Builds without an approved whitelist exception must still honor the flag.
+                    if (await RejectBuildIfDisabled(fullBuildId, isWhitelisted))
                     {
                         if (!await ForceRemoveBuildContainer(containerName))
                             throw new BuildServiceException(
@@ -257,9 +260,9 @@ public class BuildService
         await SavePluginContributorSnapshot(fullBuildId.PluginSlug, buildParameters);
     }
 
-    private async Task<bool> RejectBuildIfDisabled(FullBuildId fullBuildId)
+    private async Task<bool> RejectBuildIfDisabled(FullBuildId fullBuildId, bool isWhitelisted)
     {
-        if (_adminSettingsCache.NewBuildsEnabled)
+        if (_adminSettingsCache.NewBuildsEnabled || isWhitelisted)
             return false;
 
         Logger.LogWarning("Skipping build {BuildId} because plugin builds are disabled", fullBuildId);

--- a/PluginBuilder/Services/UserCleanupRunner.cs
+++ b/PluginBuilder/Services/UserCleanupRunner.cs
@@ -1,9 +1,10 @@
+using System.Data;
 using Dapper;
 
 namespace PluginBuilder.Services;
 
 /// <summary>
-/// Deletes stale unconfirmed users that have no linked data.
+/// Deletes stale unconfirmed users that have no linked data and are not in the build whitelist.
 /// </summary>
 public class UserCleanupRunner
 {
@@ -25,6 +26,10 @@ public class UserCleanupRunner
         _logger.LogInformation("Starting stale unconfirmed user cleanup...");
 
         await using var conn = await _connectionFactory.Open(cancellationToken);
+        await using var transaction = await conn.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
+        await conn.ExecuteAsync(new CommandDefinition(
+            "LOCK TABLE build_whitelist IN SHARE ROW EXCLUSIVE MODE", transaction: transaction,
+            cancellationToken: cancellationToken));
 
         var threshold = DateTimeOffset.UtcNow - _staleThreshold;
         var command = new CommandDefinition(
@@ -32,16 +37,18 @@ public class UserCleanupRunner
             DELETE FROM "AspNetUsers" u
             WHERE u."EmailConfirmed" = FALSE
                 AND u."CreatedAt" < @Threshold
+                AND NOT EXISTS (SELECT 1 FROM build_whitelist w WHERE w.user_id = u."Id")
                 AND NOT EXISTS (SELECT 1 FROM "AspNetUserRoles" ur WHERE ur."UserId" = u."Id")
                 AND NOT EXISTS (SELECT 1 FROM users_plugins up WHERE up.user_id = u."Id")
                 AND NOT EXISTS (SELECT 1 FROM plugin_reviewers pr WHERE pr.user_id = u."Id")
                 AND NOT EXISTS (SELECT 1 FROM plugin_reviews pr WHERE pr.helpful_voters ? u."Id")
                 AND NOT EXISTS (SELECT 1 FROM plugin_listing_requests plr WHERE plr.reviewed_by = u."Id")
             """,
-            new { Threshold = threshold },
+            new { Threshold = threshold }, transaction,
             cancellationToken: cancellationToken);
 
         var deletedCount = await conn.ExecuteAsync(command);
+        await transaction.CommitAsync(cancellationToken);
 
         _logger.LogInformation("Deleted {DeletedCount} stale unconfirmed users.", deletedCount);
 

--- a/PluginBuilder/ViewModels/Admin/SettingsEditorViewModel.cs
+++ b/PluginBuilder/ViewModels/Admin/SettingsEditorViewModel.cs
@@ -1,0 +1,7 @@
+namespace PluginBuilder.ViewModels.Admin;
+
+public class SettingsEditorViewModel
+{
+    public List<(string key, string value)> Settings { get; init; } = [];
+    public string WhitelistVersion { get; init; } = string.Empty;
+}

--- a/PluginBuilder/Views/Admin/SettingsEditor.cshtml
+++ b/PluginBuilder/Views/Admin/SettingsEditor.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<(string key, string value)>
+@model PluginBuilder.ViewModels.Admin.SettingsEditorViewModel
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(AdminNavPages.Settings, "Settings Editor");
@@ -11,6 +11,7 @@
 </div>
 
 <form id="settingsForm" asp-action="SettingsEditor" method="post">
+    <input type="hidden" name="whitelistVersion" value="@Model.WhitelistVersion" />
     <div class="table-responsive">
         <table class="table table-hover">
             <thead>
@@ -21,7 +22,7 @@
             </tr>
             </thead>
             <tbody>
-            @foreach (var setting in Model)
+            @foreach (var setting in Model.Settings)
             {
                 <tr data-key="@setting.key">
                     <td>@setting.key</td>
@@ -133,15 +134,21 @@
                 const row = this.closest('tr');
                 const key = row.dataset.key;
                 const token = document.querySelector('#settingsForm input[name="__RequestVerificationToken"]').value;
+                const whitelistVersion = document.querySelector('#settingsForm input[name="whitelistVersion"]').value;
 
-                fetch(`/admin/SettingsEditor?key=${encodeURIComponent(key)}`, {
+                fetch(`/admin/SettingsEditor?key=${encodeURIComponent(key)}&whitelistVersion=${encodeURIComponent(whitelistVersion)}`, {
                     method: 'DELETE',
                     headers: {
                         'RequestVerificationToken': token
                     }
-                }).then(response => {
+                }).then(async response => {
                     if (response.ok) {
-                        row.remove();
+                        if (key === 'NewBuildsWhitelist')
+                            window.location.reload();
+                        else
+                            row.remove();
+                    } else if (response.status === 409) {
+                        alert(await response.text());
                     } else {
                         alert('Failed to delete the setting.');
                     }

--- a/PluginBuilder/Views/Plugin/Build.cshtml
+++ b/PluginBuilder/Views/Plugin/Build.cshtml
@@ -1,8 +1,9 @@
 @using PluginBuilder.ViewModels.Shared
 @model BuildViewModel
-@inject PluginBuilder.Controllers.Logic.AdminSettingsCache AdminSettingsCache
+@inject PluginBuilder.Controllers.Logic.BuildAccessLogic BuildAccessLogic
 @{
     Layout = "_Layout";
+    var canCreateBuild = await BuildAccessLogic.CanCreateBuild(User);
     ViewData.SetActivePage(PluginNavPages.Dashboard, $"Build {Model.FullBuildId.BuildId}", Model.FullBuildId.ToString());
     var btcpayCompatibilityModalVm = new BTCPayCompatibilityModalViewModel
     {
@@ -37,7 +38,7 @@
                 <span class="badge bg-warning">@Model.State</span>
                 break;
             case "failed":
-                if (AdminSettingsCache.NewBuildsEnabled)
+                if (canCreateBuild)
                 {
                     <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
                        class="btn btn-secondary">Retry</a>
@@ -60,7 +61,7 @@
                         </form>
                     }
 
-                    if (AdminSettingsCache.NewBuildsEnabled)
+                    if (canCreateBuild)
                     {
                         <a asp-action="CreateBuild" asp-route-pluginSlug="@Model.FullBuildId.PluginSlug" asp-route-copyBuild="@Model.FullBuildId.BuildId"
                            class="btn btn-secondary">Retry</a>

--- a/PluginBuilder/Views/Plugin/Dashboard.cshtml
+++ b/PluginBuilder/Views/Plugin/Dashboard.cshtml
@@ -1,9 +1,10 @@
 @model BuildListViewModel
-@inject PluginBuilder.Controllers.Logic.AdminSettingsCache AdminSettingsCache
+@inject PluginBuilder.Controllers.Logic.BuildAccessLogic BuildAccessLogic
 @{
     Layout = "_Layout";
     ViewData.SetActivePage(PluginNavPages.Dashboard, "Builds");
     var pluginSlug = Context.GetRouteValue("pluginSlug")?.ToString();
+    var canCreateBuild = await BuildAccessLogic.CanCreateBuild(User);
 }
 
 @functions
@@ -45,7 +46,7 @@
                     Public Page
                 </a>
             }
-            @if (AdminSettingsCache.NewBuildsEnabled)
+            @if (canCreateBuild)
             {
                 <a id="CreateNewBuild" asp-action="CreateBuild" asp-route-pluginSlug="@pluginSlug" class="btn btn-primary"><span class="fa fa-plus"></span> Create a
                     new build</a>
@@ -108,7 +109,7 @@
                             <a href="@item.DownloadLink" rel="noreferrer noopener">Download</a>
                             <span> - </span>
                         }
-                        @if (AdminSettingsCache.NewBuildsEnabled)
+                        @if (canCreateBuild)
                         {
                             <a asp-action="CreateBuild" asp-controller="Plugin" asp-route-pluginSlug="@(pluginSlug ?? item.PluginSlug)"
                                asp-route-copyBuild="@item.BuildId">Retry</a>


### PR DESCRIPTION
Allow administrators to authorize selected accounts to create builds while NewBuildsEnabled is false. Administrators must also be explicitly authorized.

- Manage access through NewBuildsWhitelist in the Settings Editor, entering emails while storing grants by account ID.
- Follow VerifiedEmailForLogin for email confirmation and preserve existing plugin ownership and publishing checks.
- Reject stale whitelist edits and coordinate updates with automatic account cleanup.
- Apply revocations to new requests, including existing sessions, while allowing accepted builds to continue.
- Start with an empty whitelist; existing accounts receive no automatic access.

When NewBuildsEnabled is true, existing build access rules apply.